### PR TITLE
limit fuzzy matching 

### DIFF
--- a/src/OmniSharp/Extensions/StringExtensions.cs
+++ b/src/OmniSharp/Extensions/StringExtensions.cs
@@ -29,7 +29,20 @@ namespace OmniSharp.Extensions
             if (partial == string.Empty)
                 return true;
 
+            // Limit the number of results returned by making sure
+            // at least the first characters match.
+            // We can get far too many results back otherwise.
+            if (!FirstLetterMatches(partial, completion))
+            {
+                return false;
+            }
+
             return new string(completion.ToUpper().Intersect(partial.ToUpper()).ToArray()) == partial.ToUpper();
+        }
+
+        private static bool FirstLetterMatches(string word, string match) 
+        {
+            return char.ToLowerInvariant(word.First()) == char.ToLowerInvariant(match.First());
         }
     }
 }

--- a/tests/OmniSharp.Tests/SnippetFacts.cs
+++ b/tests/OmniSharp.Tests/SnippetFacts.cs
@@ -205,6 +205,42 @@ namespace OmniSharp.Tests
         }
 
         [Fact]
+        public async Task Fuzzy_matches_are_returned_when_first_letters_match()
+        {
+            var source = @"
+                using System;
+                public class Class1
+                {
+                    public Class1()
+                    {
+                        Console.wrl$
+                    }
+                }
+            ";
+
+            var completions = await FindCompletionsAsync(source);
+            ContainsSnippet("WriteLine();$0 : void", completions);
+        }
+
+        [Fact]
+        public async Task Fuzzy_matches_are_not_returned_when_first_letters_do_not_match()
+        {
+            var source = @"
+                using System;
+                public class Class1
+                {
+                    public Class1()
+                    {
+                        Console.rl$
+                    }
+                }
+            ";
+
+            var completions = await FindCompletionsAsync(source);
+            Assert.DoesNotContain("WriteLine();$0 : void", completions);
+        }
+
+        [Fact]
         public async Task Can_complete_parameter()
         {
             var source = @"


### PR DESCRIPTION
Limit fuzzy matching so that it only matches when the first characters match. This can improve the performance tremendously (especially when you are at the root level of a method and are matching on a single char)

It was returning far too many results previously.