### PR TITLE
updated xunit commands for new runner

### DIFF
--- a/src/OmniSharp/AspNet5/AspNet5Paths.cs
+++ b/src/OmniSharp/AspNet5/AspNet5Paths.cs
@@ -23,6 +23,7 @@ namespace OmniSharp.AspNet5
         public string Dnu { get; private set; }
         public string Klr { get; private set; }
         public string Kpm { get; private set; }
+        public string K   { get; private set; }
 
         public AspNet5Paths(IOmnisharpEnvironment env, IOptions<OmniSharpOptions> optionsAccessor,
                             ILoggerFactory loggerFactory)
@@ -36,6 +37,7 @@ namespace OmniSharp.AspNet5
             Dnu = FirstPath(RuntimePath, "dnu", "dnu.cmd");
             Klr = FirstPath(RuntimePath, "klr", "klr.exe");
             Kpm = FirstPath(RuntimePath, "kpm", "kpm.cmd");
+            K   = FirstPath(RuntimePath, "k", "k.cmd");
         }
 
         private string GetRuntimePath()

--- a/src/OmniSharp/AspNet5/AspNet5TestCommandProvider.cs
+++ b/src/OmniSharp/AspNet5/AspNet5TestCommandProvider.cs
@@ -18,7 +18,7 @@ namespace OmniSharp.AspNet5
         {
             _context = context;
             var aspNet5Paths = new AspNet5Paths(env, options, loggerFactory);
-            _dnx = aspNet5Paths.Dnx ?? aspNet5Paths.K;
+            _dnx = aspNet5Paths.Dnx + " ." ?? aspNet5Paths.K;
         }
 
         public string GetTestCommand(TestContext testContext)

--- a/src/OmniSharp/AspNet5/AspNet5TestCommandProvider.cs
+++ b/src/OmniSharp/AspNet5/AspNet5TestCommandProvider.cs
@@ -1,14 +1,24 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.Framework.Logging;
+using Microsoft.Framework.OptionsModel;
+using OmniSharp.Options;
+using OmniSharp.Services;
 
 namespace OmniSharp.AspNet5
 {
     public class AspNet5TestCommandProvider : ITestCommandProvider
     {
         private readonly AspNet5Context _context;
+        private readonly string _dnx;
 
-        public AspNet5TestCommandProvider(AspNet5Context context)
+        public AspNet5TestCommandProvider(AspNet5Context context,
+                                          IOmnisharpEnvironment env,
+                                          ILoggerFactory loggerFactory,
+                                          IOptions<OmniSharpOptions> options)
         {
             _context = context;
+            var aspNet5Paths = new AspNet5Paths(env, options, loggerFactory);
+            _dnx = aspNet5Paths.Dnx ?? aspNet5Paths.K;
         }
 
         public string GetTestCommand(TestContext testContext)
@@ -62,7 +72,7 @@ namespace OmniSharp.AspNet5
                     }
                     break;
             }
-            return "k test" + arguments;
+            return _dnx + " test" + arguments;
         }
     }
 }

--- a/src/OmniSharp/AspNet5/AspNet5TestCommandProvider.cs
+++ b/src/OmniSharp/AspNet5/AspNet5TestCommandProvider.cs
@@ -5,12 +5,12 @@ namespace OmniSharp.AspNet5
     public class AspNet5TestCommandProvider : ITestCommandProvider
     {
         private readonly AspNet5Context _context;
-        
+
         public AspNet5TestCommandProvider(AspNet5Context context)
         {
             _context = context;
         }
-        
+
         public string GetTestCommand(TestContext testContext)
         {
             if (!_context.ProjectContextMapping.ContainsKey(testContext.ProjectFile))
@@ -28,35 +28,41 @@ namespace OmniSharp.AspNet5
 
             // Find the test command, if any and use that
             var symbol = testContext.Symbol;
-            string testsToRun = "";
-            
-            if (symbol is IMethodSymbol)
-            {
-                testsToRun = symbol.ContainingType.Name + "." + symbol.Name;
-            }
-            else if (symbol is INamedTypeSymbol)
-            {
-                testsToRun = symbol.Name;
-            }
+            string arguments = "";
 
+            var containingNamespace = "";
             if (!symbol.ContainingNamespace.IsGlobalNamespace)
             {
-                testsToRun = symbol.ContainingNamespace + "." + testsToRun;
+                containingNamespace = symbol.ContainingNamespace + ".";
             }
-
-            string testCommand = null;
 
             switch (testContext.TestCommandType)
             {
-                case TestCommandType.All:
-                    testCommand = "k test";
+                case TestCommandType.Fixture:
+                    if (symbol is IMethodSymbol)
+                    {
+                        arguments = " -class " + containingNamespace
+                            + symbol.ContainingType.Name;
+                    }
+                    else if (symbol is INamedTypeSymbol)
+                    {
+                        arguments = " -class " + containingNamespace + symbol.Name;
+                    }
                     break;
                 case TestCommandType.Single:
-                case TestCommandType.Fixture:
-                    testCommand = "k test --test " + testsToRun;
+                    if (symbol is IMethodSymbol)
+                    {
+                        arguments = " -method " + containingNamespace +
+                            symbol.ContainingType.Name + "." + symbol.Name;
+                    }
+                    else if (symbol is INamedTypeSymbol)
+                    {
+                        arguments = " -class " + containingNamespace +
+                            symbol.Name;
+                    }
                     break;
             }
-            return testCommand;
+            return "k test" + arguments;
         }
     }
 }

--- a/tests/OmniSharp.Tests/Fakes/FakeLoggerFactory.cs
+++ b/tests/OmniSharp.Tests/Fakes/FakeLoggerFactory.cs
@@ -1,0 +1,16 @@
+using Microsoft.Framework.Logging;
+
+namespace OmniSharp.Tests
+{
+    public class FakeLoggerFactory : ILoggerFactory
+    {
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public ILogger Create(string name)
+        {
+            return NullLogger.Instance;
+        }
+    }
+}

--- a/tests/OmniSharp.Tests/Fakes/FakeOmniSharpEnvironment.cs
+++ b/tests/OmniSharp.Tests/Fakes/FakeOmniSharpEnvironment.cs
@@ -1,0 +1,15 @@
+using OmniSharp.Services;
+using Microsoft.Framework.Logging;
+
+namespace OmniSharp.Tests
+{
+    public class FakeEnvironment : IOmnisharpEnvironment
+    {
+        public LogLevel TraceType { get; }
+        public int Port { get; }
+        public int HostPID { get; }
+        public string Path { get { return "."; } }
+        public string SolutionFilePath { get; }
+        public TransportType TransportType { get; }
+    }
+}

--- a/tests/OmniSharp.Tests/Fakes/FakeOmniSharpEnvironment.cs
+++ b/tests/OmniSharp.Tests/Fakes/FakeOmniSharpEnvironment.cs
@@ -1,5 +1,5 @@
-using OmniSharp.Services;
 using Microsoft.Framework.Logging;
+using OmniSharp.Services;
 
 namespace OmniSharp.Tests
 {

--- a/tests/OmniSharp.Tests/Fakes/FakeOmniSharpOptions.cs
+++ b/tests/OmniSharp.Tests/Fakes/FakeOmniSharpOptions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Framework.OptionsModel;
+using OmniSharp.Options;
+
+namespace OmniSharp.Tests
+{
+    public class FakeOmniSharpOptions : IOptions<OmniSharpOptions>
+    {
+        public OmniSharpOptions Options { get; }
+        public OmniSharpOptions GetNamedOptions(string name)
+        {
+            return new OmniSharpOptions();
+        }
+    }
+}


### PR DESCRIPTION
This switches xunit arguments to be compatible with the new aspnet.xunit.runner.

`--test` becomes `-method`

I've also added a fixture `-class` command that we had in v1.

If you attempt to run a single test when the cursor is at the class level, then the fixture is ran instead.