### PR TITLE
don't use matcher when project pattern is **/project.json

### DIFF
--- a/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
+++ b/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
@@ -535,16 +535,24 @@ namespace OmniSharp.AspNet5
             }
             else
             {
+                IEnumerable<string> paths;
 #if ASPNET50
-                var matcher = new Matcher();
-                matcher.AddIncludePatterns(_options.AspNet5.Projects.Split(';'));
-
-                foreach (var path in matcher.GetResultsInFullPath(_env.Path))
+                if (_options.AspNet5.Projects != "**/project.json")
+                {
+                    var matcher = new Matcher();
+                    matcher.AddIncludePatterns(_options.AspNet5.Projects.Split(';'));
+                    paths = matcher.GetResultsInFullPath(_env.Path);
+                }
+                else
+                {
+                    paths = Directory.EnumerateFiles(_env.Path, "project.json", SearchOption.AllDirectories);
+                }
 #else
                 // The matcher works on CoreCLR but Omnisharp still targets aspnetcore50 instead of
                 // dnxcore50
-                foreach (var path in Directory.EnumerateFiles(_env.Path, "project.json", SearchOption.AllDirectories))
+                paths = Directory.EnumerateFiles(_env.Path, "project.json", SearchOption.AllDirectories);
 #endif 
+                foreach (var path in paths)
                 {
                     string projectFile = null;
                     


### PR DESCRIPTION
This PR is a pragmatic fix for #174 as it doesn't use the Matcher when the project pattern is ```**/project.json``` which is the default. If you author that flag you are supposed to know what you are doing but the default behaviour should not crash OmniSharp