### PR TITLE
do not call kvm upgrade in build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,6 @@
 @echo off
 
 set "KRE_NUGET_API_URL=https://www.myget.org/F/aspnetvnext/api/v2"
-CALL kvm upgrade
 set "KRE_NUGET_API_URL=https://www.nuget.org/api/v2"
 CALL kvm install 1.0.0-beta2
 CALL kpm pack src/OmniSharp --no-source --out artifacts/build/OmniSharp --runtime KRE-CLR-x86.1.0.0-beta2


### PR DESCRIPTION
`kvm upgrade` is not needed because OmniSharp explicitly needs `1.0.0-beta2`. `kvm upgrade` gets the latest version of KVM which is ignore anyway, moreover it is aliasing it as 'default' forcing VS to pick it up. 
so if you run the `build.cmd` you will not be able to compile OmniSharp in VS until you manually reset the `default back to `1.0.0-beta2` which is a bit odd.

Alternatively, the build script could reset the `default` alias to `1.0.0-beta2`.