### PR TITLE
Restore packages if needed

### DIFF
--- a/src/OmniSharp/AspNet5/AspNet5Paths.cs
+++ b/src/OmniSharp/AspNet5/AspNet5Paths.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.Framework.Logging;
+using Microsoft.Framework.OptionsModel;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Options;
+using OmniSharp.Services;
+
+namespace OmniSharp.AspNet5
+{
+    public class AspNet5Paths
+    {
+        private readonly IOmnisharpEnvironment _env;
+        private readonly OmniSharpOptions _options;
+        private readonly ILogger _logger;
+
+        public string RuntimePath { get; private set; }
+        public string Dnx { get; private set; }
+        public string Dnu { get; private set; }
+        public string Klr { get; private set; }
+        public string Kpm { get; private set; }
+
+        public AspNet5Paths(IOmnisharpEnvironment env, IOptions<OmniSharpOptions> optionsAccessor,
+                            ILoggerFactory loggerFactory)
+        {
+            _env = env;
+            _options = optionsAccessor.Options;
+            _logger = loggerFactory.Create<AspNet5Paths>();
+
+            RuntimePath = GetRuntimePath();
+            Dnx = FirstPath(RuntimePath, "dnx", "dnx.exe");
+            Dnu = FirstPath(RuntimePath, "dnu", "dnu.cmd");
+            Klr = FirstPath(RuntimePath, "klr", "klr.exe");
+            Kpm = FirstPath(RuntimePath, "kpm", "kpm.cmd");
+        }
+
+        private string GetRuntimePath()
+        {
+            var versionOrAlias = GetRuntimeVersionOrAlias() ?? _options.AspNet5.Alias ?? "default";
+            var seachedLocations = new List<string>();
+
+            foreach (var location in GetRuntimeLocations())
+            {
+                var paths = GetRuntimePathsFromVersionOrAlias(versionOrAlias, location);
+
+                foreach (var path in paths)
+                {
+                    if (string.IsNullOrEmpty(path))
+                    {
+                        continue;
+                    }
+
+                    if (Directory.Exists(path))
+                    {
+                        _logger.WriteInformation(string.Format("Using runtime '{0}'.", path));
+                        return path;
+                    }
+
+                    seachedLocations.Add(path);
+                }
+            }
+
+            _logger.WriteError("The specified runtime path '{0}' does not exist. Searched locations {1}", versionOrAlias, string.Join("\n", seachedLocations));
+
+            return null;
+        }
+
+        private string GetRuntimeVersionOrAlias()
+        {
+            var root = ResolveRootDirectory(_env.Path);
+
+            var globalJson = Path.Combine(root, "global.json");
+
+            if (File.Exists(globalJson))
+            {
+                _logger.WriteInformation("Looking for sdk version in '{0}'.", globalJson);
+
+                using (var stream = File.OpenRead(globalJson))
+                {
+                    var obj = JObject.Load(new JsonTextReader(new StreamReader(stream)));
+                    return obj["sdk"]?["version"]?.Value<string>();
+                }
+            }
+
+            return null;
+        }
+
+        public static string ResolveRootDirectory(string projectPath)
+        {
+            var di = new DirectoryInfo(projectPath);
+
+            while (di.Parent != null)
+            {
+                if (di.EnumerateFiles("global.json").Any())
+                {
+                    return di.FullName;
+                }
+
+                di = di.Parent;
+            }
+
+            // If we don't find any files then make the project folder the root
+            return projectPath;
+        }
+
+        private IEnumerable<string> GetRuntimeLocations()
+        {
+            yield return Environment.GetEnvironmentVariable("DNX_HOME");
+            yield return Environment.GetEnvironmentVariable("KRE_HOME");
+
+            var home = Environment.GetEnvironmentVariable("HOME") ??
+                       Environment.GetEnvironmentVariable("USERPROFILE");
+
+            // Newer path
+            yield return Path.Combine(home, ".dnx");
+
+            // New path
+
+            yield return Path.Combine(home, ".k");
+
+            // Old path
+            yield return Path.Combine(home, ".kre");
+        }
+
+        private IEnumerable<string> GetRuntimePathsFromVersionOrAlias(string versionOrAlias, string runtimePath)
+        {
+            // Newer format
+            yield return GetRuntimePathFromVersionOrAlias(versionOrAlias, runtimePath, ".dnx", "dnx-mono.{0}", "dnx-clr-win-x86.{0}", "runtimes");
+
+            // New format
+
+            yield return GetRuntimePathFromVersionOrAlias(versionOrAlias, runtimePath, ".k", "kre-mono.{0}", "kre-clr-win-x86.{0}", "runtimes");
+
+            // Old format
+            yield return GetRuntimePathFromVersionOrAlias(versionOrAlias, runtimePath, ".kre", "KRE-Mono.{0}", "KRE-CLR-x86.{0}", "packages");
+        }
+
+        private string GetRuntimePathFromVersionOrAlias(string versionOrAlias,
+                                                        string runtimeHome,
+                                                        string sdkFolder,
+                                                        string monoFormat,
+                                                        string windowsFormat,
+                                                        string runtimeFolder)
+        {
+            if (string.IsNullOrEmpty(runtimeHome))
+            {
+                return null;
+            }
+
+            var aliasDirectory = Path.Combine(runtimeHome, "alias");
+
+            var aliasFiles = new[] { "{0}.alias", "{0}.txt" };
+
+            // Check alias first
+            foreach (var shortAliasFile in aliasFiles)
+            {
+                var aliasFile = Path.Combine(aliasDirectory, string.Format(shortAliasFile, versionOrAlias));
+
+                if (File.Exists(aliasFile))
+                {
+                    var fullName = File.ReadAllText(aliasFile).Trim();
+
+                    return Path.Combine(runtimeHome, runtimeFolder, fullName);
+                }
+            }
+
+            // There was no alias, look for the input as a version
+            var version = versionOrAlias;
+
+            if (PlatformHelper.IsMono)
+            {
+                return Path.Combine(runtimeHome, runtimeFolder, string.Format(monoFormat, versionOrAlias));
+            }
+            else
+            {
+                return Path.Combine(runtimeHome, runtimeFolder, string.Format(windowsFormat, versionOrAlias));
+            }
+        }
+
+        private static string FirstPath(string runtimePath, params string[] candidates)
+        {
+            if (runtimePath == null)
+            {
+                return null;
+            }
+            return candidates
+                .Select(candidate => Path.Combine(runtimePath, "bin", candidate))
+                .FirstOrDefault(File.Exists);
+        }
+    }
+}

--- a/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
+++ b/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
@@ -269,12 +269,12 @@ namespace OmniSharp.AspNet5
                     else if (m.MessageType == "Dependencies")
                     {
                         var val = m.Payload.ToObject<DependenciesMessage>();
-                        var unreolvedDependencies = val.Dependencies.Values
+                        var unresolvedDependencies = val.Dependencies.Values
                             .Where(dep => dep.Type == "Unresolved");
 
-                        if (unreolvedDependencies.Any())
+                        if (unresolvedDependencies.Any())
                         {
-                            _logger.WriteInformation("Project {0} has these unresolved references: {1}", project.Path, string.Join(", ", unreolvedDependencies.Select(d => d.Name)));
+                            _logger.WriteInformation("Project {0} has these unresolved references: {1}", project.Path, string.Join(", ", unresolvedDependencies.Select(d => d.Name)));
                             _packagesRestoreTool.Run(project);
                         }
                     }

--- a/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
+++ b/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
@@ -274,6 +274,7 @@ namespace OmniSharp.AspNet5
 
                         if (unreolvedDependencies.Any())
                         {
+                            _logger.WriteInformation("Project {0} has these unresolved references: {1}", project.Path, string.Join(", ", unreolvedDependencies.Select(d => d.Name)));
                             _packagesRestoreTool.Run(project);
                         }
                     }

--- a/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
+++ b/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -16,7 +15,6 @@ using Microsoft.Framework.DesignTimeHost.Models.IncomingMessages;
 using Microsoft.Framework.DesignTimeHost.Models.OutgoingMessages;
 using Microsoft.Framework.Logging;
 using Microsoft.Framework.OptionsModel;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Options;
 using OmniSharp.Services;
@@ -27,9 +25,9 @@ namespace OmniSharp.AspNet5
     {
         private readonly OmnisharpWorkspace _workspace;
         private readonly IOmnisharpEnvironment _env;
-        private readonly OmniSharpOptions _options;
         private readonly ILogger _logger;
         private readonly IMetadataFileReferenceCache _metadataFileReferenceCache;
+        private readonly AspNet5Paths _aspNet5Paths;
         private readonly DesignTimeHostManager _designTimeHostManager;
         private readonly PackagesRestoreTool _packagesRestoreTool;
         private readonly AspNet5Context _context;
@@ -46,11 +44,11 @@ namespace OmniSharp.AspNet5
         {
             _workspace = workspace;
             _env = env;
-            _options = optionsAccessor.Options;
             _logger = loggerFactory.Create<AspNet5ProjectSystem>();
             _metadataFileReferenceCache = metadataFileReferenceCache;
-            _designTimeHostManager = new DesignTimeHostManager(loggerFactory);
-            _packagesRestoreTool = new PackagesRestoreTool(loggerFactory, context);
+            _aspNet5Paths = new AspNet5Paths(env, optionsAccessor, loggerFactory);
+            _designTimeHostManager = new DesignTimeHostManager(loggerFactory, _aspNet5Paths);
+            _packagesRestoreTool = new PackagesRestoreTool(loggerFactory, context, _aspNet5Paths);
             _context = context;
             _watcher = watcher;
 
@@ -59,7 +57,7 @@ namespace OmniSharp.AspNet5
 
         public void Initalize()
         {
-            _context.RuntimePath = GetRuntimePath();
+            _context.RuntimePath = _aspNet5Paths.RuntimePath;
 
             if (_context.RuntimePath == null)
             {
@@ -77,7 +75,7 @@ namespace OmniSharp.AspNet5
 
             var wh = new ManualResetEventSlim();
 
-            _designTimeHostManager.Start(_context.RuntimePath, _context.HostId, port =>
+            _designTimeHostManager.Start(_context.HostId, port =>
             {
                 var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
                 socket.Connect(new IPEndPoint(IPAddress.Loopback, port));
@@ -276,7 +274,7 @@ namespace OmniSharp.AspNet5
 
                         if (unreolvedDependencies.Any())
                         {
-                            _packagesRestoreTool.Run(GetRuntimePath(), project);
+                            _packagesRestoreTool.Run(project);
                         }
                     }
                     else if (m.MessageType == "CompilerOptions")
@@ -516,147 +514,5 @@ namespace OmniSharp.AspNet5
         {
             return Task.Factory.FromAsync((cb, state) => socket.BeginConnect(endPoint, cb, state), ar => socket.EndConnect(ar), null);
         }
-
-        private string GetRuntimePath()
-        {
-            var versionOrAlias = GetRuntimeVersionOrAlias() ?? _options.AspNet5.Alias ?? "default";
-            var seachedLocations = new List<string>();
-            
-            foreach (var location in GetRuntimeLocations())
-            {
-                var paths = GetRuntimePathsFromVersionOrAlias(versionOrAlias, location);
-
-                foreach (var path in paths)
-                {
-                    if (string.IsNullOrEmpty(path))
-                    {
-                        continue;
-                    }
-
-                    if (Directory.Exists(path))
-                    {
-                        _logger.WriteInformation(string.Format("Using runtime '{0}'.", path));
-                        return path;
-                    }
-                    
-                    seachedLocations.Add(path);
-                }
-            }
-
-            _logger.WriteError("The specified runtime path '{0}' does not exist. Searched locations {1}", versionOrAlias, string.Join("\n", seachedLocations));
-
-            return null;
-        }
-
-        private IEnumerable<string> GetRuntimeLocations()
-        {
-            yield return Environment.GetEnvironmentVariable("DNX_HOME");
-            yield return Environment.GetEnvironmentVariable("KRE_HOME");
-
-            var home = Environment.GetEnvironmentVariable("HOME") ??
-                       Environment.GetEnvironmentVariable("USERPROFILE");
-
-            // Newer path
-            yield return Path.Combine(home, ".dnx");
-            
-            // New path
-            yield return Path.Combine(home, ".k");
-
-            // Old path
-            yield return Path.Combine(home, ".kre");
-        }
-
-        private IEnumerable<string> GetRuntimePathsFromVersionOrAlias(string versionOrAlias, string runtimePath)
-        {
-            // Newer format
-            yield return GetRuntimePathFromVersionOrAlias(versionOrAlias, runtimePath, ".dnx", "dnx-mono.{0}", "dnx-clr-win-x86.{0}", "runtimes");
-            
-            // New format
-            yield return GetRuntimePathFromVersionOrAlias(versionOrAlias, runtimePath, ".k", "kre-mono.{0}", "kre-clr-win-x86.{0}", "runtimes");
-
-            // Old format
-            yield return GetRuntimePathFromVersionOrAlias(versionOrAlias, runtimePath, ".kre", "KRE-Mono.{0}", "KRE-CLR-x86.{0}", "packages");
-        }
-
-        private string GetRuntimePathFromVersionOrAlias(string versionOrAlias,
-                                                        string runtimeHome,
-                                                        string sdkFolder,
-                                                        string monoFormat,
-                                                        string windowsFormat,
-                                                        string runtimeFolder)
-        {
-            if (string.IsNullOrEmpty(runtimeHome))
-            {
-                return null;
-            }
-
-            var aliasDirectory = Path.Combine(runtimeHome, "alias");
-
-            var aliasFiles = new[] { "{0}.alias", "{0}.txt" };
-
-            // Check alias first
-            foreach (var shortAliasFile in aliasFiles)
-            {
-                var aliasFile = Path.Combine(aliasDirectory, string.Format(shortAliasFile, versionOrAlias));
-
-                if (File.Exists(aliasFile))
-                {
-                    var fullName = File.ReadAllText(aliasFile).Trim();
-
-                    return Path.Combine(runtimeHome, runtimeFolder, fullName);
-                }
-            }
-
-            // There was no alias, look for the input as a version
-            var version = versionOrAlias;
-
-            if (PlatformHelper.IsMono)
-            {
-                return Path.Combine(runtimeHome, runtimeFolder, string.Format(monoFormat, versionOrAlias));
-            }
-            else
-            {
-                return Path.Combine(runtimeHome, runtimeFolder, string.Format(windowsFormat, versionOrAlias));
-            }
-        }
-
-        private string GetRuntimeVersionOrAlias()
-        {
-            var root = ResolveRootDirectory(_env.Path);
-
-            var globalJson = Path.Combine(root, "global.json");
-
-            if (File.Exists(globalJson))
-            {
-                _logger.WriteInformation("Looking for sdk version in '{0}'.", globalJson);
-
-                using (var stream = File.OpenRead(globalJson))
-                {
-                    var obj = JObject.Load(new JsonTextReader(new StreamReader(stream)));
-                    return obj["sdk"]?["version"]?.Value<string>();
-                }
-            }
-
-            return null;
-        }
-
-        public static string ResolveRootDirectory(string projectPath)
-        {
-            var di = new DirectoryInfo(projectPath);
-
-            while (di.Parent != null)
-            {
-                if (di.EnumerateFiles("global.json").Any())
-                {
-                    return di.FullName;
-                }
-
-                di = di.Parent;
-            }
-
-            // If we don't find any files then make the project folder the root
-            return projectPath;
-        }
-
     }
 }

--- a/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
+++ b/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
@@ -390,6 +390,13 @@ namespace OmniSharp.AspNet5
 
         private void TriggerDependeees(string path)
         {
+            // temp: run [dnu|kpm] restore when project.json changed
+            var project = _context.GetProject(path);
+            if (project != null)
+            {
+                _packagesRestoreTool.Run(project);
+            }
+
             var seen = new HashSet<string>();
             var results = new HashSet<int>();
             var stack = new Stack<string>();

--- a/src/OmniSharp/AspNet5/PackagesRestoreTool.cs
+++ b/src/OmniSharp/AspNet5/PackagesRestoreTool.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Framework.DesignTimeHost.Models;
 using Microsoft.Framework.Logging;
@@ -9,24 +11,94 @@ namespace OmniSharp.AspNet5
 {
     public class PackagesRestoreTool
     {
+        private readonly object _lock = new object();
         private readonly ILogger _logger;
         private readonly AspNet5Context _context;
         private readonly AspNet5Paths _paths;
+        private readonly IDictionary<string, Task<int>> _tasks;
 
         public PackagesRestoreTool(ILoggerFactory logger, AspNet5Context context, AspNet5Paths paths)
         {
             _logger = logger.Create<PackagesRestoreTool>();
             _context = context;
             _paths = paths;
+            _tasks = new Dictionary<string, Task<int>>();
         }
 
-        public Task<int> Run(Project project)
+        public void Run(Project project)
         {
-            var tsc = new TaskCompletionSource<int>();
+            var workingDir = GetWorkingDir(project);
+            var task = GetOrCreateRestoreTask(workingDir);
+
+            task.ContinueWith(finishedTask =>
+            {
+                if (finishedTask.IsCanceled)
+                {
+                    return;
+                }
+
+                _context.Connection.Post(new Message()
+                {
+                    ContextId = project.ContextId,
+                    MessageType = "RestoreComplete",
+                    HostId = _context.HostId
+                });
+            });
+        }
+
+        private Task<int> GetOrCreateRestoreTask(string workingDir)
+        {
+            lock (_lock)
+            {
+                Task<int> task;
+                if (_tasks.TryGetValue(workingDir, out task))
+                {
+                    return task;
+                }
+
+                Action<int> onRestoreDone = null;
+                var tokenBefore = ComputeToken(workingDir);
+                var tsc = new TaskCompletionSource<int>();
+                task = tsc.Task;
+
+                onRestoreDone = code =>
+                {
+                    var tokenAfter = ComputeToken(workingDir);
+                    if (!Enumerable.SequenceEqual(tokenBefore, tokenAfter))
+                    {
+                        // once again
+                        TryStartRestore(workingDir, onRestoreDone);
+                        return;
+                    }
+                    else
+                    {
+                        lock (_lock)
+                        {
+                            _tasks.Remove(workingDir);
+                        }
+                        tsc.SetResult(code);
+                    }
+                };
+
+                if (TryStartRestore(workingDir, onRestoreDone))
+                {
+                    _tasks[workingDir] = task;
+                }
+                else
+                {
+                    tsc.SetCanceled();
+                }
+
+                return task;
+            }
+        }
+
+        private bool TryStartRestore(string workingDir, Action<int> onDone)
+        {
             var psi = new ProcessStartInfo()
             {
                 FileName = _paths.Dnu ?? _paths.Kpm,
-                WorkingDirectory = Path.GetDirectoryName(project.Path),
+                WorkingDirectory = workingDir,
                 CreateNoWindow = true,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
@@ -34,33 +106,37 @@ namespace OmniSharp.AspNet5
                 Arguments = "restore"
             };
 
-            _logger.WriteInformation("restore packages with {0} {1}", psi.FileName, psi.Arguments);
+            _logger.WriteInformation("restore packages {0} {1} for {2}", psi.FileName, psi.Arguments, psi.WorkingDirectory);
 
             var restoreProcess = Process.Start(psi);
             if (restoreProcess.HasExited)
             {
-                tsc.SetException(new Exception("Failed to start process: " + psi.FileName));
-            }
-            else
-            {
-                ReadAndWriteOutput(restoreProcess, _logger);
-                restoreProcess.EnableRaisingEvents = true;
-                restoreProcess.OnExit(() =>
-                {
-                    _context.Connection.Post(new Message()
-                    {
-                        ContextId = project.ContextId,
-                        MessageType = "RestoreComplete",
-                        HostId = _context.HostId
-                    });
-                    tsc.SetResult(restoreProcess.ExitCode);
-                });
+                _logger.WriteError("restore command ({0}) failed with error code {1}", psi.FileName, restoreProcess.ExitCode);
+                return false;
             }
 
-            return tsc.Task;
+            RedirectOutput(restoreProcess, _logger);
+
+            restoreProcess.EnableRaisingEvents = true;
+            restoreProcess.OnExit(() => onDone(restoreProcess.ExitCode));
+            return true;
         }
 
-        private static void ReadAndWriteOutput(Process process, ILogger logger)
+        private static string GetWorkingDir(Project project)
+        {
+            return project.GlobalJsonPath != null
+                ? Path.GetDirectoryName(project.GlobalJsonPath)
+                : Path.GetDirectoryName(project.Path);
+        }
+
+        private static IEnumerable<DateTime> ComputeToken(string dir)
+        {
+            return Directory.GetFiles(dir)
+                .Select(File.GetLastWriteTimeUtc)
+                .OrderBy(element => element);
+        }
+
+        private static void RedirectOutput(Process process, ILogger logger)
         {
             Task.Factory.StartNew(async () =>
             {

--- a/src/OmniSharp/AspNet5/PackagesRestoreTool.cs
+++ b/src/OmniSharp/AspNet5/PackagesRestoreTool.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Framework.DesignTimeHost.Models;
 using Microsoft.Framework.Logging;
@@ -12,19 +11,21 @@ namespace OmniSharp.AspNet5
     {
         private readonly ILogger _logger;
         private readonly AspNet5Context _context;
+        private readonly AspNet5Paths _paths;
 
-        public PackagesRestoreTool(ILoggerFactory logger, AspNet5Context context)
+        public PackagesRestoreTool(ILoggerFactory logger, AspNet5Context context, AspNet5Paths paths)
         {
             _logger = logger.Create<PackagesRestoreTool>();
             _context = context;
+            _paths = paths;
         }
 
-        public Task<int> Run(string runtimePath, Project project)
+        public Task<int> Run(Project project)
         {
             var tsc = new TaskCompletionSource<int>();
             var psi = new ProcessStartInfo()
             {
-                FileName = GetRuntimeExecutable(runtimePath),
+                FileName = _paths.Dnu ?? _paths.Kpm,
                 WorkingDirectory = Path.GetDirectoryName(project.Path),
                 CreateNoWindow = true,
                 UseShellExecute = false,
@@ -55,16 +56,6 @@ namespace OmniSharp.AspNet5
             }
 
             return tsc.Task;
-        }
-
-        private static string GetRuntimeExecutable(string runtimePath)
-        {
-            var newPath = Path.Combine(runtimePath, "bin", "dnu");
-            var newPathCmd = Path.Combine(runtimePath, "bin", "dnu.cmd");
-            var oldPath = Path.Combine(runtimePath, "bin", "kpm");
-            var oldPathCmd = Path.Combine(runtimePath, "bin", "kpm.cmd");
-
-            return new[] { newPath, newPathCmd, oldPath, oldPathCmd }.First(File.Exists);
         }
     }
 }

--- a/src/OmniSharp/AspNet5/PackagesRestoreTool.cs
+++ b/src/OmniSharp/AspNet5/PackagesRestoreTool.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Framework.DesignTimeHost.Models;
+using Microsoft.Framework.Logging;
+
+namespace OmniSharp.AspNet5
+{
+    public class PackagesRestoreTool
+    {
+        private readonly ILogger _logger;
+        private readonly AspNet5Context _context;
+
+        public PackagesRestoreTool(ILoggerFactory logger, AspNet5Context context)
+        {
+            _logger = logger.Create<PackagesRestoreTool>();
+            _context = context;
+        }
+
+        public Task<int> Run(string runtimePath, Project project)
+        {
+            var tsc = new TaskCompletionSource<int>();
+            var psi = new ProcessStartInfo()
+            {
+                FileName = GetRuntimeExecutable(runtimePath),
+                WorkingDirectory = Path.GetDirectoryName(project.Path),
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardError = true,
+                Arguments = "restore"
+            };
+
+            _logger.WriteInformation("restore packages with {0} {1}", psi.FileName, psi.Arguments);
+
+            var restoreProcess = Process.Start(psi);
+            if (restoreProcess.HasExited)
+            {
+                tsc.SetException(new Exception("Failed to start process: " + psi.FileName));
+            }
+            else
+            {
+                restoreProcess.EnableRaisingEvents = true;
+                restoreProcess.OnExit(() =>
+                {
+                    _context.Connection.Post(new Message()
+                    {
+                        ContextId = project.ContextId,
+                        MessageType = "RestoreComplete",
+                        HostId = _context.HostId
+                    });
+                    tsc.SetResult(restoreProcess.ExitCode);
+                });
+            }
+
+            return tsc.Task;
+        }
+
+        private static string GetRuntimeExecutable(string runtimePath)
+        {
+            var newPath = Path.Combine(runtimePath, "bin", "dnu");
+            var newPathCmd = Path.Combine(runtimePath, "bin", "dnu.cmd");
+            var oldPath = Path.Combine(runtimePath, "bin", "kpm");
+            var oldPathCmd = Path.Combine(runtimePath, "bin", "kpm.cmd");
+
+            return new[] { newPath, newPathCmd, oldPath, oldPathCmd }.First(File.Exists);
+        }
+    }
+}


### PR DESCRIPTION
This PR makes sure that OmniSharp automatically restores packages (via ```dnu restore``` or ```kpm restore```) if needed. The flow goes like this:

1. OmniSharp receives a _dependencies_-message from DTH which flags ```unresolved``` dependencies
2. OmniSharp runs ```dnu restore``` or ```kpm restore``` (depending on the target runtime)
3. Upon completion OmniSharp sends DTH _restoreComplete_-messages (one per project)
4. DTH updates project references etc which in return makes OmniSharp update the Roslyn project
5. Roslyn emit a project modification event and forwards that to the editor
6. The editor ask request a new code check etc