### PR TITLE
Files changed

### DIFF
--- a/src/OmniSharp/Api/Files/OmnisharpController.Files.cs
+++ b/src/OmniSharp/Api/Files/OmnisharpController.Files.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using Microsoft.AspNet.Mvc;
+using OmniSharp.Models;
+using OmniSharp.Services;
+
+namespace OmniSharp
+{
+    public class FilesController
+    {
+        private readonly IFileSystemWatcher _watcher;
+
+        public FilesController(IFileSystemWatcher watcher)
+        {
+            _watcher = watcher;
+        }
+
+        [HttpPost("/filesChanged")]
+        public bool OnFilesChanged(IEnumerable<Request> requests)
+        {
+            foreach (var request in requests)
+            {
+                _watcher.TriggerChange(request.FileName);
+            }
+            return true;
+        }
+    }
+}

--- a/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
+++ b/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
@@ -300,6 +300,8 @@ namespace OmniSharp.AspNet5
                         // The sources to feed to the language service
                         var val = m.Payload.ToObject<SourcesMessage>();
 
+                        project.SourceFiles = val.Files;
+
                         var frameworkProject = project.ProjectsByFramework[val.Framework.FrameworkName];
                         var projectId = frameworkProject.ProjectId;
 
@@ -453,8 +455,6 @@ namespace OmniSharp.AspNet5
             {
                 return project.ContextId;
             }
-
-            _watcher.Watch(projectFile, TriggerDependeees);
 
             // Send an InitializeMessage for each project
             var initializeMessage = new InitializeMessage

--- a/src/OmniSharp/AspNet5/Project.cs
+++ b/src/OmniSharp/AspNet5/Project.cs
@@ -24,6 +24,8 @@ namespace OmniSharp.AspNet5
 
         public bool InitializeSent { get; set; }
 
+        public IList<string> SourceFiles { get; set; }
+
         public Project()
         {
             ProjectsByFramework = new ConcurrentDictionary<string, FrameworkProject>();

--- a/src/OmniSharp/Models/AspNet5Project.cs
+++ b/src/OmniSharp/Models/AspNet5Project.cs
@@ -13,6 +13,7 @@ namespace OmniSharp.Models
         public IList<string> ProjectSearchPaths { get; set; }
         public IList<string> Frameworks { get; set; }
         public string GlobalJsonPath { get; set; }
+        public IList<string> SourceFiles { get; set; }
 
         public AspNet5Project(Project project)
         {
@@ -23,6 +24,7 @@ namespace OmniSharp.Models
             GlobalJsonPath = project.GlobalJsonPath;
             ProjectSearchPaths = project.ProjectSearchPaths;
             Frameworks = project.ProjectsByFramework.Keys.ToList();
+            SourceFiles = project.SourceFiles;
         }
     }
 }

--- a/src/OmniSharp/Models/MSBuildProject.cs
+++ b/src/OmniSharp/Models/MSBuildProject.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using OmniSharp.MSBuild.ProjectFile;
 
 namespace OmniSharp.Models
@@ -10,6 +11,7 @@ namespace OmniSharp.Models
         public string AssemblyName { get; set; }
         public string TargetPath { get; set; }
         public string TargetFramework { get; set; }
+        public IList<string> SourceFiles { get; set; }
 
         public MSBuildProject(ProjectFileInfo p)
         {
@@ -18,6 +20,7 @@ namespace OmniSharp.Models
             TargetPath = p.TargetPath;
             ProjectGuid = p.ProjectId;
             TargetFramework = p.TargetFramework.ToString();
+            SourceFiles = p.SourceFiles;
         }
     }
 }

--- a/src/OmniSharp/Roslyn/ProjectEventForwarder.cs
+++ b/src/OmniSharp/Roslyn/ProjectEventForwarder.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using OmniSharp.AspNet5;
+using OmniSharp.Models;
+using OmniSharp.MSBuild;
+using OmniSharp.Services;
+
+namespace OmniSharp.Roslyn
+{
+    public class ProjectEventForwarder
+    {
+        private readonly AspNet5Context _aspnet5Context;
+        private readonly MSBuildContext _msbuildContext;
+        private readonly OmnisharpWorkspace _workspace;
+        private readonly IEventEmitter _emitter;
+        private readonly ISet<SimpleWorkspaceEvent> _queue = new HashSet<SimpleWorkspaceEvent>();
+        private readonly object _lock = new object();
+
+        public ProjectEventForwarder(AspNet5Context aspnet5Context, MSBuildContext msbuildContext, OmnisharpWorkspace workspace, IEventEmitter emitter)
+        {
+            _aspnet5Context = aspnet5Context;
+            _msbuildContext = msbuildContext;
+            _workspace = workspace;
+            _emitter = emitter;
+            _workspace.WorkspaceChanged += OnWorkspaceChanged;
+        }
+
+        private void OnWorkspaceChanged(object source, WorkspaceChangeEventArgs args)
+        {
+
+            SimpleWorkspaceEvent e = null;
+
+            switch (args.Kind)
+            {
+                case WorkspaceChangeKind.ProjectAdded:
+                case WorkspaceChangeKind.ProjectChanged:
+                case WorkspaceChangeKind.ProjectReloaded:
+                    e = new SimpleWorkspaceEvent(args.NewSolution.GetProject(args.ProjectId).FilePath, args.Kind);
+                    break;
+                case WorkspaceChangeKind.ProjectRemoved:
+                    e = new SimpleWorkspaceEvent(args.OldSolution.GetProject(args.ProjectId).FilePath, args.Kind);
+                    break;
+            }
+
+            if (e != null)
+            {
+                lock (_lock)
+                {
+                    var removed = _queue.Remove(e);
+                    _queue.Add(e);
+                    if (!removed)
+                    {
+                        Task.Factory.StartNew(async () =>
+                        {
+                            await Task.Delay(500);
+
+                            lock (_lock)
+                            {
+                                _queue.Remove(e);
+
+                                object payload = null;
+                                if (e.Kind != WorkspaceChangeKind.ProjectRemoved)
+                                {
+                                    payload = GetProjectInformation(e.FileName);
+                                }
+                                _emitter.Emit(e.Kind.ToString(), payload);
+                            }
+                        });
+                    }
+                }
+            }
+        }
+
+        private ProjectInformationResponse GetProjectInformation(string fileName)
+        {
+            var msBuildContextProject = _msbuildContext.GetProject(fileName);
+            var aspNet5ContextProject = _aspnet5Context.GetProject(fileName);
+
+            return new ProjectInformationResponse
+            {
+                MsBuildProject = msBuildContextProject != null ? new MSBuildProject(msBuildContextProject) : null,
+                AspNet5Project = aspNet5ContextProject != null ? new AspNet5Project(aspNet5ContextProject) : null
+            };
+        }
+
+
+        private class SimpleWorkspaceEvent
+        {
+            public string FileName { get; private set; }
+            public WorkspaceChangeKind Kind { get; private set; }
+
+            public SimpleWorkspaceEvent(string fileName, WorkspaceChangeKind kind)
+            {
+                FileName = fileName;
+                Kind = kind;
+            }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as SimpleWorkspaceEvent;
+                return other != null && Kind == other.Kind && FileName == other.FileName;
+            }
+
+            public override int GetHashCode()
+            {
+                return Kind.GetHashCode() * 23 + FileName.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/OmniSharp/Roslyn/ProjectEventForwarder.cs
+++ b/src/OmniSharp/Roslyn/ProjectEventForwarder.cs
@@ -28,7 +28,6 @@ namespace OmniSharp.Roslyn
 
         private void OnWorkspaceChanged(object source, WorkspaceChangeEventArgs args)
         {
-
             SimpleWorkspaceEvent e = null;
 
             switch (args.Kind)

--- a/src/OmniSharp/Services/IEventEmitter.cs
+++ b/src/OmniSharp/Services/IEventEmitter.cs
@@ -1,0 +1,7 @@
+namespace OmniSharp.Services
+{
+    public interface IEventEmitter
+    {
+        void Emit(string kind, object args);
+    }
+}

--- a/src/OmniSharp/Services/ManualFileSystemWatcher.cs
+++ b/src/OmniSharp/Services/ManualFileSystemWatcher.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace OmniSharp.Services
+{
+    public class ManualFileSystemWatcher : IFileSystemWatcher
+    {
+        private readonly Dictionary<string, Action<string>> _callbacks = new Dictionary<string, Action<string>>();
+
+        public void TriggerChange(string path)
+        {
+            Action<string> callback;
+            if (_callbacks.TryGetValue(path, out callback))
+            {
+                callback(path);
+            }
+        }
+
+        public void Watch(string path, Action<string> callback)
+        {
+            _callbacks[path] = callback;
+        }
+    }
+}

--- a/src/OmniSharp/Services/NullEventEmitter.cs
+++ b/src/OmniSharp/Services/NullEventEmitter.cs
@@ -1,0 +1,10 @@
+namespace OmniSharp.Services
+{
+    public class NullEventEmitter : IEventEmitter
+    {
+        public void Emit(string kind, object args)
+        {
+            // nothing
+        }
+    }
+}

--- a/src/OmniSharp/Services/StdioEventEmitter.cs
+++ b/src/OmniSharp/Services/StdioEventEmitter.cs
@@ -1,0 +1,24 @@
+using OmniSharp.Stdio.Protocol;
+using OmniSharp.Stdio.Services;
+
+namespace OmniSharp.Services
+{
+    public class StdioEventEmitter : IEventEmitter
+    {
+        private readonly ISharedTextWriter _writer;
+
+        public StdioEventEmitter(ISharedTextWriter writer)
+        {
+            _writer = writer;
+        }
+
+        public void Emit(string kind, object args)
+        {
+            _writer.WriteLineAsync(new EventPacket()
+            {
+                Event = kind,
+                Body = args
+            });
+        }
+    }
+}

--- a/src/OmniSharp/Startup.cs
+++ b/src/OmniSharp/Startup.cs
@@ -14,6 +14,7 @@ using OmniSharp.Filters;
 using OmniSharp.Middleware;
 using OmniSharp.MSBuild;
 using OmniSharp.Options;
+using OmniSharp.Roslyn;
 using OmniSharp.Services;
 using OmniSharp.Settings;
 using OmniSharp.Stdio.Logging;
@@ -71,7 +72,7 @@ namespace OmniSharp
             services.AddSingleton<IProjectSystem, MSBuildProjectSystem>();
 
             // Add the file watcher
-            services.AddSingleton<IFileSystemWatcher, FileSystemWatcherWrapper>();
+            services.AddSingleton<IFileSystemWatcher, ManualFileSystemWatcher>();
 
             // Add test command providers
             services.AddSingleton<ITestCommandProvider, AspNet5TestCommandProvider>();
@@ -82,6 +83,17 @@ namespace OmniSharp
 #if ASPNET50
             services.AddSingleton<ICodeActionProvider, NRefactoryCodeActionProvider>();
 #endif
+
+            if (Program.Environment.TransportType == TransportType.Stdio)
+            {
+                services.AddSingleton<IEventEmitter, StdioEventEmitter>();
+            }
+            else
+            {
+                services.AddSingleton<IEventEmitter, NullEventEmitter>();
+            }
+
+            services.AddSingleton<ProjectEventForwarder, ProjectEventForwarder>();
 
             // Setup the options from configuration
             services.Configure<OmniSharpOptions>(Configuration);
@@ -114,10 +126,13 @@ namespace OmniSharp
             app.UseMvc();
 
             logger.WriteInformation($"Omnisharp server running on port '{env.Port}' at location '{env.Path}' on host {env.HostPID}.");
+            
+            // Forward workspace events
+            app.ApplicationServices.GetRequiredService<ProjectEventForwarder>();
 
             // Initialize everything!
             var projectSystems = app.ApplicationServices.GetRequiredService<IEnumerable<IProjectSystem>>();
-
+            
             foreach (var projectSystem in projectSystems)
             {
                 projectSystem.Initalize();


### PR DESCRIPTION
This PR covers the ground work for #106 and I would like get it out before it gets too big. Until now, it contains these changes

* replace the (flaky) file event watcher with a ```filesChanged``` route which drives the ```IFileWatcher```
* Add an IEventEmitter interface which allows OmniSharp to talk back to an editor (such that it can communicate the effects of changed files)
* Listen for some workspace events (project modifications) and send those events (in the shape of ```ProjectInformationResponse```-objects) to the connected editor
* Make ```ProjectInformationResponse``` also include the source files of a project such that an editor can use this information, for instance requesting diagnostics for more than the open files.

What still needs to be done is refining the file events (adding types ```added```, ```changed```, and ```deleted```) and make the ASP project system smarter such that it picks up new files. 