### PR TITLE
fix windows launch bug

### DIFF
--- a/src/OmniSharp/AspNet5/DesignTimeHostManager.cs
+++ b/src/OmniSharp/AspNet5/DesignTimeHostManager.cs
@@ -32,7 +32,7 @@ namespace OmniSharp.AspNet5
                 {
                     return;
                 }
-                
+
                 int port = GetFreePort();
 
                 var psi = new ProcessStartInfo
@@ -103,9 +103,11 @@ namespace OmniSharp.AspNet5
         private static string GetRuntimeExecutable(string runtimePath)
         {
             var newPath = Path.Combine(runtimePath, "bin", "dnx");
+            var newPathExe = Path.Combine(runtimePath, "bin", "dnx.exe");
             var oldPath = Path.Combine(runtimePath, "bin", "klr");
+            var oldPathExe = Path.Combine(runtimePath, "bin", "klr.exe");
 
-            return new[] { newPath, oldPath }.First(File.Exists);
+            return new[] { newPath, newPathExe, oldPath, oldPathExe }.First(File.Exists);
         }
 
         public void Stop()

--- a/src/OmniSharp/AspNet5/DesignTimeHostManager.cs
+++ b/src/OmniSharp/AspNet5/DesignTimeHostManager.cs
@@ -34,7 +34,6 @@ namespace OmniSharp.AspNet5
                 }
 
                 int port = GetFreePort();
-
                 var psi = new ProcessStartInfo
                 {
                     FileName = GetRuntimeExecutable(runtimePath),


### PR DESCRIPTION
With the dnx adoption we broke launching on windows, because ```File.Exists``` isn't so smart to figure out the ```klr``` is ```klr.exe``` when executed.