### PR TITLE
fix for #113

### DIFF
--- a/src/OmniSharp/Api/Refactoring/OmnisharpController.Rename.cs
+++ b/src/OmniSharp/Api/Refactoring/OmnisharpController.Rename.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
 using Microsoft.CodeAnalysis;
@@ -27,7 +28,14 @@ namespace OmniSharp
 
                 if (symbol != null)
                 {
-                    solution = await Renamer.RenameSymbolAsync(solution, symbol, request.RenameTo, _workspace.Options);
+                    try
+                    {
+                        solution = await Renamer.RenameSymbolAsync(solution, symbol, request.RenameTo, _workspace.Options);
+                    }
+                    catch (ArgumentException e)
+                    {
+                        response.ErrorMessage = e.Message;
+                    }
                 }
 
                 var changes = new List<ModifiedFileResponse>();

--- a/src/OmniSharp/Models/RenameResponse.cs
+++ b/src/OmniSharp/Models/RenameResponse.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace OmniSharp.Models
 {
@@ -11,5 +10,7 @@ namespace OmniSharp.Models
         }
 
         public IEnumerable<ModifiedFileResponse> Changes { get; set; }
+
+        public string ErrorMessage { get; set; }
     }
 }

--- a/tests/OmniSharp.Tests/RenameFacts.cs
+++ b/tests/OmniSharp.Tests/RenameFacts.cs
@@ -142,5 +142,25 @@ namespace OmniSharp.Tests
 
             Assert.Equal(0, result.Changes.Count());
         }
+
+        [Fact]
+        public async Task Rename_DoesNotExplodeWhenAttemptingToRenameALibrarySymbol()
+        {
+            const string fileContent = @"
+                using System;
+                public class Program
+                {
+                    public static void Main()
+                    {
+                        Console.Wri$te(1);
+                    }
+                }";
+
+            var workspace = TestHelpers.CreateSimpleWorkspace(fileContent, "test.cs");
+            var result = await SendRequest(workspace, "foo", "test.cs", fileContent);
+
+            Assert.Equal(0, result.Changes.Count());
+            Assert.NotNull(result.ErrorMessage);
+        }
     }
 }


### PR DESCRIPTION
Catches ```ArgumentException``` from the renamer and fills a error message. Added a test which tries to rename ```Console.Write```