### PR TITLE
allow any change to be done in OmnisharpWorkspace

### DIFF
--- a/src/OmniSharp/Api/Refactoring/OmnisharpController.Rename.cs
+++ b/src/OmniSharp/Api/Refactoring/OmnisharpController.Rename.cs
@@ -13,7 +13,7 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("rename")]
-        public async Task<IActionResult> Rename([FromBody]RenameRequest request)
+        public async Task<RenameResponse> Rename([FromBody]RenameRequest request)
         {
             _workspace.EnsureBufferUpdated(request);
 
@@ -56,7 +56,7 @@ namespace OmniSharp
                 }
             }
 
-            return new ObjectResult(response);
+            return response;
         }
     }
 }

--- a/src/OmniSharp/Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp/Roslyn/OmniSharpWorkspace.cs
@@ -111,5 +111,10 @@ namespace OmniSharp
         {
             OnDocumentChanged(id, text);
         }
+
+        public override bool CanApplyChange(ApplyChangesKind feature)
+        {
+            return true;
+        }
     }
 }

--- a/tests/OmniSharp.Tests/OmnisharpControllerFacts.cs
+++ b/tests/OmniSharp.Tests/OmnisharpControllerFacts.cs
@@ -26,35 +26,6 @@ namespace OmniSharp.Tests
         }
 
         [Fact]
-        public async Task Rename_UpdatesWorkspace()
-        {
-            const string fileContent = @"using System;
-
-namespace OmniSharp.Models
-{
-    public class CodeFormatResponse
-    {
-        public string Buffer { get; set; }
-    }
-}";
-
-            OmnisharpWorkspace workspace;
-            OmnisharpController controller;
-            DocumentInfo document;
-            CreateSimpleWorkspace(out workspace, out controller, out document, "test.cs", fileContent);
-            var result = await controller.Rename(new Models.RenameRequest
-                        {
-                            Line = 7,
-                            Column = 27,
-                            RenameTo = "foo",
-                            FileName = "test.cs"
-                        });
-            var sourceText = await workspace.CurrentSolution.GetDocument(document.Id).GetTextAsync();
-            Assert.Equal(result.Changes.First().Buffer, sourceText.ToString());
-            Assert.Equal(result.Changes.First().FileName, "test.cs");
-        }
-
-        [Fact]
         public async Task UpdateBuffer_HandlesVoidRequest()
         {
             OmnisharpWorkspace workspace;

--- a/tests/OmniSharp.Tests/OmnisharpControllerFacts.cs
+++ b/tests/OmniSharp.Tests/OmnisharpControllerFacts.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
+using System.Linq;
 
 namespace OmniSharp.Tests
 {
@@ -22,6 +23,35 @@ namespace OmniSharp.Tests
 
             workspace.AddProject(projectInfo);
             workspace.AddDocument(document);
+        }
+
+        [Fact]
+        public async Task Rename_UpdatesWorkspace()
+        {
+            const string fileContent = @"using System;
+
+namespace OmniSharp.Models
+{
+    public class CodeFormatResponse
+    {
+        public string Buffer { get; set; }
+    }
+}";
+
+            OmnisharpWorkspace workspace;
+            OmnisharpController controller;
+            DocumentInfo document;
+            CreateSimpleWorkspace(out workspace, out controller, out document, "test.cs", fileContent);
+            var result = await controller.Rename(new Models.RenameRequest
+                        {
+                            Line = 7,
+                            Column = 27,
+                            RenameTo = "foo",
+                            FileName = "test.cs"
+                        });
+            var sourceText = await workspace.CurrentSolution.GetDocument(document.Id).GetTextAsync();
+            Assert.Equal(result.Changes.First().Buffer, sourceText.ToString());
+            Assert.Equal(result.Changes.First().FileName, "test.cs");
         }
 
         [Fact]

--- a/tests/OmniSharp.Tests/RenameFacts.cs
+++ b/tests/OmniSharp.Tests/RenameFacts.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OmniSharp.Tests
+{
+    public class RenameFacts
+    {
+        [Fact]
+        public async Task Rename_UpdatesWorkspaceAndDocumentText()
+        {
+            const string fileContent = @"using System;
+
+                        namespace OmniSharp.Models
+                        {
+                            public class CodeFormat$Response
+                            {
+                                public string Buffer { get; set; }
+                            }
+                        }";
+
+            var lineColumn = TestHelpers.GetLineAndColumnFromDollar(fileContent);
+            var workspace = TestHelpers.CreateSimpleWorkspace(fileContent, "test.cs");
+            var controller = new OmnisharpController(workspace, null);
+            var result = await controller.Rename(new Models.RenameRequest
+            {
+                Line = lineColumn.Line,
+                Column = lineColumn.Column,
+                RenameTo = "foo",
+                FileName = "test.cs",
+                Buffer = fileContent.Replace("$", "")
+            });
+
+            var docId = workspace.CurrentSolution.GetDocumentIdsWithFilePath("test.cs").First();
+            var sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
+            Assert.Equal(result.Changes.First().Buffer, sourceText.ToString());
+            Assert.Equal(result.Changes.First().FileName, "test.cs");
+        }
+
+        [Fact]
+        public async Task Rename_UpdatesMultipleDocumentsIfNecessary()
+        {
+            const string file1 = "public class F$oo {}";
+            const string file2 = @"public class Bar {
+                                    public Foo Property {get; set;}
+                                }";
+
+
+            var lineColumn = TestHelpers.GetLineAndColumnFromDollar(file1);
+            var workspace = TestHelpers.CreateSimpleWorkspace(new Dictionary<string, string> { { "test1.cs", file1 }, { "test2.cs", file2 } });
+
+            var controller = new OmnisharpController(workspace, null);
+            var result = await controller.Rename(new Models.RenameRequest
+            {
+                Line = lineColumn.Line,
+                Column = lineColumn.Column,
+                RenameTo = "xxx",
+                FileName = "test1.cs",
+                Buffer = file1.Replace("$", "")
+            });
+
+            var doc1Id = workspace.CurrentSolution.GetDocumentIdsWithFilePath("test1.cs").First();
+            var doc2Id = workspace.CurrentSolution.GetDocumentIdsWithFilePath("test2.cs").First();
+            var source1Text = await workspace.CurrentSolution.GetDocument(doc1Id).GetTextAsync();
+            var source2Text = await workspace.CurrentSolution.GetDocument(doc2Id).GetTextAsync();
+
+            Assert.Equal(result.Changes.ElementAt(0).Buffer, source1Text.ToString());
+            Assert.Equal(result.Changes.ElementAt(0).FileName, "test1.cs");
+
+            Assert.Equal(result.Changes.ElementAt(1).Buffer, source2Text.ToString());
+            Assert.Equal(result.Changes.ElementAt(1).FileName, "test2.cs");
+        }
+    }
+}

--- a/tests/OmniSharp.Tests/TestHelpers.cs
+++ b/tests/OmniSharp.Tests/TestHelpers.cs
@@ -48,22 +48,32 @@ namespace OmniSharp.Tests
 
         public static OmnisharpWorkspace CreateSimpleWorkspace(string source, string fileName = "dummy.cs")
         {
+            return CreateSimpleWorkspace(new Dictionary<string, string> { { fileName, source } });
+        }
+
+        public static OmnisharpWorkspace CreateSimpleWorkspace(Dictionary<string, string> sourceFiles)
+        {
             var workspace = new OmnisharpWorkspace();
             var projectId = ProjectId.CreateNewId();
             var versionStamp = VersionStamp.Create();
             var mscorlib = MetadataReference.CreateFromAssembly(AssemblyFromType(typeof(object)));
             var systemCore = MetadataReference.CreateFromAssembly(AssemblyFromType(typeof(Enumerable)));
-            var references = new [] { mscorlib, systemCore };
+            var references = new[] { mscorlib, systemCore };
             var projectInfo = ProjectInfo.Create(projectId, versionStamp,
                                                  "ProjectName", "AssemblyName",
                                                  LanguageNames.CSharp, "project.json", metadataReferences: references);
 
-            var document = DocumentInfo.Create(DocumentId.CreateNewId(projectInfo.Id), fileName,
-                null, SourceCodeKind.Regular,
-                TextLoader.From(TextAndVersion.Create(SourceText.From(source), versionStamp)), fileName);
-
             workspace.AddProject(projectInfo);
-            workspace.AddDocument(document);
+
+            foreach (var file in sourceFiles)
+            {
+                var document = DocumentInfo.Create(DocumentId.CreateNewId(projectInfo.Id), file.Key,
+                    null, SourceCodeKind.Regular,
+                    TextLoader.From(TextAndVersion.Create(SourceText.From(file.Value), versionStamp)), file.Key);
+
+                workspace.AddDocument(document);
+            }
+
             return workspace;
         }
 

--- a/tests/OmniSharp.Tests/project.json
+++ b/tests/OmniSharp.Tests/project.json
@@ -1,15 +1,19 @@
 ﻿{
-    "version": "1.0.0-*",
-    "dependencies": {
-        "OmniSharp": "1.0.0-*",
-        "Xunit.KRunner": "1.0.0-beta1",
-        "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.0.0-beta2"
-    },
-    "commands": {
-        "test": "Xunit.KRunner"
-    },
-    "frameworks": {
-        "aspnet50": { },
-        "aspnetcore50": { }
-    }
+	"version": "1.0.0-*",
+	"dependencies": {
+		"OmniSharp": "1.0.0-*",
+		"Xunit.KRunner": "1.0.0-beta1",
+		"Microsoft.CodeAnalysis.CSharp.Workspaces": "1.0.0-beta2"
+	},
+	"commands": {
+		"test": "Xunit.KRunner"
+	},
+	"frameworks": {
+		"aspnet50": { },
+		"aspnetcore50": {
+			"dependencies": {
+				"System.Collections": ""
+			}
+		}
+	}
 }


### PR DESCRIPTION
 fixes #55.

Since `OmniSharpWorkspace` inherits from `Workspace` abstract class, it needs to explicitly specify which changes can be done - and it seems reasonable to assume that all changes specified in the `ApplyChangesKind` should be allowed.

This prevents the exception mentioned in the #55 from happening and the buffer is correctly updated. 

However, the changes are not saved to disk at this moment. Roslyn normally does it using `MSBuildWorkspace` not through the base `Workspace` class. I haven't included this in the PR as I am not sure if any strategy for that has been discussed, but I can extend `OmniSharpWorkspace` to persist to disk if needed. 