### PR TITLE
Added /stopserver. Kestrel throws exception

### DIFF
--- a/src/OmniSharp/Api/Server/OmnisharpController.cs
+++ b/src/OmniSharp/Api/Server/OmnisharpController.cs
@@ -3,18 +3,18 @@ using Microsoft.Framework.Runtime;
 
 namespace OmniSharp.Api.Server
 {
-	public partial class OmnisharpController : Controller
-	{
-		protected readonly IApplicationShutdown _applicationShutdown;
-		public OmnisharpController(IApplicationShutdown applicationShutdown)
-		{
-			_applicationShutdown = applicationShutdown;
-		}
+    public partial class OmnisharpController : Controller
+    {
+        protected readonly IApplicationShutdown _applicationShutdown;
+        public OmnisharpController(IApplicationShutdown applicationShutdown)
+        {
+            _applicationShutdown = applicationShutdown;
+        }
 
-		[HttpPost("/stopserver")]
-		public void StopServer()
-		{
-			_applicationShutdown.RequestShutdown();
-		}
-	}
+        [HttpPost("/stopserver")]
+        public void StopServer()
+        {
+            _applicationShutdown.RequestShutdown();
+        }
+    }
 }

--- a/src/OmniSharp/Api/Server/OmnisharpController.cs
+++ b/src/OmniSharp/Api/Server/OmnisharpController.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNet.Mvc;
+using Microsoft.Framework.Runtime;
+
+namespace OmniSharp.Api.Server
+{
+	public partial class OmnisharpController : Controller
+	{
+		protected readonly IApplicationShutdown _applicationShutdown;
+		public OmnisharpController(IApplicationShutdown applicationShutdown)
+		{
+			_applicationShutdown = applicationShutdown;
+		}
+
+		[HttpPost("/stopserver")]
+		public void StopServer()
+		{
+			_applicationShutdown.RequestShutdown();
+		}
+	}
+}


### PR DESCRIPTION
Probably WIP because of Kestrel bug.

Add gist @cubitouch, updated to POST instead of GET from #16.

This does shut down the DTH, but Kestrel throws an exception:

```
System.NullReferenceException was unhandled
Message: An unhandled exception of type 'System.NullReferenceException' occurred in Microsoft.AspNet.Server.Kestrel.dll
Additional information: Object reference not set to an instance of an object.
```

Update #29 when merged...