### PR TITLE
Automatically use [FromBody] for all complex types

### DIFF
--- a/src/OmniSharp/Api/Buffer/OmnisharpController.Buffer.cs
+++ b/src/OmniSharp/Api/Buffer/OmnisharpController.Buffer.cs
@@ -8,13 +8,13 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("updatebuffer")]
-        public ObjectResult UpdateBuffer([FromBody]Request request)
+        public ObjectResult UpdateBuffer(Request request)
         {
             return new ObjectResult(true);
         }
 
         [HttpPost("changebuffer")]
-        public async Task<ObjectResult> ChangeBuffer([FromBody]ChangeBufferRequest request)
+        public async Task<ObjectResult> ChangeBuffer(ChangeBufferRequest request)
         {
             foreach (var documentId in _workspace.CurrentSolution.GetDocumentIdsWithFilePath(request.FileName))
             {

--- a/src/OmniSharp/Api/Diagnostics/OmnisharpController.Diagnostics.cs
+++ b/src/OmniSharp/Api/Diagnostics/OmnisharpController.Diagnostics.cs
@@ -10,7 +10,7 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("codecheck")]
-        public async Task<IActionResult> CodeCheck([FromBody]Request request)
+        public async Task<IActionResult> CodeCheck(Request request)
         {
             var quickFixes = new List<QuickFix>();
 

--- a/src/OmniSharp/Api/Formatting/OmnisharpController.Format.cs
+++ b/src/OmniSharp/Api/Formatting/OmnisharpController.Format.cs
@@ -10,7 +10,7 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("formatAfterKeystroke")]
-        public async Task<FormatRangeResponse> FormatAfterKeystroke([FromBody]FormatAfterKeystrokeRequest request)
+        public async Task<FormatRangeResponse> FormatAfterKeystroke(FormatAfterKeystrokeRequest request)
         {
             var document = _workspace.GetDocument(request.FileName);
             if (document == null)
@@ -29,7 +29,7 @@ namespace OmniSharp
         }
 
         [HttpPost("formatRange")]
-        public async Task<FormatRangeResponse> FormatRange([FromBody]FormatRangeRequest request)
+        public async Task<FormatRangeResponse> FormatRange(FormatRangeRequest request)
         {
             var document = _workspace.GetDocument(request.FileName);
             if (document == null)
@@ -49,7 +49,7 @@ namespace OmniSharp
         }
 
         [HttpPost("codeformat")]
-        public async Task<CodeFormatResponse> FormatDocument([FromBody]Request request)
+        public async Task<CodeFormatResponse> FormatDocument(Request request)
         {
             var document = _workspace.GetDocument(request.FileName);
             if (document == null)

--- a/src/OmniSharp/Api/Intellisense/OmnisharpController.Intellisense.cs
+++ b/src/OmniSharp/Api/Intellisense/OmnisharpController.Intellisense.cs
@@ -17,7 +17,7 @@ namespace OmniSharp
             = new HashSet<AutoCompleteResponse>();
 
         [HttpPost("autocomplete")]
-        public async Task<IEnumerable<AutoCompleteResponse>> AutoComplete([FromBody]AutoCompleteRequest request)
+        public async Task<IEnumerable<AutoCompleteResponse>> AutoComplete(AutoCompleteRequest request)
         {
             var documents = _workspace.GetDocuments(request.FileName);
             var wordToComplete = request.WordToComplete;

--- a/src/OmniSharp/Api/Navigation/OmnisharpController.FindImplementations.cs
+++ b/src/OmniSharp/Api/Navigation/OmnisharpController.FindImplementations.cs
@@ -13,7 +13,7 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("findimplementations")]
-        public async Task<QuickFixResponse> FindImplementations([FromBody]Request request)
+        public async Task<QuickFixResponse> FindImplementations(Request request)
         {
             var document = _workspace.GetDocument(request.FileName);
             var response = new QuickFixResponse();

--- a/src/OmniSharp/Api/Navigation/OmnisharpController.FindUsages.cs
+++ b/src/OmniSharp/Api/Navigation/OmnisharpController.FindUsages.cs
@@ -13,7 +13,7 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("findusages")]
-        public async Task<QuickFixResponse> FindUsages([FromBody]FindUsagesRequest request)
+        public async Task<QuickFixResponse> FindUsages(FindUsagesRequest request)
         {
             var document = _workspace.GetDocument(request.FileName);
             var response = new QuickFixResponse();

--- a/src/OmniSharp/Api/Navigation/OmnisharpController.GotoDefinition.cs
+++ b/src/OmniSharp/Api/Navigation/OmnisharpController.GotoDefinition.cs
@@ -11,7 +11,7 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("gotodefinition")]
-        public async Task<IActionResult> GotoDefinition([FromBody]Request request)
+        public async Task<IActionResult> GotoDefinition(Request request)
         {
             var quickFixes = new List<QuickFix>();
 

--- a/src/OmniSharp/Api/ProjectSystem/OmnisharpController.ProjectSystem.cs
+++ b/src/OmniSharp/Api/ProjectSystem/OmnisharpController.ProjectSystem.cs
@@ -31,7 +31,7 @@ namespace OmniSharp
         }
 
         [HttpPost("/project")]
-        public ProjectInformationResponse CurrentProject([FromBody]Request request)
+        public ProjectInformationResponse CurrentProject(Request request)
         {
             var document = _workspace.GetDocument(request.FileName);
 

--- a/src/OmniSharp/Api/Refactoring/OmnisharpController.CodeActions.cs
+++ b/src/OmniSharp/Api/Refactoring/OmnisharpController.CodeActions.cs
@@ -23,7 +23,7 @@ namespace OmniSharp
         }
 
         [HttpPost("getcodeactions")]
-        public async Task<GetCodeActionsResponse> GetCodeActions([FromBody]CodeActionRequest request)
+        public async Task<GetCodeActionsResponse> GetCodeActions(CodeActionRequest request)
         {
             var actions = new List<CodeAction>();
             var context = await GetContext(request, actions);
@@ -32,7 +32,7 @@ namespace OmniSharp
         }
 
         [HttpPost("runcodeaction")]
-        public async Task<RunCodeActionResponse> RunCodeAction([FromBody]CodeActionRequest request)
+        public async Task<RunCodeActionResponse> RunCodeAction(CodeActionRequest request)
         {
             var actions = new List<CodeAction>();
             var context = await GetContext(request, actions);

--- a/src/OmniSharp/Api/Refactoring/OmnisharpController.Rename.cs
+++ b/src/OmniSharp/Api/Refactoring/OmnisharpController.Rename.cs
@@ -12,7 +12,7 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("rename")]
-        public async Task<RenameResponse> Rename([FromBody]RenameRequest request)
+        public async Task<RenameResponse> Rename(RenameRequest request)
         {
             var response = new RenameResponse();
 

--- a/src/OmniSharp/Api/Structure/OmnisharpController.Members.cs
+++ b/src/OmniSharp/Api/Structure/OmnisharpController.Members.cs
@@ -8,7 +8,7 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("currentfilemembersastree")]
-        public async Task<IActionResult> MembersAsTree([FromBody]Request request)
+        public async Task<IActionResult> MembersAsTree(Request request)
         {
             return new ObjectResult(new
             {
@@ -17,7 +17,7 @@ namespace OmniSharp
         }
 
         [HttpPost("currentfilemembersasflat")]
-        public async Task<IActionResult> MembersAsFlat([FromBody]Request request)
+        public async Task<IActionResult> MembersAsFlat(Request request)
         {
             var stack = new List<FileMemberElement>(await StructureComputer.Compute(_workspace.GetDocuments(request.FileName)));
             var ret = new List<QuickFix>();

--- a/src/OmniSharp/Api/TestCommands/TestCommandController.cs
+++ b/src/OmniSharp/Api/TestCommands/TestCommandController.cs
@@ -24,7 +24,7 @@ namespace OmniSharp
         }
 
         [HttpPost("gettestcontext")]
-        public async Task<GetTestCommandResponse> GetTestCommand([FromBody]TestCommandRequest request)
+        public async Task<GetTestCommandResponse> GetTestCommand(TestCommandRequest request)
         {
             var quickFixes = new List<QuickFix>();
 

--- a/src/OmniSharp/Api/Types/OmnisharpController.TypeLookup.cs
+++ b/src/OmniSharp/Api/Types/OmnisharpController.TypeLookup.cs
@@ -10,7 +10,7 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("typelookup")]
-        public async Task<IActionResult> TypeLookup([FromBody]TypeLookupRequest request)
+        public async Task<IActionResult> TypeLookup(TypeLookupRequest request)
         {
             var document = _workspace.GetDocument(request.FileName);
             var response = new TypeLookupResponse();

--- a/src/OmniSharp/Settings/FromBodyApplicationModelConvention.cs
+++ b/src/OmniSharp/Settings/FromBodyApplicationModelConvention.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNet.Mvc;
+using Microsoft.AspNet.Mvc.ApplicationModels;
+using Microsoft.AspNet.Mvc.ModelBinding;
+
+namespace OmniSharp.Settings
+{
+    public class FromBodyApplicationModelConvention : IApplicationModelConvention
+    {
+        public void Apply(ApplicationModel application)
+        {
+            foreach (var controller in application.Controllers)
+            {
+                foreach (var action in controller.Actions)
+                {
+                    foreach (var parameter in action.Parameters)
+                    {
+                        if (parameter.BinderMetadata is IBinderMetadata || ValueProviderResult.CanConvertFromString(parameter.ParameterInfo.ParameterType))
+                        {
+                            // behavior configured or simple type so do nothing
+                        }
+                        else
+                        {
+                            // Complex types are by-default from the body.
+                            parameter.BinderMetadata = new FromBodyAttribute();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/OmniSharp/Startup.cs
+++ b/src/OmniSharp/Startup.cs
@@ -15,6 +15,7 @@ using OmniSharp.Middleware;
 using OmniSharp.MSBuild;
 using OmniSharp.Options;
 using OmniSharp.Services;
+using OmniSharp.Settings;
 
 namespace OmniSharp
 {
@@ -49,6 +50,7 @@ namespace OmniSharp
             services.Configure<MvcOptions>(opt =>
             {
                 opt.OutputFormatters.RemoveAll(r => r.Instance is XmlOutputFormatter);
+                opt.ApplicationModelConventions.Add(new FromBodyApplicationModelConvention());
                 opt.Filters.Add(new UpdateBufferFilter(Workspace));
             });
 


### PR DESCRIPTION
This ensures that `[FromBody]` is auto-applied to all complex types. It also respects overriding this, so if you use i.e. `[FromQuery]` on a parameter, that will take precedence.

This will help avoid issues such as #87 