### PR TITLE
Fixing the display text so it shows correctly

### DIFF
--- a/src/OmniSharp/Api/Intellisense/OmnisharpController.Intellisense.cs
+++ b/src/OmniSharp/Api/Intellisense/OmnisharpController.Intellisense.cs
@@ -104,11 +104,15 @@ namespace OmniSharp
 
         private AutoCompleteResponse MakeAutoCompleteResponse(AutoCompleteRequest request, ISymbol symbol, bool includeOptionalParams = true)
         {
+            var displayNameGenerator = new SnippetGenerator();
+            displayNameGenerator.IncludeMarkers = false;
+            displayNameGenerator.IncludeOptionalParameters = includeOptionalParams;
+
             var response = new AutoCompleteResponse();
             response.CompletionText = symbol.Name;
 
             // TODO: Do something more intelligent here
-            response.DisplayText = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+            response.DisplayText = displayNameGenerator.Generate(symbol);
 
             if (request.WantDocumentationForEveryCompletionResult)
             {
@@ -130,15 +134,12 @@ namespace OmniSharp
                 var snippetGenerator = new SnippetGenerator();
                 snippetGenerator.IncludeMarkers = true;
                 snippetGenerator.IncludeOptionalParameters = includeOptionalParams;
-                response.Snippet = snippetGenerator.GenerateSnippet(symbol);
+                response.Snippet = snippetGenerator.Generate(symbol);
             }
 
             if (request.WantMethodHeader)
             {
-                var snippetGenerator = new SnippetGenerator();
-                snippetGenerator.IncludeMarkers = false;
-                snippetGenerator.IncludeOptionalParameters = includeOptionalParams;
-                response.MethodHeader = snippetGenerator.GenerateSnippet(symbol);
+                response.MethodHeader = displayNameGenerator.Generate(symbol);
             }
 
             return response;

--- a/src/OmniSharp/Workers/Intellisense/SnippetGenerator.cs
+++ b/src/OmniSharp/Workers/Intellisense/SnippetGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,13 +15,13 @@ namespace OmniSharp
         public bool IncludeMarkers { get; set; }
         public bool IncludeOptionalParameters { get; set; }
 
-        public string GenerateSnippet(ISymbol symbol)
+        public string Generate(ISymbol symbol)
         {
             _format = SymbolDisplayFormat.MinimallyQualifiedFormat;
             _format = _format.WithMemberOptions(_format.MemberOptions
                                                 ^ SymbolDisplayMemberOptions.IncludeContainingType
                                                 ^ SymbolDisplayMemberOptions.IncludeType);
-            
+
             if (IsConstructor(symbol))
             {
                 // only the containing type contains the type parameters
@@ -46,10 +47,12 @@ namespace OmniSharp
                     RenderDisplayParts(symbol, parts);
                 }
             }
+
             if (IncludeMarkers)
             {
                 _sb.Append("$0");
             }
+
             return _sb.ToString();
         }
 
@@ -57,7 +60,7 @@ namespace OmniSharp
         {
             var nonInferredTypeArguments = NonInferredTypeArguments(methodSymbol);
             _sb.Append(methodSymbol.Name);
-            
+
             if (nonInferredTypeArguments.Any())
             {
                 _sb.Append("<");
@@ -67,7 +70,7 @@ namespace OmniSharp
                     RenderSnippetStartMarker();
                     _sb.Append(arg);
                     RenderSnippetEndMarker();
-                    
+
                     if (arg != last)
                     {
                         _sb.Append(", ");
@@ -75,9 +78,9 @@ namespace OmniSharp
                 }
                 _sb.Append(">");
             }
-            
+
             RenderParameters(methodSymbol);
-            if (methodSymbol.ReturnsVoid)
+            if (methodSymbol.ReturnsVoid && IncludeMarkers)
             {
                 _sb.Append(";");
             }


### PR DESCRIPTION
Display text now displays correctly for both snippeted and no snippeted response