### PR TITLE
Fixed issues with build

### DIFF
--- a/src/OmniSharp/Program.cs
+++ b/src/OmniSharp/Program.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNet.Hosting;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;

--- a/src/OmniSharp/project.json
+++ b/src/OmniSharp/project.json
@@ -12,7 +12,7 @@
         "Microsoft.Framework.Logging.Console": "1.0.0-beta3",
         "Microsoft.Framework.ConfigurationModel.Json": "1.0.0-beta3",
         "Microsoft.Framework.Cache.Memory": "1.0.0-beta3",
-        "Microsoft.Composition": "1.0.27"
+        "Microsoft.Composition": "1.0.30"
     },
     "commands": {
         "omnisharp": "run"


### PR DESCRIPTION
When I tried to `build.sh` the latest master to use in OmniSharp-Sublime I found:

* the `OmniSharp` build failed because of a missing namespace in `Program.cs`
* when running the server from Sublime it failed because it needed `Microsoft.Composition 1.0.30` and the bundled version was `1.0.27`

This fixes those two problems.