### PR TITLE
Signature Help

### DIFF
--- a/src/OmniSharp/Api/Signatures/InvocationContext.cs
+++ b/src/OmniSharp/Api/Signatures/InvocationContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace OmniSharp
+{
+    internal class InvocationContext
+    {
+        public SemanticModel SemanticModel { get; set; }
+        public int Position { get; set; }
+        public SyntaxNode Receiver { get; set; }
+        public ArgumentListSyntax ArgumentList { get; set; }
+    }
+}

--- a/src/OmniSharp/Api/Signatures/OmnisharpController.SignatureHelp.cs
+++ b/src/OmniSharp/Api/Signatures/OmnisharpController.SignatureHelp.cs
@@ -11,7 +11,6 @@ namespace OmniSharp
 {
     public partial class OmnisharpController
     {
-
         [HttpPost("signatureHelp")]
         public async Task<SignatureHelp> GetSignatureHelp(Request request)
         {

--- a/src/OmniSharp/Api/Signatures/OmnisharpController.SignatureHelp.cs
+++ b/src/OmniSharp/Api/Signatures/OmnisharpController.SignatureHelp.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Models;
@@ -12,28 +14,85 @@ namespace OmniSharp
     {
 
         [HttpPost("signatureHelp")]
-        public async Task<object> SignatureLookup(Request request)
-        {
-            var symbol = await FindSymbol(request);
-
-            return null;
-        }
-
-        private async Task<ISymbol> FindSymbol(Request request)
+        public async Task<SignatureHelp> GetSignatureHelp(Request request)
         {
             foreach (var document in _workspace.GetDocuments(request.FileName))
             {
-                var semanticModel = await document.GetSemanticModelAsync();
-                var sourceText = await document.GetTextAsync();
-                var position = sourceText.Lines.GetPosition(new LinePosition(request.Line - 1, request.Column - 1));
-                var symbol = SymbolFinder.FindSymbolAtPosition(semanticModel, position, _workspace);
-                if (symbol != null)
+                var response = await GetSignatureHelp(document, request);
+                if (response != null)
                 {
-                    return symbol;
+                    return response;
                 }
+            }
+            return null;
+        }
+
+        private async Task<SignatureHelp> GetSignatureHelp(Document document, Request request)
+        {
+            var sourceText = await document.GetTextAsync();
+            var position = sourceText.Lines.GetPosition(new LinePosition(request.Line - 1, request.Column - 1));
+
+            var invocation = await FindInvocationExpression(document, position);
+            if (invocation == null)
+            {
+                return null;
+            }
+
+            var methodSymbol = await SymbolFinder.FindSymbolAtPositionAsync(document, invocation.Expression.Span.End) as IMethodSymbol;
+            if (methodSymbol == null)
+            {
+                return null;
+            }
+
+            var activeSymbol = await SymbolFinder.FindSymbolAtPositionAsync(document, position);
+
+            return BuildSignatureHelp(methodSymbol, activeSymbol);
+        }
+
+        private SignatureHelp BuildSignatureHelp(IMethodSymbol methodSymbol, ISymbol parameterCandidate)
+        {
+            var signatures = new List<SignatureHelpItem>();
+            foreach (var overload in methodSymbol.ContainingType.GetMembers(methodSymbol.Name))
+            {
+                var methodOverload = (IMethodSymbol)overload;
+                var signatureItem = new SignatureHelpItem();
+                signatureItem.Name = methodOverload.Name;
+                signatureItem.Documentation = methodOverload.GetDocumentationCommentXml();
+                signatureItem.Parameters = methodOverload.Parameters.Select(parameter =>
+                {
+                    return new SignatureHelpParameter()
+                    {
+                        Name = parameter.Name,
+                        Type = parameter.ToDisplayString(),
+                        Documentation = parameter.GetDocumentationCommentXml()
+                    };
+                });
+
+                signatures.Add(signatureItem);
+            }
+
+            var signatureHelp = new SignatureHelp();
+            signatureHelp.Signatures = signatures;
+
+            return signatureHelp;
+        }
+
+        private async Task<InvocationExpressionSyntax> FindInvocationExpression(Document document, int position)
+        {
+            var tree = await document.GetSyntaxTreeAsync();
+            var node = tree.GetRoot().FindToken(position).Parent;
+
+            while (node != null)
+            {
+                var invocation = node as InvocationExpressionSyntax;
+                if (invocation != null && invocation.ArgumentList.FullSpan.IntersectsWith(position))
+                {
+                    return invocation;
+                }
+                node = node.Parent;
             }
 
             return null;
         }
-    }    
+    }
 }

--- a/src/OmniSharp/Api/Signatures/OmnisharpController.SignatureHelp.cs
+++ b/src/OmniSharp/Api/Signatures/OmnisharpController.SignatureHelp.cs
@@ -114,14 +114,15 @@ namespace OmniSharp
 
         private int InvocationScore(IMethodSymbol symbol, IEnumerable<TypeInfo> types)
         {
-            if (symbol.Parameters.Count() < types.Count())
+            var parameters = GetParameters(symbol);
+            if (parameters.Count() < types.Count())
             {
                 return int.MinValue;
             }
 
             var score = 0;
             var invocationEnum = types.GetEnumerator();
-            var definitionEnum = symbol.Parameters.GetEnumerator();
+            var definitionEnum = parameters.GetEnumerator();
             while (invocationEnum.MoveNext() && definitionEnum.MoveNext())
             {
                 if (invocationEnum.Current.ConvertedType == null)
@@ -149,12 +150,13 @@ namespace OmniSharp
                 signature.Name = symbol.ContainingType.Name;
                 signature.Label = symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
             }
-            else 
+            else
             {
                 signature.Name = symbol.Name;
                 signature.Label = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
             }
-            signature.Parameters = symbol.Parameters.Select(parameter =>
+
+            signature.Parameters = GetParameters(symbol).Select(parameter =>
             {
                 return new SignatureHelpParameter()
                 {
@@ -164,6 +166,18 @@ namespace OmniSharp
                 };
             });
             return signature;
+        }
+
+        private static IEnumerable<IParameterSymbol> GetParameters(IMethodSymbol methodSymbol)
+        {
+            if (!methodSymbol.IsExtensionMethod)
+            {
+                return methodSymbol.Parameters;
+            }
+            else
+            {
+                return methodSymbol.Parameters.RemoveAt(0);
+            }
         }
     }
 }

--- a/src/OmniSharp/Api/Signatures/OmnisharpController.SignatureHelp.cs
+++ b/src/OmniSharp/Api/Signatures/OmnisharpController.SignatureHelp.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Mvc;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Models;
+
+namespace OmniSharp
+{
+    public partial class OmnisharpController
+    {
+
+        [HttpPost("signatureHelp")]
+        public async Task<object> SignatureLookup(Request request)
+        {
+            var symbol = await FindSymbol(request);
+
+            return null;
+        }
+
+        private async Task<ISymbol> FindSymbol(Request request)
+        {
+            foreach (var document in _workspace.GetDocuments(request.FileName))
+            {
+                var semanticModel = await document.GetSemanticModelAsync();
+                var sourceText = await document.GetTextAsync();
+                var position = sourceText.Lines.GetPosition(new LinePosition(request.Line - 1, request.Column - 1));
+                var symbol = SymbolFinder.FindSymbolAtPosition(semanticModel, position, _workspace);
+                if (symbol != null)
+                {
+                    return symbol;
+                }
+            }
+
+            return null;
+        }
+    }    
+}

--- a/src/OmniSharp/Models/SignatureHelp.cs
+++ b/src/OmniSharp/Models/SignatureHelp.cs
@@ -6,8 +6,8 @@ namespace OmniSharp.Models
     {
         public IEnumerable<SignatureHelpItem> Signatures { get; set; }
 
-//         public int ActiveSignature { get; set; }
-//         
-//         public int ActiveParameter { get; set; }
+        public int ActiveSignature { get; set; }
+        
+        public int ActiveParameter { get; set; }
     }
 }

--- a/src/OmniSharp/Models/SignatureHelp.cs
+++ b/src/OmniSharp/Models/SignatureHelp.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace OmniSharp.Models
+{
+    public class SignatureHelp
+    {
+        public IEnumerable<SignatureHelpItem> Signatures { get; set; }
+
+//         public int ActiveSignature { get; set; }
+//         
+//         public int ActiveParameter { get; set; }
+    }
+}

--- a/src/OmniSharp/Models/SignatureHelpItem.cs
+++ b/src/OmniSharp/Models/SignatureHelpItem.cs
@@ -6,6 +6,8 @@ namespace OmniSharp.Models
     {
         public string Name { get; set; }
 
+        public string Label { get; set; }
+
         public string Documentation { get; set; }
 
         public IEnumerable<SignatureHelpParameter> Parameters { get; set; }

--- a/src/OmniSharp/Models/SignatureHelpItem.cs
+++ b/src/OmniSharp/Models/SignatureHelpItem.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace OmniSharp.Models
+{
+    public class SignatureHelpItem
+    {
+        public string Name { get; set; }
+
+        public string Documentation { get; set; }
+
+        public IEnumerable<SignatureHelpParameter> Parameters { get; set; }
+    }
+}

--- a/src/OmniSharp/Models/SignatureHelpItem.cs
+++ b/src/OmniSharp/Models/SignatureHelpItem.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace OmniSharp.Models
 {
@@ -11,5 +12,27 @@ namespace OmniSharp.Models
         public string Documentation { get; set; }
 
         public IEnumerable<SignatureHelpParameter> Parameters { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as SignatureHelpItem;
+            if (other == null)
+            {
+                return false;
+            }
+
+            return Name == other.Name
+                && Label == other.Label
+                && Documentation == other.Documentation
+                && Enumerable.SequenceEqual(Parameters, other.Parameters);
+        }
+
+        public override int GetHashCode()
+        {
+            return 17 * Name.GetHashCode()
+                + 23 * Label.GetHashCode()
+                + 31 * Documentation.GetHashCode()
+                + Enumerable.Aggregate(Parameters, 37, (current, element) => current + element.GetHashCode());
+        }
     }
 }

--- a/src/OmniSharp/Models/SignatureHelpParameter.cs
+++ b/src/OmniSharp/Models/SignatureHelpParameter.cs
@@ -7,5 +7,25 @@ namespace OmniSharp.Models
         public string Label { get; set; }
 
         public string Documentation { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as SignatureHelpParameter;
+            if (other == null)
+            {
+                return false;
+            }
+
+            return Name == other.Name
+                && Label == other.Label
+                && Documentation == other.Documentation;
+        }
+
+        public override int GetHashCode()
+        {
+            return 17 * Name.GetHashCode()
+                + 23 * Label.GetHashCode()
+                + 31 * Documentation.GetHashCode();
+        }
     }
 }

--- a/src/OmniSharp/Models/SignatureHelpParameter.cs
+++ b/src/OmniSharp/Models/SignatureHelpParameter.cs
@@ -1,0 +1,11 @@
+namespace OmniSharp.Models
+{
+    public class SignatureHelpParameter
+    {
+        public string Name { get; set; }
+
+        public string Type { get; set; }
+
+        public string Documentation { get; set; }
+    }
+}

--- a/src/OmniSharp/Models/SignatureHelpParameter.cs
+++ b/src/OmniSharp/Models/SignatureHelpParameter.cs
@@ -4,7 +4,7 @@ namespace OmniSharp.Models
     {
         public string Name { get; set; }
 
-        public string Type { get; set; }
+        public string Label { get; set; }
 
         public string Documentation { get; set; }
     }

--- a/tests/OmniSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Tests/SignatureHelpFacts.cs
@@ -1,0 +1,121 @@
+using System.Linq;
+using System.Threading.Tasks;
+using OmniSharp.Models;
+using Xunit;
+
+namespace OmniSharp.Tests
+{
+    public class SignatureHelpFacts
+    {
+
+        [Fact]
+        public async Task NoInvocationNoHelp()
+        {
+            var source =
+@"class Program
+{
+    public static void Ma$in(){
+        System.Console.Clear();
+    }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Null(actual);
+
+            source =
+@"class Program
+{
+    public static void Main(){
+        System.Cons$ole.Clear();
+    }
+}";
+            actual = await GetSignatureHelp(source);
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public async Task NoTypeNoHelp()
+        {
+            var source =
+@"class Program
+{
+    public static void Main(){
+        System.Console.Foo$Bar();
+    }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public async Task NoMethodNoHelp()
+        {
+            var source =
+@"class Program
+{
+    public static void Main(){
+        System.Conso$le;
+    }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public async Task SimpleSignatureHelp()
+        {
+            var source =
+@"class Program
+{
+    public static void Main(){
+        System.Console.Clear($);
+    }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Equal(1, actual.Signatures.Count());
+            Assert.Equal("Clear", actual.Signatures.ElementAt(0).Name);
+            Assert.Equal(0, actual.Signatures.ElementAt(0).Parameters.Count());
+        }
+
+        [Fact]
+        public async Task SignaureWithOverloads()
+        {
+            var source =
+@"class Program
+{
+    public static void Main(){
+        new Program().Foo($
+    }
+    
+    private int Foo() 
+    {
+        return 3;
+    }
+    
+    private int Foo(int m)
+    {
+        return m * Foo();
+    }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Equal(2, actual.Signatures.Count());
+        }
+
+        private async Task<SignatureHelp> GetSignatureHelp(string source)
+        {
+            var lineColumn = TestHelpers.GetLineAndColumnFromDollar(source);
+            source = source.Replace("$", string.Empty);
+
+            var request = new Request()
+            {
+                FileName = "dummy.cs",
+                Line = lineColumn.Line,
+                Column = lineColumn.Column,
+                Buffer = source
+            };
+
+            var workspace = TestHelpers.CreateSimpleWorkspace(source);
+            var controller = new OmnisharpController(workspace, null);
+            return await controller.GetSignatureHelp(request);
+        }
+    }
+}

--- a/tests/OmniSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Tests/SignatureHelpFacts.cs
@@ -7,7 +7,6 @@ namespace OmniSharp.Tests
 {
     public class SignatureHelpFacts
     {
-
         [Fact]
         public async Task NoInvocationNoHelp()
         {

--- a/tests/OmniSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Tests/SignatureHelpFacts.cs
@@ -333,6 +333,31 @@ namespace OmniSharp.Tests
             Assert.True(actual.Signatures.ElementAt(actual.ActiveSignature).Documentation.Contains("ctor2"));
         }
 
+        [Fact]
+        public async Task SkipReceiverOfExtensionMethods()
+        {
+            var source =
+@"class Program
+{
+    public static void Main()
+    {
+        new Program().B($);
+    }
+    public Program()
+    {
+    }
+    public bool B(this Program p, int n)
+    {
+        return p.Foo() > n;
+    }
+}";
+
+            var actual = await GetSignatureHelp(source);
+            Assert.Equal(1, actual.Signatures.Count());
+            Assert.Equal(1, actual.Signatures.ElementAt(actual.ActiveSignature).Parameters.Count());
+            Assert.Equal("n", actual.Signatures.ElementAt(actual.ActiveSignature).Parameters.ElementAt(0).Name);
+        }
+
         private async Task<SignatureHelp> GetSignatureHelp(string source)
         {
             var lineColumn = TestHelpers.GetLineAndColumnFromDollar(source);

--- a/tests/OmniSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Tests/SignatureHelpFacts.cs
@@ -72,18 +72,20 @@ namespace OmniSharp.Tests
 }";
             var actual = await GetSignatureHelp(source);
             Assert.Equal(1, actual.Signatures.Count());
+            Assert.Equal(0, actual.ActiveParameter);
+            Assert.Equal(0, actual.ActiveSignature);
             Assert.Equal("Clear", actual.Signatures.ElementAt(0).Name);
             Assert.Equal(0, actual.Signatures.ElementAt(0).Parameters.Count());
         }
 
         [Fact]
-        public async Task SignaureWithOverloads()
+        public async Task SignatureWithOverloads()
         {
             var source =
 @"class Program
 {
     public static void Main(){
-        new Program().Foo($
+        new Program().Foo(12, $
     }
     
     private int Foo() 
@@ -91,13 +93,15 @@ namespace OmniSharp.Tests
         return 3;
     }
     
-    private int Foo(int m)
+    private int Foo(int m, int n)
     {
-        return m * Foo();
+        return m * Foo() * n;
     }
 }";
             var actual = await GetSignatureHelp(source);
             Assert.Equal(2, actual.Signatures.Count());
+            Assert.Equal(1, actual.ActiveParameter);
+            Assert.Equal(2, actual.Signatures.ElementAt(actual.ActiveSignature).Parameters.Count());
         }
 
         private async Task<SignatureHelp> GetSignatureHelp(string source)


### PR DESCRIPTION
This PR add a new route ```/signatureHelp``` which can be used to get information about signatures at a given position. It will return a list of signatures if invoked inside a constructor call or method call. Each signature represents an overload with its specific comment and parameters. The active signature and active parameter are denoted by the result object.