### PR TITLE
tackle #107, add (and fix) tests, check for valid request packet

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,9 @@ rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 cd tests/OmniSharp.Tests
 k test
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+cd ../OmniSharp.Stdio.Tests
+k test
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 cd ../../
 kvm use 1.0.0-beta3
 kpm bundle src/OmniSharp --no-source --out artifacts/build/omnisharp --runtime kre-mono.1.0.0-beta3 2>&1 | tee buildlog

--- a/src/OmniSharp.Stdio/Protocol/RequestPacket.cs
+++ b/src/OmniSharp.Stdio/Protocol/RequestPacket.cs
@@ -11,6 +11,16 @@ namespace OmniSharp.Stdio.Protocol
         {
             var obj = JObject.Parse(json);
             var result = obj.ToObject<RequestPacket>();
+
+            if (result.Seq <= 0)
+            {
+                throw new ArgumentException("invalid seq-value");
+            }
+            
+            if (string.IsNullOrWhiteSpace(result.Command))
+            {
+                throw new ArgumentException("missing command");
+            }
             
             JToken arguments;
             if (obj.TryGetValue("arguments", StringComparison.OrdinalIgnoreCase, out arguments))

--- a/src/OmniSharp.Stdio/StdioServer.cs
+++ b/src/OmniSharp.Stdio/StdioServer.cs
@@ -94,7 +94,10 @@ namespace OmniSharp.Stdio
 
                     // HttpResponse stream becomes body as is
                     var buffer = outputStream.ToArray();
-                    response.Body = new JRaw(new String(Encoding.UTF8.GetChars(buffer, 0, buffer.Length)));
+                    if (buffer.Length > 0)
+                    {
+                        response.Body = new JRaw(new String(Encoding.UTF8.GetChars(buffer, 0, buffer.Length)));
+                    }
                 }
                 catch (Exception e)
                 {

--- a/tests/OmniSharp.Stdio.Tests/TestTextWriter.cs
+++ b/tests/OmniSharp.Stdio.Tests/TestTextWriter.cs
@@ -24,10 +24,18 @@ namespace OmniSharp.Stdio.Tests
 
         public void WriteLine(object value)
         {
-            _callbacks.Current(value.ToString());
-            if (!_callbacks.MoveNext())
+            try
             {
-                _completion.SetResult(null);
+                _callbacks.Current(value.ToString());
+                
+                if (!_callbacks.MoveNext())
+                {
+                    _completion.SetResult(null);
+                }
+            }
+            catch (Exception e)
+            {
+                _completion.SetException(e);
             }
         }
 


### PR DESCRIPTION
learnt that ```JsonConvert.DeserializeObject``` does not complain about something like this: ```{"KeyWithOutValue":,"KeyWithValue":true}```