### PR TITLE
Transient buffers

### DIFF
--- a/src/OmniSharp/Api/Buffer/OmnisharpController.Buffer.cs
+++ b/src/OmniSharp/Api/Buffer/OmnisharpController.Buffer.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
-using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Models;
 
 namespace OmniSharp
@@ -16,19 +15,7 @@ namespace OmniSharp
         [HttpPost("changebuffer")]
         public async Task<ObjectResult> ChangeBuffer(ChangeBufferRequest request)
         {
-            foreach (var documentId in _workspace.CurrentSolution.GetDocumentIdsWithFilePath(request.FileName))
-            {
-                var document = _workspace.CurrentSolution.GetDocument(documentId);
-                var sourceText = await document.GetTextAsync();
-                var startOffset = sourceText.Lines.GetPosition(new LinePosition(request.StartLine - 1, request.StartColumn - 1));
-                var endOffset = sourceText.Lines.GetPosition(new LinePosition(request.EndLine - 1, request.EndColumn - 1));
-
-                sourceText = sourceText.WithChanges(new[] {
-                    new Microsoft.CodeAnalysis.Text.TextChange(new TextSpan(startOffset, endOffset - startOffset), request.NewText)
-                });
-
-                _workspace.OnDocumentChanged(documentId, sourceText);
-            }
+            await _workspace.BufferManager.UpdateBuffer(request);
             return new ObjectResult(true);
         }
     }

--- a/src/OmniSharp/Filters/UpdateBufferFilter.cs
+++ b/src/OmniSharp/Filters/UpdateBufferFilter.cs
@@ -24,11 +24,7 @@ namespace OmniSharp.Filters
                 var request = context.ActionArguments.FirstOrDefault(arg => arg.Value is Request);
                 if (request.Value != null)
                 {
-                    var typedRequest = (Request)request.Value;
-                    if (typedRequest.Buffer != null && typedRequest.FileName != null)
-                    {
-                        _workspace.EnsureBufferUpdated(typedRequest);
-                    }
+                    _workspace.BufferManager.UpdateBuffer((Request)request.Value);
                 }
             }
         }

--- a/src/OmniSharp/Roslyn/BufferManager.cs
+++ b/src/OmniSharp/Roslyn/BufferManager.cs
@@ -10,7 +10,6 @@ namespace OmniSharp.Roslyn
 {
     public class BufferManager
     {
-
         private readonly OmnisharpWorkspace _workspace;
         private readonly IDictionary<string, IEnumerable<DocumentId>> _transientDocuments = new Dictionary<string, IEnumerable<DocumentId>>(StringComparer.OrdinalIgnoreCase);
         private readonly ISet<DocumentId> _transientDocumentIds = new HashSet<DocumentId>();

--- a/src/OmniSharp/Roslyn/BufferManager.cs
+++ b/src/OmniSharp/Roslyn/BufferManager.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Models;
+
+namespace OmniSharp.Roslyn
+{
+    public class BufferManager
+    {
+
+        private readonly OmnisharpWorkspace _workspace;
+
+        public BufferManager(OmnisharpWorkspace workspace)
+        {
+            _workspace = workspace;
+        }
+
+        public void UpdateBuffer(Request request)
+        {
+            if (request.Buffer == null || request.FileName == null)
+            {
+                return;
+            }
+
+            var sourceText = SourceText.From(request.Buffer);
+            var documentIds = _workspace.CurrentSolution.GetDocumentIdsWithFilePath(request.FileName);
+            foreach (var documentId in documentIds)
+            {
+                _workspace.OnDocumentChanged(documentId, sourceText);
+            }
+        }
+
+        public async Task UpdateBuffer(ChangeBufferRequest request)
+        {
+            if (request.FileName == null)
+            {
+                return;
+            }
+
+            var documentIds = _workspace.CurrentSolution.GetDocumentIdsWithFilePath(request.FileName);
+            foreach (var documentId in documentIds)
+            {
+                var document = _workspace.CurrentSolution.GetDocument(documentId);
+                var sourceText = await document.GetTextAsync();
+                var startOffset = sourceText.Lines.GetPosition(new LinePosition(request.StartLine - 1, request.StartColumn - 1));
+                var endOffset = sourceText.Lines.GetPosition(new LinePosition(request.EndLine - 1, request.EndColumn - 1));
+
+                sourceText = sourceText.WithChanges(new[] {
+                    new TextChange(new TextSpan(startOffset, endOffset - startOffset), request.NewText)
+                });
+
+                _workspace.OnDocumentChanged(documentId, sourceText);
+            }
+        }
+    }
+}

--- a/src/OmniSharp/Roslyn/BufferManager.cs
+++ b/src/OmniSharp/Roslyn/BufferManager.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Models;
 
@@ -8,10 +12,14 @@ namespace OmniSharp.Roslyn
     {
 
         private readonly OmnisharpWorkspace _workspace;
+        private readonly IDictionary<string, IEnumerable<DocumentId>> _transientDocuments = new Dictionary<string, IEnumerable<DocumentId>>(StringComparer.OrdinalIgnoreCase);
+        private readonly ISet<DocumentId> _transientDocumentIds = new HashSet<DocumentId>();
+        private readonly object _lock = new object();
 
         public BufferManager(OmnisharpWorkspace workspace)
         {
             _workspace = workspace;
+            _workspace.WorkspaceChanged += OnWorkspaceChanged;
         }
 
         public void UpdateBuffer(Request request)
@@ -21,11 +29,18 @@ namespace OmniSharp.Roslyn
                 return;
             }
 
-            var sourceText = SourceText.From(request.Buffer);
             var documentIds = _workspace.CurrentSolution.GetDocumentIdsWithFilePath(request.FileName);
-            foreach (var documentId in documentIds)
+            if (!documentIds.IsEmpty)
             {
-                _workspace.OnDocumentChanged(documentId, sourceText);
+                var sourceText = SourceText.From(request.Buffer);
+                foreach (var documentId in documentIds)
+                {
+                    _workspace.OnDocumentChanged(documentId, sourceText);
+                }
+            }
+            else
+            {
+                TryAddTransientDocument(request.FileName, request.Buffer);
             }
         }
 
@@ -37,18 +52,97 @@ namespace OmniSharp.Roslyn
             }
 
             var documentIds = _workspace.CurrentSolution.GetDocumentIdsWithFilePath(request.FileName);
-            foreach (var documentId in documentIds)
+            if (!documentIds.IsEmpty)
             {
-                var document = _workspace.CurrentSolution.GetDocument(documentId);
-                var sourceText = await document.GetTextAsync();
-                var startOffset = sourceText.Lines.GetPosition(new LinePosition(request.StartLine - 1, request.StartColumn - 1));
-                var endOffset = sourceText.Lines.GetPosition(new LinePosition(request.EndLine - 1, request.EndColumn - 1));
+                foreach (var documentId in documentIds)
+                {
+                    var document = _workspace.CurrentSolution.GetDocument(documentId);
+                    var sourceText = await document.GetTextAsync();
+                    var startOffset = sourceText.Lines.GetPosition(new LinePosition(request.StartLine - 1, request.StartColumn - 1));
+                    var endOffset = sourceText.Lines.GetPosition(new LinePosition(request.EndLine - 1, request.EndColumn - 1));
 
-                sourceText = sourceText.WithChanges(new[] {
-                    new TextChange(new TextSpan(startOffset, endOffset - startOffset), request.NewText)
-                });
+                    sourceText = sourceText.WithChanges(new[] {
+                        new TextChange(new TextSpan(startOffset, endOffset - startOffset), request.NewText)
+                    });
 
-                _workspace.OnDocumentChanged(documentId, sourceText);
+                    _workspace.OnDocumentChanged(documentId, sourceText);
+                }
+            }
+            else
+            {
+                // TODO@joh ensure the edit is an insert at offset zero
+                TryAddTransientDocument(request.FileName, request.NewText);
+            }
+        }
+
+        private bool TryAddTransientDocument(string fileName, string fileContent)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return false;
+            }
+
+            var sourceText = SourceText.From(fileContent);
+            var documents = new List<DocumentInfo>();
+            foreach (var projectId in _workspace.CurrentSolution.ProjectIds)
+            {
+                var id = DocumentId.CreateNewId(projectId);
+                var version = VersionStamp.Create();
+                var document = DocumentInfo.Create(id, fileName, filePath: fileName, loader: TextLoader.From(TextAndVersion.Create(sourceText, version)));
+
+                documents.Add(document);
+            }
+
+            lock (_lock)
+            {
+                var documentIds = documents.Select(document => document.Id);
+                _transientDocuments.Add(fileName, documentIds);
+                _transientDocumentIds.UnionWith(documentIds);
+            }
+
+            foreach (var document in documents)
+            {
+                _workspace.AddDocument(document);
+            }
+            return true;
+        }
+
+        private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs args)
+        {
+            string fileName = null;
+            if (args.Kind == WorkspaceChangeKind.DocumentAdded)
+            {
+                fileName = args.NewSolution.GetDocument(args.DocumentId).FilePath;
+            }
+            else if (args.Kind == WorkspaceChangeKind.DocumentRemoved)
+            {
+                fileName = args.OldSolution.GetDocument(args.DocumentId).FilePath;
+            }
+
+            if (fileName == null)
+            {
+                return;
+            }
+
+            lock (_lock)
+            {
+                if (_transientDocumentIds.Contains(args.DocumentId))
+                {
+                    return;
+                }
+
+                IEnumerable<DocumentId> documentIds;
+                if (!_transientDocuments.TryGetValue(fileName, out documentIds))
+                {
+                    return;
+                }
+
+                _transientDocuments.Remove(fileName);
+                foreach (var documentId in documentIds)
+                {
+                    _workspace.RemoveDocument(documentId);
+                    _transientDocumentIds.Remove(documentId);
+                }
             }
         }
     }

--- a/src/OmniSharp/Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp/Roslyn/OmniSharpWorkspace.cs
@@ -1,11 +1,10 @@
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Models;
+using OmniSharp.Roslyn;
 
 namespace OmniSharp
 {
@@ -13,8 +12,11 @@ namespace OmniSharp
     {
         public bool Initialized { get; set; }
 
+        public BufferManager BufferManager { get; private set; }
+
         public OmnisharpWorkspace() : base(MefHostServices.DefaultHost, "Custom")
         {
+            BufferManager = new BufferManager(this);
         }
 
         public void AddProject(ProjectInfo projectInfo)
@@ -70,20 +72,6 @@ namespace OmniSharp
         public void OnDocumentChanged(DocumentId documentId, SourceText text)
         {
             OnDocumentTextChanged(documentId, text, PreservationMode.PreserveIdentity);
-        }
-
-        public void EnsureBufferUpdated(Request request)
-        {
-            if(request.Buffer == null || request.FileName == null)
-            {
-                return;
-            }
-
-            var sourceText = SourceText.From(request.Buffer);
-            foreach (var documentId in CurrentSolution.GetDocumentIdsWithFilePath(request.FileName))
-            {
-                OnDocumentChanged(documentId, sourceText);
-            }
         }
 
         public DocumentId GetDocumentId(string filePath)

--- a/tests/OmniSharp.Tests/BufferManagerFacts.cs
+++ b/tests/OmniSharp.Tests/BufferManagerFacts.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using OmniSharp.Models;
 using Xunit;
 
@@ -9,7 +10,7 @@ namespace OmniSharp.Tests
     public class BufferManagerFacts
     {
         [Fact]
-        public void UpdateBufferIgnoresVoidRequests()
+        public async Task UpdateBufferIgnoresVoidRequests()
         {
             var workspace = TestHelpers.CreateSimpleWorkspace("class C {}", "test.cs");
             Assert.Equal(2, workspace.CurrentSolution.Projects.Count());
@@ -28,7 +29,7 @@ namespace OmniSharp.Tests
         }
 
         [Fact]
-        public void UpdateBufferIgnoresFilePathsThatDontMatchAProjectPath()
+        public async Task UpdateBufferIgnoresFilePathsThatDontMatchAProjectPath()
         {
             var workspace = GetWorkspaceWithProjects();
 
@@ -38,7 +39,7 @@ namespace OmniSharp.Tests
         }
 
         [Fact]
-        public void UpdateBufferFindsProjectBasedOnPath()
+        public async Task UpdateBufferFindsProjectBasedOnPath()
         {
             var workspace = GetWorkspaceWithProjects();
 
@@ -53,7 +54,7 @@ namespace OmniSharp.Tests
         }
 
         [Fact]
-        public void UpdateBufferFindsProjectBasedOnNearestPath()
+        public async Task UpdateBufferFindsProjectBasedOnNearestPath()
         {
             var workspace = new OmnisharpWorkspace();
 

--- a/tests/OmniSharp.Tests/BufferManagerFacts.cs
+++ b/tests/OmniSharp.Tests/BufferManagerFacts.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using OmniSharp.Models;
 using Xunit;
@@ -31,8 +32,8 @@ namespace OmniSharp.Tests
         {
             var workspace = GetWorkspaceWithProjects();
 
-            workspace.BufferManager.UpdateBuffer(new Request() { FileName = @"c:\some\path.cs", Buffer = "enum E {}" });
-            var documents = workspace.GetDocuments(@"c:\some\path.cs");
+            workspace.BufferManager.UpdateBuffer(new Request() { FileName = Path.Combine("some", " path.cs"), Buffer = "enum E {}" });
+            var documents = workspace.GetDocuments(Path.Combine("some", "path.cs"));
             Assert.Equal(0, documents.Count());
         }
 
@@ -41,13 +42,13 @@ namespace OmniSharp.Tests
         {
             var workspace = GetWorkspaceWithProjects();
 
-            workspace.BufferManager.UpdateBuffer(new Request() { FileName = @"c:\src\newFile.cs", Buffer = "enum E {}" });
-            var documents = workspace.GetDocuments(@"c:\src\newFile.cs");
+            workspace.BufferManager.UpdateBuffer(new Request() { FileName = Path.Combine("src", "newFile.cs"), Buffer = "enum E {}" });
+            var documents = workspace.GetDocuments(Path.Combine("src", "newFile.cs"));
             Assert.Equal(2, documents.Count());
 
             foreach (var document in documents)
             {
-                Assert.Equal(@"c:\src\project.json", document.Project.FilePath);
+                Assert.Equal(Path.Combine("src", "project.json"), document.Project.FilePath);
             }
         }
 
@@ -56,24 +57,24 @@ namespace OmniSharp.Tests
         {
             var workspace = new OmnisharpWorkspace();
 
-            TestHelpers.AddProjectToWorkspace(workspace, @"c:\src\root\foo.csproj",
+            TestHelpers.AddProjectToWorkspace(workspace, Path.Combine("src", "root", "foo.csproj"),
                 new[] { "" },
-                new Dictionary<string, string>() { { @"c:\src\root\foo.cs", "class C1 {}" } });
+                new Dictionary<string, string>() { { Path.Combine("src", "root", "foo.cs"), "class C1 {}" } });
 
-            TestHelpers.AddProjectToWorkspace(workspace, @"c:\src\root\foo\bar\insane.csproj",
+            TestHelpers.AddProjectToWorkspace(workspace, Path.Combine("src", "root", "foo", "bar", "insane.csproj"),
                 new[] { "" },
-                new Dictionary<string, string>() { { @"c:\src\root\foo\bar\nested\code.cs", "class C2 {}" } });
+                new Dictionary<string, string>() { { Path.Combine("src", "root", "foo", "bar", "nested", "code.cs"), "class C2 {}" } });
 
-            workspace.BufferManager.UpdateBuffer(new Request() { FileName = @"c:\src\root\bar.cs", Buffer = "enum E {}" });
-            var documents = workspace.GetDocuments(@"c:\src\root\bar.cs");
+            workspace.BufferManager.UpdateBuffer(new Request() { FileName = Path.Combine("src", "root", "bar.cs"), Buffer = "enum E {}" });
+            var documents = workspace.GetDocuments(Path.Combine("src", "root", "bar.cs"));
             Assert.Equal(1, documents.Count());
-            Assert.Equal(@"c:\src\root\foo.csproj", documents.ElementAt(0).Project.FilePath);
+            Assert.Equal(Path.Combine("src", "root", "foo.csproj"), documents.ElementAt(0).Project.FilePath);
             Assert.Equal(2, documents.ElementAt(0).Project.Documents.Count());
 
-            workspace.BufferManager.UpdateBuffer(new Request() { FileName = @"c:\src\root\foo\bar\nested\paths\dance.cs", Buffer = "enum E {}" });
-            documents = workspace.GetDocuments(@"c:\src\root\foo\bar\nested\paths\dance.cs");
+            workspace.BufferManager.UpdateBuffer(new Request() { FileName = Path.Combine("src", "root", "foo", "bar", "nested", "paths", "dance.cs"), Buffer = "enum E {}" });
+            documents = workspace.GetDocuments(Path.Combine("src", "root", "foo", "bar", "nested", "paths", "dance.cs"));
             Assert.Equal(1, documents.Count());
-            Assert.Equal(@"c:\src\root\foo\bar\insane.csproj", documents.ElementAt(0).Project.FilePath);
+            Assert.Equal(Path.Combine("src", "root", "foo", "bar", "insane.csproj"), documents.ElementAt(0).Project.FilePath);
             Assert.Equal(2, documents.ElementAt(0).Project.Documents.Count());
         }
 
@@ -81,13 +82,13 @@ namespace OmniSharp.Tests
         {
             var workspace = new OmnisharpWorkspace();
 
-            TestHelpers.AddProjectToWorkspace(workspace, @"c:\src\project.json",
+            TestHelpers.AddProjectToWorkspace(workspace, Path.Combine("src", "project.json"),
                 new[] { "aspnet50", "aspnet50core" },
-                new Dictionary<string, string>() { { @"c:\src\a.cs", "class C {}" } });
+                new Dictionary<string, string>() { { Path.Combine("src", "a.cs"), "class C {}" } });
 
-            TestHelpers.AddProjectToWorkspace(workspace, @"c:\test\project.json",
+            TestHelpers.AddProjectToWorkspace(workspace, Path.Combine("test", "project.json"),
                 new[] { "aspnet50", "aspnet50core" },
-                new Dictionary<string, string>() { { @"c:\test\b.cs", "class C {}" } });
+                new Dictionary<string, string>() { { Path.Combine("test", "b.cs"), "class C {}" } });
 
             Assert.Equal(4, workspace.CurrentSolution.Projects.Count());
             foreach (var project in workspace.CurrentSolution.Projects)

--- a/tests/OmniSharp.Tests/BufferManagerFacts.cs
+++ b/tests/OmniSharp.Tests/BufferManagerFacts.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Linq;
+using OmniSharp.Models;
+using Xunit;
+
+namespace OmniSharp.Tests
+{
+    public class BufferManagerFacts
+    {
+        [Fact]
+        public void UpdateBufferIgnoresVoidRequests()
+        {
+            var workspace = TestHelpers.CreateSimpleWorkspace("class C {}", "test.cs");
+            Assert.Equal(2, workspace.CurrentSolution.Projects.Count());
+            Assert.Equal(1, workspace.CurrentSolution.Projects.ElementAt(0).Documents.Count());
+            Assert.Equal(1, workspace.CurrentSolution.Projects.ElementAt(1).Documents.Count());
+
+            workspace.BufferManager.UpdateBuffer(new Request() { });
+            Assert.Equal(2, workspace.CurrentSolution.Projects.Count());
+            Assert.Equal(1, workspace.CurrentSolution.Projects.ElementAt(0).Documents.Count());
+            Assert.Equal(1, workspace.CurrentSolution.Projects.ElementAt(1).Documents.Count());
+
+            workspace.BufferManager.UpdateBuffer(new Request() { FileName = "", Buffer = "enum E {}" });
+            Assert.Equal(2, workspace.CurrentSolution.Projects.Count());
+            Assert.Equal(1, workspace.CurrentSolution.Projects.ElementAt(0).Documents.Count());
+            Assert.Equal(1, workspace.CurrentSolution.Projects.ElementAt(1).Documents.Count());
+        }
+
+        [Fact]
+        public void UpdateBufferIgnoresFilePathsThatDontMatchAProjectPath()
+        {
+            var workspace = GetWorkspaceWithProjects();
+
+            workspace.BufferManager.UpdateBuffer(new Request() { FileName = @"c:\some\path.cs", Buffer = "enum E {}" });
+            var documents = workspace.GetDocuments(@"c:\some\path.cs");
+            Assert.Equal(0, documents.Count());
+        }
+
+        [Fact]
+        public void UpdateBufferFindsProjectBasedOnPath()
+        {
+            var workspace = GetWorkspaceWithProjects();
+
+            workspace.BufferManager.UpdateBuffer(new Request() { FileName = @"c:\src\newFile.cs", Buffer = "enum E {}" });
+            var documents = workspace.GetDocuments(@"c:\src\newFile.cs");
+            Assert.Equal(2, documents.Count());
+
+            foreach (var document in documents)
+            {
+                Assert.Equal(@"c:\src\project.json", document.Project.FilePath);
+            }
+        }
+
+        [Fact]
+        public void UpdateBufferFindsProjectBasedOnNearestPath()
+        {
+            var workspace = new OmnisharpWorkspace();
+
+            TestHelpers.AddProjectToWorkspace(workspace, @"c:\src\root\foo.csproj",
+                new[] { "" },
+                new Dictionary<string, string>() { { @"c:\src\root\foo.cs", "class C1 {}" } });
+
+            TestHelpers.AddProjectToWorkspace(workspace, @"c:\src\root\foo\bar\insane.csproj",
+                new[] { "" },
+                new Dictionary<string, string>() { { @"c:\src\root\foo\bar\nested\code.cs", "class C2 {}" } });
+
+            workspace.BufferManager.UpdateBuffer(new Request() { FileName = @"c:\src\root\bar.cs", Buffer = "enum E {}" });
+            var documents = workspace.GetDocuments(@"c:\src\root\bar.cs");
+            Assert.Equal(1, documents.Count());
+            Assert.Equal(@"c:\src\root\foo.csproj", documents.ElementAt(0).Project.FilePath);
+            Assert.Equal(2, documents.ElementAt(0).Project.Documents.Count());
+
+            workspace.BufferManager.UpdateBuffer(new Request() { FileName = @"c:\src\root\foo\bar\nested\paths\dance.cs", Buffer = "enum E {}" });
+            documents = workspace.GetDocuments(@"c:\src\root\foo\bar\nested\paths\dance.cs");
+            Assert.Equal(1, documents.Count());
+            Assert.Equal(@"c:\src\root\foo\bar\insane.csproj", documents.ElementAt(0).Project.FilePath);
+            Assert.Equal(2, documents.ElementAt(0).Project.Documents.Count());
+        }
+
+        private static OmnisharpWorkspace GetWorkspaceWithProjects()
+        {
+            var workspace = new OmnisharpWorkspace();
+
+            TestHelpers.AddProjectToWorkspace(workspace, @"c:\src\project.json",
+                new[] { "aspnet50", "aspnet50core" },
+                new Dictionary<string, string>() { { @"c:\src\a.cs", "class C {}" } });
+
+            TestHelpers.AddProjectToWorkspace(workspace, @"c:\test\project.json",
+                new[] { "aspnet50", "aspnet50core" },
+                new Dictionary<string, string>() { { @"c:\test\b.cs", "class C {}" } });
+
+            Assert.Equal(4, workspace.CurrentSolution.Projects.Count());
+            foreach (var project in workspace.CurrentSolution.Projects)
+            {
+                Assert.Equal(1, project.Documents.Count());
+            }
+
+            return workspace;
+        }
+    }
+}

--- a/tests/OmniSharp.Tests/RenameFacts.cs
+++ b/tests/OmniSharp.Tests/RenameFacts.cs
@@ -133,14 +133,15 @@ namespace OmniSharp.Tests
         }
 
         [Fact]
-        public async Task Rename_DoesNotUpdateAnythingWhenDocumentIsNotFound()
+        public async Task Rename_DoesTheRightThingWhenDocumentIsNotFound()
         {
             const string fileContent = "class f$oo{}";
             var workspace = TestHelpers.CreateSimpleWorkspace(fileContent);
 
-            var result = await SendRequest(workspace, "xxx", "test.cs", fileContent); 
+            var result = await SendRequest(workspace, "xxx", "test.cs", fileContent);
 
-            Assert.Equal(0, result.Changes.Count());
+            Assert.Equal(1, result.Changes.Count());
+            Assert.Equal("test.cs", result.Changes.ElementAt(0).FileName);
         }
 
         [Fact]

--- a/tests/OmniSharp.Tests/TestHelpers.cs
+++ b/tests/OmniSharp.Tests/TestHelpers.cs
@@ -73,18 +73,22 @@ namespace OmniSharp.Tests
         public static OmnisharpWorkspace CreateSimpleWorkspace(Dictionary<string, string> sourceFiles)
         {
             var workspace = new OmnisharpWorkspace();
+            AddProjectToWorkspace(workspace, "project.json", new[] { "aspnet50", "aspnetcore50" }, sourceFiles);
+            return workspace;
+        }
+        
+        public static OmnisharpWorkspace AddProjectToWorkspace(OmnisharpWorkspace workspace, string filePath, string[] frameworks, Dictionary<string, string> sourceFiles)
+        {
             var versionStamp = VersionStamp.Create();
             var mscorlib = MetadataReference.CreateFromAssembly(AssemblyFromType(typeof(object)));
             var systemCore = MetadataReference.CreateFromAssembly(AssemblyFromType(typeof(Enumerable)));
             var references = new[] { mscorlib, systemCore };
 
-            var projects = new[] { "aspnet50", "aspnetcore50" };
-
-            foreach (var project in projects)
+            foreach (var framework in frameworks)
             {
                 var projectInfo = ProjectInfo.Create(ProjectId.CreateNewId(), versionStamp,
-                                                     "OmniSharp+" + project, "AssemblyName",
-                                                     LanguageNames.CSharp, "project.json", metadataReferences: references);
+                                                     "OmniSharp+" + framework, "AssemblyName",
+                                                     LanguageNames.CSharp, filePath, metadataReferences: references);
                 workspace.AddProject(projectInfo);
 
                 foreach (var file in sourceFiles)
@@ -99,7 +103,7 @@ namespace OmniSharp.Tests
 
             return workspace;
         }
-
+        
         private static Assembly AssemblyFromType(Type type)
         {
             return type.GetTypeInfo().Assembly;

--- a/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
+++ b/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Filters;
 using Xunit;
 
@@ -53,6 +55,7 @@ namespace OmniSharp.Tests
             var bufferFilter = new UpdateBufferFilter(workspace);
             bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(new Models.Request() { FileName = "test2.cs", Buffer = "interface I {}" }));
 
+            Assert.Equal(2, workspace.CurrentSolution.GetDocumentIdsWithFilePath("test2.cs").Length);
             var docId = workspace.CurrentSolution.GetDocumentIdsWithFilePath("test2.cs").FirstOrDefault();
             Assert.NotNull(docId);
             var sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
@@ -62,6 +65,40 @@ namespace OmniSharp.Tests
             Assert.NotNull(docId);
             sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
             Assert.Equal("class C {}", sourceText.ToString());
+
+
+            var project1 = workspace.CurrentSolution.Projects.First();
+
+        }
+
+        [Fact]
+        public async Task UpdateBuffer_TransientDocumentsDisappearWhenProjectAddsThem()
+        {
+            var workspace = TestHelpers.CreateSimpleWorkspace(new Dictionary<string, string>
+            {
+                { "test.cs", "class C {}" }
+            });
+            var bufferFilter = new UpdateBufferFilter(workspace);
+            bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(new Models.Request() { FileName = "transient.cs", Buffer = "interface I {}" }));
+
+            var docIds = workspace.CurrentSolution.GetDocumentIdsWithFilePath("transient.cs");
+            Assert.Equal(2, docIds.Length);
+
+            // simulate a project system adding the file for real
+            var project1 = workspace.CurrentSolution.Projects.First();
+            var document = DocumentInfo.Create(DocumentId.CreateNewId(project1.Id), "transient.cs",
+                loader: TextLoader.From(TextAndVersion.Create(SourceText.From("enum E{}"), VersionStamp.Create())),
+                filePath: "transient.cs");
+            workspace.CurrentSolution.AddDocument(document);
+
+            docIds = workspace.CurrentSolution.GetDocumentIdsWithFilePath("transient.cs");
+            Assert.Equal(2, docIds.Length);
+
+            bufferFilter.OnActionExecuting(TestHelpers.CreateActionExecutingContext(new Models.Request() { FileName = "transient.cs", Buffer = "enum E {}" }));
+            var sourceText = await workspace.CurrentSolution.GetDocument(docIds.First()).GetTextAsync();
+            Assert.Equal("enum E {}", sourceText.ToString());
+            sourceText = await workspace.CurrentSolution.GetDocument(docIds.Last()).GetTextAsync();
+            Assert.Equal("enum E {}", sourceText.ToString());
         }
     }
 }

--- a/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
+++ b/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
@@ -65,10 +65,6 @@ namespace OmniSharp.Tests
             Assert.NotNull(docId);
             sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
             Assert.Equal("class C {}", sourceText.ToString());
-
-
-            var project1 = workspace.CurrentSolution.Projects.First();
-
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds support for handling unknown buffers. The idea goes like this:

1. a ```Request``` for an unknown files comes in and
2. the buffer manager simply adds this file to all projects (I figured it's better then guessing, but we can discuss) and
3. the buffer manager remembers that file path so that later when
4. a project system adds the same file (because it caught up after a FS change event or ```/addToProject``` was called) the buffer manager can remove the transient file again (avoid duplication)
