### PR TITLE
Find usages in file

### DIFF
--- a/src/OmniSharp/Api/Navigation/OmnisharpController.FindUsages.cs
+++ b/src/OmniSharp/Api/Navigation/OmnisharpController.FindUsages.cs
@@ -37,7 +37,9 @@ namespace OmniSharp
                         locations.Add(location.Location);
                     }
 
-                    var definitionLocations = usage.Definition.Locations.Where(loc => loc.IsInSource);
+                    var definitionLocations = usage.Definition.Locations
+                        .Where(loc => loc.IsInSource && (!request.OnlyThisFile || loc.SourceTree.FilePath == request.FileName));
+                        
                     foreach (var location in definitionLocations)
                     {
                         locations.Add(location);

--- a/src/OmniSharp/Api/Navigation/OmnisharpController.FindUsages.cs
+++ b/src/OmniSharp/Api/Navigation/OmnisharpController.FindUsages.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
@@ -12,7 +13,7 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("findusages")]
-        public async Task<QuickFixResponse> FindUsages([FromBody]Request request)
+        public async Task<QuickFixResponse> FindUsages([FromBody]FindUsagesRequest request)
         {
             var document = _workspace.GetDocument(request.FileName);
             var response = new QuickFixResponse();
@@ -23,7 +24,9 @@ namespace OmniSharp
                 var position = sourceText.Lines.GetPosition(new LinePosition(request.Line - 1, request.Column - 1));
                 var symbol = SymbolFinder.FindSymbolAtPosition(semanticModel, position, _workspace);
                 var definition = await SymbolFinder.FindSourceDefinitionAsync(symbol, _workspace.CurrentSolution);
-                var usages = await SymbolFinder.FindReferencesAsync(definition ?? symbol, _workspace.CurrentSolution);
+                var usages = request.OnlyThisFile
+                    ? await SymbolFinder.FindReferencesAsync(definition ?? symbol, _workspace.CurrentSolution, ImmutableHashSet.Create(document))
+                    : await SymbolFinder.FindReferencesAsync(definition ?? symbol, _workspace.CurrentSolution);
 
                 var locations = new HashSet<Location>();
 

--- a/src/OmniSharp/Models/FindUsagesRequest.cs
+++ b/src/OmniSharp/Models/FindUsagesRequest.cs
@@ -1,0 +1,11 @@
+﻿
+namespace OmniSharp.Models
+{
+    public class FindUsagesRequest : Request
+    {
+        /// <summary>
+        /// Only search for references in the current file
+        /// </summary>
+        public bool OnlyThisFile { get; set; }
+    }
+}

--- a/tests/OmniSharp.Tests/FindReferencesFacts.cs
+++ b/tests/OmniSharp.Tests/FindReferencesFacts.cs
@@ -167,6 +167,21 @@ namespace OmniSharp.Tests
             Assert.Equal("a.cs", usages.QuickFixes.ElementAt(0).FileName);
             Assert.Equal("a.cs", usages.QuickFixes.ElementAt(1).FileName);
         }
+        
+        [Fact]
+        public async Task DontFindDefinitionInAnotherFile()
+        {
+            var sourceA = @"public class Bar : F$oo {}";
+            var sourceB = @"public class Foo {
+                public Foo Clone() {
+                    return null;
+                }
+            }";
+
+            var usages = await FindUsages(new Dictionary<string, string> { { "a.cs", sourceA }, { "b.cs", sourceB } }, "a.cs", true);
+            Assert.Equal(1, usages.QuickFixes.Count());
+            Assert.Equal("a.cs", usages.QuickFixes.ElementAt(0).FileName);
+        }
 
         private FindUsagesRequest CreateRequest(string source, string fileName = "dummy.cs")
         {

--- a/tests/OmniSharp.Tests/FindReferencesFacts.cs
+++ b/tests/OmniSharp.Tests/FindReferencesFacts.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using OmniSharp.Filters;
@@ -145,23 +146,52 @@ namespace OmniSharp.Tests
             Assert.Equal(2, usages.QuickFixes.Count());
         }
 
-        private Request CreateRequest(string source, string fileName = "dummy.cs")
+        [Fact]
+        public async Task LimitReferenceSearchToThisFile()
+        {
+            var sourceA = @"public class F$oo {
+                public Foo Clone() {
+                    return null;
+                }
+            }";
+            var sourceB = @"public class Bar : Foo {}";
+
+            var usages = await FindUsages(new Dictionary<string, string> { { "a.cs", sourceA }, { "b.cs", sourceB } }, "a.cs", false);
+            Assert.Equal(3, usages.QuickFixes.Count());
+            Assert.Equal("a.cs", usages.QuickFixes.ElementAt(0).FileName);
+            Assert.Equal("a.cs", usages.QuickFixes.ElementAt(1).FileName);
+            Assert.Equal("b.cs", usages.QuickFixes.ElementAt(2).FileName);
+            
+            usages = await FindUsages(new Dictionary<string, string> { { "a.cs", sourceA }, { "b.cs", sourceB } }, "a.cs", true);
+            Assert.Equal(2, usages.QuickFixes.Count());
+            Assert.Equal("a.cs", usages.QuickFixes.ElementAt(0).FileName);
+            Assert.Equal("a.cs", usages.QuickFixes.ElementAt(1).FileName);
+        }
+
+        private FindUsagesRequest CreateRequest(string source, string fileName = "dummy.cs")
         {
             var lineColumn = TestHelpers.GetLineAndColumnFromDollar(source);
-            return new Request
+            return new FindUsagesRequest
             {
                 Line = lineColumn.Line,
                 Column = lineColumn.Column,
                 FileName = fileName,
-                Buffer = source.Replace("$", "")
+                Buffer = source.Replace("$", ""),
+                OnlyThisFile = false
             };
         }
 
         private async Task<QuickFixResponse> FindUsages(string source)
         {
-            var workspace = TestHelpers.CreateSimpleWorkspace(source);
+            return await FindUsages(new Dictionary<string, string> { { "dummy.cs", source }}, "dummy.cs", false);
+        }
+
+        private async Task<QuickFixResponse> FindUsages(Dictionary<string, string> sources, string currentFile, bool onlyThisFile)
+        {
+            var workspace = TestHelpers.CreateSimpleWorkspace(sources);
             var controller = new OmnisharpController(workspace, null);
-            var request = CreateRequest(source);
+            var request = CreateRequest(sources[currentFile], currentFile);
+            request.OnlyThisFile = onlyThisFile;
             var bufferFilter = new UpdateBufferFilter(workspace);
             bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(request));
             return await controller.FindUsages(request);


### PR DESCRIPTION
Allows to limit the find usages call to the current file. This will allow editors to implement a _mark occurrences_ feature (highlighting all occurrences of the symbol under the caret)