### PR TITLE
if the Request has buffer content and filename, always update buffer

### DIFF
--- a/src/OmniSharp/Api/Buffer/OmnisharpController.Buffer.cs
+++ b/src/OmniSharp/Api/Buffer/OmnisharpController.Buffer.cs
@@ -10,7 +10,6 @@ namespace OmniSharp
         [HttpPost("updatebuffer")]
         public ObjectResult UpdateBuffer([FromBody]Request request)
         {
-            _workspace.EnsureBufferUpdated(request);
             return new ObjectResult(true);
         }
 

--- a/src/OmniSharp/Api/Diagnostics/OmnisharpController.Diagnostics.cs
+++ b/src/OmniSharp/Api/Diagnostics/OmnisharpController.Diagnostics.cs
@@ -12,8 +12,6 @@ namespace OmniSharp
         [HttpPost("codecheck")]
         public async Task<IActionResult> CodeCheck([FromBody]Request request)
         {
-            _workspace.EnsureBufferUpdated(request);
-
             var quickFixes = new List<QuickFix>();
 
             var documents = _workspace.GetDocuments(request.FileName);

--- a/src/OmniSharp/Api/Formatting/OmnisharpController.FormatDocument.cs
+++ b/src/OmniSharp/Api/Formatting/OmnisharpController.FormatDocument.cs
@@ -11,8 +11,6 @@ namespace OmniSharp
         [HttpPost("codeformat")]
         public async Task<IActionResult> CodeFormat([FromBody]Request request)
         {
-            _workspace.EnsureBufferUpdated(request);
-
             var options = _workspace.Options
                 .WithChangedOption(FormattingOptions.NewLine, LanguageNames.CSharp, _options.FormattingOptions.NewLine)
                 .WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, _options.FormattingOptions.UseTabs)

--- a/src/OmniSharp/Api/Intellisense/OmnisharpController.Intellisense.cs
+++ b/src/OmniSharp/Api/Intellisense/OmnisharpController.Intellisense.cs
@@ -19,8 +19,6 @@ namespace OmniSharp
         [HttpPost("autocomplete")]
         public async Task<IEnumerable<AutoCompleteResponse>> AutoComplete([FromBody]AutoCompleteRequest request)
         {
-            _workspace.EnsureBufferUpdated(request);
-
             var documents = _workspace.GetDocuments(request.FileName);
             var wordToComplete = request.WordToComplete;
             

--- a/src/OmniSharp/Api/Navigation/OmnisharpController.FindImplementations.cs
+++ b/src/OmniSharp/Api/Navigation/OmnisharpController.FindImplementations.cs
@@ -15,8 +15,6 @@ namespace OmniSharp
         [HttpPost("findimplementations")]
         public async Task<QuickFixResponse> FindImplementations([FromBody]Request request)
         {
-            _workspace.EnsureBufferUpdated(request);
-
             var document = _workspace.GetDocument(request.FileName);
             var response = new QuickFixResponse();
 

--- a/src/OmniSharp/Api/Navigation/OmnisharpController.FindUsages.cs
+++ b/src/OmniSharp/Api/Navigation/OmnisharpController.FindUsages.cs
@@ -14,8 +14,6 @@ namespace OmniSharp
         [HttpPost("findusages")]
         public async Task<QuickFixResponse> FindUsages([FromBody]Request request)
         {
-            _workspace.EnsureBufferUpdated(request);
-
             var document = _workspace.GetDocument(request.FileName);
             var response = new QuickFixResponse();
             if (document != null)

--- a/src/OmniSharp/Api/Navigation/OmnisharpController.GotoDefinition.cs
+++ b/src/OmniSharp/Api/Navigation/OmnisharpController.GotoDefinition.cs
@@ -13,8 +13,6 @@ namespace OmniSharp
         [HttpPost("gotodefinition")]
         public async Task<IActionResult> GotoDefinition([FromBody]Request request)
         {
-            _workspace.EnsureBufferUpdated(request);
-
             var quickFixes = new List<QuickFix>();
 
             var document = _workspace.GetDocument(request.FileName);

--- a/src/OmniSharp/Api/OmnisharpController.cs
+++ b/src/OmniSharp/Api/OmnisharpController.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.AspNet.Mvc;
 using Microsoft.Framework.OptionsModel;
+using OmniSharp.Filters;
 using OmniSharp.Options;
 
 namespace OmniSharp
 {
     [Route("/")]
+    [TypeFilter(typeof(UpdateBufferFilter))]
     public partial class OmnisharpController
     {
         private readonly OmnisharpWorkspace _workspace;

--- a/src/OmniSharp/Api/OmnisharpController.cs
+++ b/src/OmniSharp/Api/OmnisharpController.cs
@@ -1,12 +1,10 @@
 ﻿using Microsoft.AspNet.Mvc;
 using Microsoft.Framework.OptionsModel;
-using OmniSharp.Filters;
 using OmniSharp.Options;
 
 namespace OmniSharp
 {
     [Route("/")]
-    [TypeFilter(typeof(UpdateBufferFilter))]
     public partial class OmnisharpController
     {
         private readonly OmnisharpWorkspace _workspace;

--- a/src/OmniSharp/Api/Refactoring/OmnisharpController.CodeActions.cs
+++ b/src/OmniSharp/Api/Refactoring/OmnisharpController.CodeActions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,9 +6,9 @@ using Microsoft.AspNet.Mvc;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Filters;
 using OmniSharp.Models;
 using OmniSharp.Services;
-using OmniSharp.Filters;
 
 namespace OmniSharp
 {

--- a/src/OmniSharp/Api/Refactoring/OmnisharpController.CodeActions.cs
+++ b/src/OmniSharp/Api/Refactoring/OmnisharpController.CodeActions.cs
@@ -9,9 +9,11 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Models;
 using OmniSharp.Services;
+using OmniSharp.Filters;
 
 namespace OmniSharp
 {
+    [TypeFilter(typeof(UpdateBufferFilter))]
     public class CodeActionController
     {
         private readonly OmnisharpWorkspace _workspace;
@@ -26,7 +28,6 @@ namespace OmniSharp
         [HttpPost("getcodeactions")]
         public async Task<GetCodeActionsResponse> GetCodeActions([FromBody]CodeActionRequest request)
         {
-            _workspace.EnsureBufferUpdated(request);
             var actions = new List<CodeAction>();
             var context = await GetContext(request, actions);
             await GetContextualCodeActions(context);
@@ -36,7 +37,6 @@ namespace OmniSharp
         [HttpPost("runcodeaction")]
         public async Task<RunCodeActionResponse> RunCodeAction([FromBody]CodeActionRequest request)
         {
-            _workspace.EnsureBufferUpdated(request);
             var actions = new List<CodeAction>();
             var context = await GetContext(request, actions);
             await GetContextualCodeActions(context);

--- a/src/OmniSharp/Api/Refactoring/OmnisharpController.CodeActions.cs
+++ b/src/OmniSharp/Api/Refactoring/OmnisharpController.CodeActions.cs
@@ -6,13 +6,11 @@ using Microsoft.AspNet.Mvc;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Text;
-using OmniSharp.Filters;
 using OmniSharp.Models;
 using OmniSharp.Services;
 
 namespace OmniSharp
 {
-    [TypeFilter(typeof(UpdateBufferFilter))]
     public class CodeActionController
     {
         private readonly OmnisharpWorkspace _workspace;

--- a/src/OmniSharp/Api/Refactoring/OmnisharpController.Rename.cs
+++ b/src/OmniSharp/Api/Refactoring/OmnisharpController.Rename.cs
@@ -15,8 +15,6 @@ namespace OmniSharp
         [HttpPost("rename")]
         public async Task<RenameResponse> Rename([FromBody]RenameRequest request)
         {
-            _workspace.EnsureBufferUpdated(request);
-
             var response = new RenameResponse();
 
             var document = _workspace.GetDocument(request.FileName);

--- a/src/OmniSharp/Api/TestCommands/TestCommandController.cs
+++ b/src/OmniSharp/Api/TestCommands/TestCommandController.cs
@@ -8,9 +8,11 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Models;
+using OmniSharp.Filters;
 
 namespace OmniSharp
 {
+    [TypeFilter(typeof(UpdateBufferFilter))]
     public class TestCommandController
     {
         private OmnisharpWorkspace _workspace;
@@ -26,8 +28,6 @@ namespace OmniSharp
         [HttpPost("gettestcontext")]
         public async Task<GetTestCommandResponse> GetTestCommand([FromBody]TestCommandRequest request)
         {
-            _workspace.EnsureBufferUpdated(request);
-
             var quickFixes = new List<QuickFix>();
 
             var document = _workspace.GetDocument(request.FileName);

--- a/src/OmniSharp/Api/TestCommands/TestCommandController.cs
+++ b/src/OmniSharp/Api/TestCommands/TestCommandController.cs
@@ -7,8 +7,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
-using OmniSharp.Models;
 using OmniSharp.Filters;
+using OmniSharp.Models;
 
 namespace OmniSharp
 {

--- a/src/OmniSharp/Api/TestCommands/TestCommandController.cs
+++ b/src/OmniSharp/Api/TestCommands/TestCommandController.cs
@@ -7,12 +7,10 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
-using OmniSharp.Filters;
 using OmniSharp.Models;
 
 namespace OmniSharp
 {
-    [TypeFilter(typeof(UpdateBufferFilter))]
     public class TestCommandController
     {
         private OmnisharpWorkspace _workspace;

--- a/src/OmniSharp/Api/Types/OmnisharpController.TypeLookup.cs
+++ b/src/OmniSharp/Api/Types/OmnisharpController.TypeLookup.cs
@@ -12,8 +12,6 @@ namespace OmniSharp
         [HttpPost("typelookup")]
         public async Task<IActionResult> TypeLookup([FromBody]TypeLookupRequest request)
         {
-            _workspace.EnsureBufferUpdated(request);
-
             var document = _workspace.GetDocument(request.FileName);
             var response = new TypeLookupResponse();
             if (document != null)

--- a/src/OmniSharp/Filters/UpdateBufferFilter.cs
+++ b/src/OmniSharp/Filters/UpdateBufferFilter.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿using System.Linq;
+using Microsoft.AspNet.Mvc;
 using OmniSharp.Models;
-using System;
-using System.Linq;
 
 namespace OmniSharp.Filters
 {

--- a/src/OmniSharp/Filters/UpdateBufferFilter.cs
+++ b/src/OmniSharp/Filters/UpdateBufferFilter.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNet.Mvc;
+using OmniSharp.Models;
+using System;
+using System.Linq;
+
+namespace OmniSharp.Filters
+{
+    public class UpdateBufferFilter : IActionFilter
+    {
+        private OmnisharpWorkspace _workspace;
+
+        public UpdateBufferFilter(OmnisharpWorkspace workspace)
+        {
+            _workspace = workspace;
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+        }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (context.ActionArguments.Any())
+            {
+                var request = context.ActionArguments.FirstOrDefault(arg => arg.Value is Request);
+                if (request.Value != null)
+                {
+                    var typedRequest = (Request)request.Value;
+                    if (typedRequest.Buffer != null && typedRequest.FileName != null)
+                    {
+                        _workspace.EnsureBufferUpdated(typedRequest);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/OmniSharp/Startup.cs
+++ b/src/OmniSharp/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Logging;
 using Microsoft.Framework.Logging.Console;
 using OmniSharp.AspNet5;
+using OmniSharp.Filters;
 using OmniSharp.Middleware;
 using OmniSharp.MSBuild;
 using OmniSharp.Options;
@@ -48,6 +49,7 @@ namespace OmniSharp
             services.Configure<MvcOptions>(opt =>
             {
                 opt.OutputFormatters.RemoveAll(r => r.Instance is XmlOutputFormatter);
+                opt.Filters.Add(new UpdateBufferFilter(Workspace));
             });
 
             // Add the omnisharp workspace to the container

--- a/tests/OmniSharp.Tests/FindImplementationFacts.cs
+++ b/tests/OmniSharp.Tests/FindImplementationFacts.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using OmniSharp.Models;
 using Xunit;
+using OmniSharp.Filters;
 
 namespace OmniSharp.Tests
 {
@@ -72,6 +73,8 @@ namespace OmniSharp.Tests
             var workspace = TestHelpers.CreateSimpleWorkspace(source);
             var controller = new OmnisharpController(workspace, null);
             var request = CreateRequest(source);
+            var bufferFilter = new UpdateBufferFilter(workspace);
+            bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(request));
             var implementations = await controller.FindImplementations(request);
             return await TestHelpers.SymbolsFromQuickFixes(workspace, implementations.QuickFixes);
         }

--- a/tests/OmniSharp.Tests/FindImplementationFacts.cs
+++ b/tests/OmniSharp.Tests/FindImplementationFacts.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using OmniSharp.Models;
 using Xunit;
 using OmniSharp.Filters;
+using OmniSharp.Models;
 
 namespace OmniSharp.Tests
 {

--- a/tests/OmniSharp.Tests/FindReferencesFacts.cs
+++ b/tests/OmniSharp.Tests/FindReferencesFacts.cs
@@ -1,8 +1,8 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
-using OmniSharp.Models;
 using OmniSharp.Filters;
+using OmniSharp.Models;
 
 namespace OmniSharp.Tests
 {

--- a/tests/OmniSharp.Tests/FindReferencesFacts.cs
+++ b/tests/OmniSharp.Tests/FindReferencesFacts.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using OmniSharp.Models;
+using OmniSharp.Filters;
 
 namespace OmniSharp.Tests
 {
@@ -161,6 +162,8 @@ namespace OmniSharp.Tests
             var workspace = TestHelpers.CreateSimpleWorkspace(source);
             var controller = new OmnisharpController(workspace, null);
             var request = CreateRequest(source);
+            var bufferFilter = new UpdateBufferFilter(workspace);
+            bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(request));
             return await controller.FindUsages(request);
         }
     }

--- a/tests/OmniSharp.Tests/OmnisharpControllerFacts.cs
+++ b/tests/OmniSharp.Tests/OmnisharpControllerFacts.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace OmniSharp.Tests

--- a/tests/OmniSharp.Tests/OmnisharpControllerFacts.cs
+++ b/tests/OmniSharp.Tests/OmnisharpControllerFacts.cs
@@ -1,7 +1,6 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace OmniSharp.Tests
@@ -23,37 +22,6 @@ namespace OmniSharp.Tests
 
             workspace.AddProject(projectInfo);
             workspace.AddDocument(document);
-        }
-
-        [Fact]
-        public async Task UpdateBuffer_HandlesVoidRequest()
-        {
-            OmnisharpWorkspace workspace;
-            OmnisharpController controller;
-            DocumentInfo document;
-            CreateSimpleWorkspace(out workspace, out controller, out document, "test.cs", "class C {}");
-            
-            // ignore void buffers
-            controller.UpdateBuffer(new Models.Request() { });
-            var sourceText = await workspace.CurrentSolution.GetDocument(document.Id).GetTextAsync();
-            Assert.Equal("class C {}", sourceText.ToString());
-
-            controller.UpdateBuffer(new Models.Request() { FileName = "test.cs" });
-            sourceText = await workspace.CurrentSolution.GetDocument(document.Id).GetTextAsync();
-            Assert.Equal("class C {}", sourceText.ToString());
-
-            controller.UpdateBuffer(new Models.Request() { Buffer = "// c", FileName = "some_other_file.cs" });
-            sourceText = await workspace.CurrentSolution.GetDocument(document.Id).GetTextAsync();
-            Assert.Equal("class C {}", sourceText.ToString());
-
-            // valid updates
-            controller.UpdateBuffer(new Models.Request() { FileName = "test.cs", Buffer = "interface I {}" });
-            sourceText = await workspace.CurrentSolution.GetDocument(document.Id).GetTextAsync();
-            Assert.Equal("interface I {}", sourceText.ToString());
-
-            controller.UpdateBuffer(new Models.Request() { FileName = "test.cs", Buffer = "" });
-            sourceText = await workspace.CurrentSolution.GetDocument(document.Id).GetTextAsync();
-            Assert.Equal("", sourceText.ToString());
         }
 
         [Fact]

--- a/tests/OmniSharp.Tests/RenameFacts.cs
+++ b/tests/OmniSharp.Tests/RenameFacts.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using OmniSharp.Models;
+using OmniSharp.Filters;
 
 namespace OmniSharp.Tests
 {
@@ -20,6 +21,9 @@ namespace OmniSharp.Tests
                 FileName = filename,
                 Buffer = fileContent.Replace("$", "")
             };
+
+            var bufferFilter = new UpdateBufferFilter(workspace);
+            bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(request));
 
             return await controller.Rename(request);
         }

--- a/tests/OmniSharp.Tests/RenameFacts.cs
+++ b/tests/OmniSharp.Tests/RenameFacts.cs
@@ -2,8 +2,8 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
-using OmniSharp.Models;
 using OmniSharp.Filters;
+using OmniSharp.Models;
 
 namespace OmniSharp.Tests
 {

--- a/tests/OmniSharp.Tests/TestCommandFacts.cs
+++ b/tests/OmniSharp.Tests/TestCommandFacts.cs
@@ -1,9 +1,8 @@
 using System.Threading.Tasks;
-using Microsoft.AspNet.Mvc;
 using Xunit;
 using OmniSharp.AspNet5;
-using OmniSharp.Models;
 using OmniSharp.Filters;
+using OmniSharp.Models;
 
 namespace OmniSharp.Tests
 {

--- a/tests/OmniSharp.Tests/TestCommandFacts.cs
+++ b/tests/OmniSharp.Tests/TestCommandFacts.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNet.Mvc;
 using Xunit;
 using OmniSharp.AspNet5;
 using OmniSharp.Models;
+using OmniSharp.Filters;
 
 namespace OmniSharp.Tests
 {
@@ -151,6 +152,8 @@ namespace OmniSharp.Tests
             var testCommandProviders = new[] { new AspNet5TestCommandProvider(context) };
             var controller = new TestCommandController(workspace, testCommandProviders);
             var request = CreateRequest(source);
+            var bufferFilter = new UpdateBufferFilter(workspace);
+            bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(request));
             return await controller.GetTestCommand(request);
         }
 

--- a/tests/OmniSharp.Tests/TestHelpers.cs
+++ b/tests/OmniSharp.Tests/TestHelpers.cs
@@ -7,6 +7,8 @@ using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Models;
 using System.Reflection;
+using Microsoft.AspNet.Mvc;
+using Microsoft.AspNet.Routing;
 
 namespace OmniSharp.Tests
 {
@@ -99,6 +101,13 @@ namespace OmniSharp.Tests
                 symbols.Add(await TestHelpers.SymbolFromQuickFix(workspace, quickfix)); 
             }
             return symbols;
+        }
+
+        public static ActionExecutingContext CreateActionExecutingContext(Request req)
+        {
+            var actionContext = new ActionContext(null, null, null);
+            var actionExecutingContext = new ActionExecutingContext(actionContext, new List<IFilter>(), new Dictionary<string, object> { { "request", req} });
+            return actionExecutingContext;
         }
     }
 }

--- a/tests/OmniSharp.Tests/TestHelpers.cs
+++ b/tests/OmniSharp.Tests/TestHelpers.cs
@@ -1,14 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Mvc;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Models;
-using System.Reflection;
-using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Routing;
 
 namespace OmniSharp.Tests
 {

--- a/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
+++ b/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.AspNet.Mvc;
-using Microsoft.CodeAnalysis.CSharp;
-using OmniSharp.Filters;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
+using OmniSharp.Filters;
 
 namespace OmniSharp.Tests
 {

--- a/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
+++ b/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNet.Mvc;
+using Microsoft.CodeAnalysis.CSharp;
+using OmniSharp.Filters;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OmniSharp.Tests
+{
+    public class UpdateBufferFilterFacts
+    {
+        [Fact]
+        public async Task UpdateBuffer_HandlesVoidRequest()
+        {
+            var workspace = TestHelpers.CreateSimpleWorkspace(new Dictionary<string, string>
+            {
+                { "test.cs", "class C {}" }
+            });
+
+            var bufferFilter = new UpdateBufferFilter(workspace);
+            var docId = workspace.CurrentSolution.GetDocumentIdsWithFilePath("test.cs").First();
+
+            // ignore void buffers
+            bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(new Models.Request() { }));
+            var sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
+            Assert.Equal("class C {}", sourceText.ToString());
+
+            bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(new Models.Request() { FileName = "test.cs" }));
+            sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
+            Assert.Equal("class C {}", sourceText.ToString());
+
+            bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(new Models.Request() { Buffer = "// c", FileName = "some_other_file.cs" }));
+            sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
+            Assert.Equal("class C {}", sourceText.ToString());
+
+            // valid updates
+            bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(new Models.Request() { FileName = "test.cs", Buffer = "interface I {}" }));
+            sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
+            Assert.Equal("interface I {}", sourceText.ToString());
+
+            bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(new Models.Request() { FileName = "test.cs", Buffer = "" }));
+            sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
+            Assert.Equal("", sourceText.ToString());
+        }
+    }
+}


### PR DESCRIPTION
instead of remembering to update buffer all over the place, if the action takes a `Request` model and if the request has `FileName` and `Buffer` populated, update the buffer automatically