### PR TITLE
Reduce memory usage in EnsureBufferUpdated

### DIFF
--- a/src/OmniSharp/Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp/Roslyn/OmniSharpWorkspace.cs
@@ -79,10 +79,9 @@ namespace OmniSharp
                 return;
             }
 
+            var sourceText = SourceText.From(request.Buffer);
             foreach (var documentId in CurrentSolution.GetDocumentIdsWithFilePath(request.FileName))
             {
-                var buffer = Encoding.UTF8.GetBytes(request.Buffer);
-                var sourceText = SourceText.From(new MemoryStream(buffer), encoding: Encoding.UTF8);
                 OnDocumentChanged(documentId, sourceText);
             }
         }


### PR DESCRIPTION
Instead of creating two memory streams of the file contents, just to
have SourceText.From turn them back into strings, create a single
SourceText for all documents from the already existing string.
