### PR TITLE
Add support for language services for scriptcs

### DIFF
--- a/src/OmniSharp/Api/Diagnostics/OmnisharpController.Diagnostics.cs
+++ b/src/OmniSharp/Api/Diagnostics/OmnisharpController.Diagnostics.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
@@ -21,8 +22,14 @@ namespace OmniSharp
             foreach (var document in documents)
             {
                 var semanticModel = await document.GetSemanticModelAsync();
+                IEnumerable<Diagnostic> diagnostics = semanticModel.GetDiagnostics();
 
-                foreach (var quickFix in semanticModel.GetDiagnostics().Select(MakeQuickFix))
+                if (document.SourceCodeKind != SourceCodeKind.Regular)
+                {
+                    diagnostics = diagnostics.Where(diagnostic => diagnostic.Id != "CS1024");
+                }
+
+                foreach (var quickFix in diagnostics.Select(MakeQuickFix))
                 {
                     var existingQuickFix = quickFixes.FirstOrDefault(q => q.Equals(quickFix));
                     if (existingQuickFix == null)

--- a/src/OmniSharp/Api/ProjectSystem/OmnisharpController.ProjectSystem.cs
+++ b/src/OmniSharp/Api/ProjectSystem/OmnisharpController.ProjectSystem.cs
@@ -2,6 +2,7 @@
 using OmniSharp.AspNet5;
 using OmniSharp.Models;
 using OmniSharp.MSBuild;
+using OmniSharp.ScriptCs;
 
 namespace OmniSharp
 {
@@ -10,11 +11,14 @@ namespace OmniSharp
         private readonly AspNet5Context _aspnet5Context;
         private readonly OmnisharpWorkspace _workspace;
         private readonly MSBuildContext _msbuildContext;
+        private readonly ScriptCsContext _scriptCsContext;
 
-        public ProjectSystemController(AspNet5Context aspnet5Context, MSBuildContext msbuildContext, OmnisharpWorkspace workspace)
+        public ProjectSystemController(AspNet5Context aspnet5Context, MSBuildContext msbuildContext, ScriptCsContext scriptCsContext,
+            OmnisharpWorkspace workspace)
         {
             _aspnet5Context = aspnet5Context;
             _msbuildContext = msbuildContext;
+            _scriptCsContext = scriptCsContext;
             _workspace = workspace;
         }
 
@@ -25,7 +29,8 @@ namespace OmniSharp
             return new WorkspaceInformationResponse
             {
                 MSBuild = new MsBuildWorkspaceInformation(_msbuildContext),
-                AspNet5 = new AspNet5WorkspaceInformation(_aspnet5Context)
+                AspNet5 = new AspNet5WorkspaceInformation(_aspnet5Context),
+                ScriptCs = _scriptCsContext
             };
         }
 
@@ -44,6 +49,7 @@ namespace OmniSharp
             {
                 msBuildProjectItem = new MSBuildProject(msBuildContextProject);
             }
+
             if (aspNet5ContextProject != null)
             {
                 aspNet5ProjectItem = new AspNet5Project(aspNet5ContextProject);

--- a/src/OmniSharp/MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp/MSBuild/MSBuildProjectSystem.cs
@@ -12,9 +12,66 @@ using Microsoft.Framework.Logging;
 using OmniSharp.Models;
 using OmniSharp.MSBuild.ProjectFile;
 using OmniSharp.Services;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Reflection;
 
 namespace OmniSharp.MSBuild
 {
+    public class ScriptCsProjectSystem : IProjectSystem
+    {
+        private readonly OmnisharpWorkspace _workspace;
+        private readonly IOmnisharpEnvironment _env;
+        private readonly ILogger _logger;
+
+        public ScriptCsProjectSystem(OmnisharpWorkspace workspace, IOmnisharpEnvironment env, ILoggerFactory loggerFactory)
+        {
+            _workspace = workspace;
+            _env = env;
+            _logger = loggerFactory.Create<ScriptCsProjectSystem>();
+        }
+
+        public void Initalize()
+        {
+            var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.Parse,
+                SourceCodeKind.Script, null);
+            var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+
+            _logger.WriteInformation(string.Format("Detecting CSX files in '{0}'.", _env.Path));
+            var csxPath = Directory.GetFiles(_env.Path, "*.csx").FirstOrDefault();
+            if (csxPath != null)
+            {
+                _logger.WriteInformation(string.Format("Using CSX files at '{0}'.", csxPath));
+
+                using (var stream = File.OpenRead(csxPath))
+                using (var reader = new StreamReader(stream))
+                {
+                    var csxFileName = Path.GetFileName(csxPath);
+                    var csxFile = reader.ReadToEnd();
+                    var projectId = ProjectId.CreateNewId("ScriptCs");
+                    var documentId = DocumentId.CreateNewId(projectId, csxFileName);
+
+                    var mscorlib = MetadataReference.CreateFromAssembly(typeof(object).GetTypeInfo().Assembly);
+                    var systemCore = MetadataReference.CreateFromAssembly(typeof(Enumerable).GetTypeInfo().Assembly);
+                    var references = new[] { mscorlib, systemCore };
+
+                    var project = ProjectInfo.Create(projectId, VersionStamp.Create(), "ScriptCs", "ScriptCs.dll", LanguageNames.CSharp, null, null,
+                                                            compilationOptions, parseOptions, null, null, references, null, null, true, null); //todo add refs & host object
+                    _workspace.AddProject(project);
+
+                    var documentInfo = DocumentInfo.Create(documentId, csxFileName, null, SourceCodeKind.Script, null, csxPath)
+                            //var documentInfo = DocumentInfo.Create(documentId, csxFileName)
+                            .WithSourceCodeKind(SourceCodeKind.Script)
+                           .WithTextLoader(TextLoader.From(TextAndVersion.Create(SourceText.From(csxFile), VersionStamp.Create())));
+                    _workspace.AddDocument(documentInfo);
+                }
+            }
+            else
+            {
+                _logger.WriteError("Could not find CSX files");
+            }
+        }
+    }
+
     public class MSBuildProjectSystem : IProjectSystem
     {
         private readonly OmnisharpWorkspace _workspace;

--- a/src/OmniSharp/MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp/MSBuild/MSBuildProjectSystem.cs
@@ -12,8 +12,6 @@ using Microsoft.Framework.Logging;
 using OmniSharp.Models;
 using OmniSharp.MSBuild.ProjectFile;
 using OmniSharp.Services;
-using Microsoft.CodeAnalysis.CSharp;
-using System.Reflection;
 
 namespace OmniSharp.MSBuild
 {

--- a/src/OmniSharp/MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp/MSBuild/MSBuildProjectSystem.cs
@@ -17,61 +17,6 @@ using System.Reflection;
 
 namespace OmniSharp.MSBuild
 {
-    public class ScriptCsProjectSystem : IProjectSystem
-    {
-        private readonly OmnisharpWorkspace _workspace;
-        private readonly IOmnisharpEnvironment _env;
-        private readonly ILogger _logger;
-
-        public ScriptCsProjectSystem(OmnisharpWorkspace workspace, IOmnisharpEnvironment env, ILoggerFactory loggerFactory)
-        {
-            _workspace = workspace;
-            _env = env;
-            _logger = loggerFactory.Create<ScriptCsProjectSystem>();
-        }
-
-        public void Initalize()
-        {
-            var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.Parse,
-                SourceCodeKind.Script, null);
-            var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
-
-            _logger.WriteInformation(string.Format("Detecting CSX files in '{0}'.", _env.Path));
-            var csxPath = Directory.GetFiles(_env.Path, "*.csx").FirstOrDefault();
-            if (csxPath != null)
-            {
-                _logger.WriteInformation(string.Format("Using CSX files at '{0}'.", csxPath));
-
-                using (var stream = File.OpenRead(csxPath))
-                using (var reader = new StreamReader(stream))
-                {
-                    var csxFileName = Path.GetFileName(csxPath);
-                    var csxFile = reader.ReadToEnd();
-                    var projectId = ProjectId.CreateNewId("ScriptCs");
-                    var documentId = DocumentId.CreateNewId(projectId, csxFileName);
-
-                    var mscorlib = MetadataReference.CreateFromAssembly(typeof(object).GetTypeInfo().Assembly);
-                    var systemCore = MetadataReference.CreateFromAssembly(typeof(Enumerable).GetTypeInfo().Assembly);
-                    var references = new[] { mscorlib, systemCore };
-
-                    var project = ProjectInfo.Create(projectId, VersionStamp.Create(), "ScriptCs", "ScriptCs.dll", LanguageNames.CSharp, null, null,
-                                                            compilationOptions, parseOptions, null, null, references, null, null, true, null); //todo add refs & host object
-                    _workspace.AddProject(project);
-
-                    var documentInfo = DocumentInfo.Create(documentId, csxFileName, null, SourceCodeKind.Script, null, csxPath)
-                            //var documentInfo = DocumentInfo.Create(documentId, csxFileName)
-                            .WithSourceCodeKind(SourceCodeKind.Script)
-                           .WithTextLoader(TextLoader.From(TextAndVersion.Create(SourceText.From(csxFile), VersionStamp.Create())));
-                    _workspace.AddDocument(documentInfo);
-                }
-            }
-            else
-            {
-                _logger.WriteError("Could not find CSX files");
-            }
-        }
-    }
-
     public class MSBuildProjectSystem : IProjectSystem
     {
         private readonly OmnisharpWorkspace _workspace;

--- a/src/OmniSharp/Models/WorkspaceInformationResponse.cs
+++ b/src/OmniSharp/Models/WorkspaceInformationResponse.cs
@@ -1,8 +1,11 @@
-﻿namespace OmniSharp.Models
+﻿using OmniSharp.ScriptCs;
+
+namespace OmniSharp.Models
 {
     public class WorkspaceInformationResponse
     {
         public AspNet5WorkspaceInformation AspNet5 { get; set; }
         public MsBuildWorkspaceInformation MSBuild { get; set; }
+        public ScriptCsContext ScriptCs { get; set; }
     }
 }

--- a/src/OmniSharp/Roslyn/ProjectEventForwarder.cs
+++ b/src/OmniSharp/Roslyn/ProjectEventForwarder.cs
@@ -104,7 +104,7 @@ namespace OmniSharp.Roslyn
 
             public override int GetHashCode()
             {
-                return EventType.GetHashCode() * 23 + FileName.GetHashCode();
+                return EventType?.GetHashCode() * 23 + FileName?.GetHashCode() ?? 0;
             }
         }
     }

--- a/src/OmniSharp/ScriptCs/NullScriptEngine.cs
+++ b/src/OmniSharp/ScriptCs/NullScriptEngine.cs
@@ -1,0 +1,21 @@
+﻿#if ASPNET50
+using ScriptCs.Contracts;
+using System.Collections.Generic;
+
+namespace OmniSharp.ScriptCs
+{
+    public class NullScriptEngine : IScriptEngine
+    {
+        public string BaseDirectory { get; set; }
+
+        public string CacheDirectory { get; set; }
+
+        public string FileName { get; set; }
+
+        public ScriptResult Execute(string code, string[] scriptArgs, AssemblyReferences references, IEnumerable<string> namespaces, ScriptPackSession scriptPackSession)
+        {
+            return new ScriptResult();
+        }
+    }
+}
+#endif

--- a/src/OmniSharp/ScriptCs/ScriptCsContext.cs
+++ b/src/OmniSharp/ScriptCs/ScriptCsContext.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace OmniSharp.ScriptCs
+{
+    public class ScriptCsContext
+    {
+        public HashSet<string> CsxFiles { get; } = new HashSet<string>();
+        public HashSet<string> References { get; } = new HashSet<string>();
+        public HashSet<string> Usings { get; } = new HashSet<string>();
+        public HashSet<string> ScriptPacks { get; } = new HashSet<string>();
+
+        public string Path { get; set; }
+    }
+}

--- a/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
+++ b/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿#if ASPNET50
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Framework.Logging;
@@ -6,6 +7,10 @@ using OmniSharp.Services;
 using System.Reflection;
 using System.IO;
 using System.Linq;
+using ScriptCs;
+using Common.Logging;
+using ScriptCs.Contracts;
+using System.Collections.Generic;
 
 namespace OmniSharp.ScriptCs
 {
@@ -24,43 +29,81 @@ namespace OmniSharp.ScriptCs
 
         public void Initalize()
         {
-            var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.Parse,
-                SourceCodeKind.Script, null);
-            var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
-
             _logger.WriteInformation(string.Format("Detecting CSX files in '{0}'.", _env.Path));
-            var csxPath = Directory.GetFiles(_env.Path, "*.csx").FirstOrDefault();
+
+            //temp hack, only work with files like foo.csx - starting with F
+            var csxPath = Directory.GetFiles(_env.Path, "*.csx").FirstOrDefault(x => Path.GetFileName(x).StartsWith("f"));
             if (csxPath != null)
             {
                 _logger.WriteInformation(string.Format("Using CSX files at '{0}'.", csxPath));
 
-                using (var stream = File.OpenRead(csxPath))
-                using (var reader = new StreamReader(stream))
+                var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.Parse,
+    SourceCodeKind.Script, null);
+                var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+
+                var fs = new FileSystem();
+                var scriptCsPreProcessor = new FilePreProcessor(fs, LogManager.GetCurrentClassLogger(), new ILineProcessor[] {
+                        new LoadLineProcessor(fs),
+                        new UsingLineProcessor(),
+                        new ReferenceLineProcessor(fs)
+                    });
+
+                var processResult = scriptCsPreProcessor.ProcessFile(csxPath);
+
+                var mscorlib = MetadataReference.CreateFromAssembly(typeof(object).GetTypeInfo().Assembly);
+                var systemCore = MetadataReference.CreateFromAssembly(typeof(Enumerable).GetTypeInfo().Assembly);
+                var references = new List<MetadataReference> { mscorlib, systemCore };
+
+                var baseAssemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
+                foreach (var importedReference in processResult.References)
                 {
-                    var csxFileName = Path.GetFileName(csxPath);
-                    var csxFile = reader.ReadToEnd();
-                    var projectId = ProjectId.CreateNewId("ScriptCs");
-                    var documentId = DocumentId.CreateNewId(projectId, csxFileName);
-
-                    var mscorlib = MetadataReference.CreateFromAssembly(typeof(object).GetTypeInfo().Assembly);
-                    var systemCore = MetadataReference.CreateFromAssembly(typeof(Enumerable).GetTypeInfo().Assembly);
-                    var references = new[] { mscorlib, systemCore };
-
-                    var project = ProjectInfo.Create(projectId, VersionStamp.Create(), "ScriptCs", "ScriptCs.dll", LanguageNames.CSharp, null, null,
-                                                            compilationOptions, parseOptions, null, null, references, null, null, true, null); //todo add refs & host object
-                    _workspace.AddProject(project);
-
-                    var documentInfo = DocumentInfo.Create(documentId, csxFileName, null, SourceCodeKind.Script, null, csxPath)
-                            //var documentInfo = DocumentInfo.Create(documentId, csxFileName)
-                            .WithSourceCodeKind(SourceCodeKind.Script)
-                           .WithTextLoader(TextLoader.From(TextAndVersion.Create(SourceText.From(csxFile), VersionStamp.Create())));
-                    _workspace.AddDocument(documentInfo);
+                    if (fs.FileExists(importedReference))
+                    {
+                        references.Add(MetadataReference.CreateFromFile(importedReference));
+                    }
+                    else
+                    {
+                        references.Add(MetadataReference.CreateFromFile(Path.Combine(baseAssemblyPath, importedReference.ToLower().EndsWith(".dll") ? importedReference : importedReference + ".dll")));
+                    }
                 }
+
+                var projectId = ProjectId.CreateNewId("ScriptCs");
+                var project = ProjectInfo.Create(projectId, VersionStamp.Create(), "ScriptCs", "ScriptCs.dll", LanguageNames.CSharp, null, null,
+                                                        compilationOptions, parseOptions, null, null, references, null, null, true, null); //todo add refs & host object
+                _workspace.AddProject(project);
+
+                AddFile(csxPath, projectId);
+
+                //foreach (var filePath in processResult.LoadedScripts.Distinct())
+                //{
+                //    AddFile(filePath, projectId);
+                //}
             }
             else
             {
                 _logger.WriteError("Could not find CSX files");
             }
         }
+
+        private void AddFile(string filePath, ProjectId projectId)
+        {
+
+            using (var stream = File.OpenRead(filePath))
+            using (var reader = new StreamReader(stream))
+            {
+                var fileName = Path.GetFileName(filePath);
+                var csxFile = reader.ReadToEnd();
+
+                var documentId = DocumentId.CreateNewId(projectId, fileName);
+                var documentInfo = DocumentInfo.Create(documentId, fileName, null, SourceCodeKind.Script, null, filePath)
+        .WithSourceCodeKind(SourceCodeKind.Script)
+       .WithTextLoader(TextLoader.From(TextAndVersion.Create(SourceText.From(csxFile), VersionStamp.Create())));
+                _workspace.AddDocument(documentInfo);
+
+            }
+
+
+        }
     }
 }
+#endif

--- a/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
+++ b/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Framework.Logging;
+using OmniSharp.Services;
+using System.Reflection;
+using System.IO;
+using System.Linq;
+
+namespace OmniSharp.ScriptCs
+{
+    public class ScriptCsProjectSystem : IProjectSystem
+    {
+        private readonly OmnisharpWorkspace _workspace;
+        private readonly IOmnisharpEnvironment _env;
+        private readonly ILogger _logger;
+
+        public ScriptCsProjectSystem(OmnisharpWorkspace workspace, IOmnisharpEnvironment env, ILoggerFactory loggerFactory)
+        {
+            _workspace = workspace;
+            _env = env;
+            _logger = loggerFactory.Create<ScriptCsProjectSystem>();
+        }
+
+        public void Initalize()
+        {
+            var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.Parse,
+                SourceCodeKind.Script, null);
+            var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+
+            _logger.WriteInformation(string.Format("Detecting CSX files in '{0}'.", _env.Path));
+            var csxPath = Directory.GetFiles(_env.Path, "*.csx").FirstOrDefault();
+            if (csxPath != null)
+            {
+                _logger.WriteInformation(string.Format("Using CSX files at '{0}'.", csxPath));
+
+                using (var stream = File.OpenRead(csxPath))
+                using (var reader = new StreamReader(stream))
+                {
+                    var csxFileName = Path.GetFileName(csxPath);
+                    var csxFile = reader.ReadToEnd();
+                    var projectId = ProjectId.CreateNewId("ScriptCs");
+                    var documentId = DocumentId.CreateNewId(projectId, csxFileName);
+
+                    var mscorlib = MetadataReference.CreateFromAssembly(typeof(object).GetTypeInfo().Assembly);
+                    var systemCore = MetadataReference.CreateFromAssembly(typeof(Enumerable).GetTypeInfo().Assembly);
+                    var references = new[] { mscorlib, systemCore };
+
+                    var project = ProjectInfo.Create(projectId, VersionStamp.Create(), "ScriptCs", "ScriptCs.dll", LanguageNames.CSharp, null, null,
+                                                            compilationOptions, parseOptions, null, null, references, null, null, true, null); //todo add refs & host object
+                    _workspace.AddProject(project);
+
+                    var documentInfo = DocumentInfo.Create(documentId, csxFileName, null, SourceCodeKind.Script, null, csxPath)
+                            //var documentInfo = DocumentInfo.Create(documentId, csxFileName)
+                            .WithSourceCodeKind(SourceCodeKind.Script)
+                           .WithTextLoader(TextLoader.From(TextAndVersion.Create(SourceText.From(csxFile), VersionStamp.Create())));
+                    _workspace.AddDocument(documentInfo);
+                }
+            }
+            else
+            {
+                _logger.WriteError("Could not find CSX files");
+            }
+        }
+    }
+}

--- a/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
+++ b/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
@@ -1,22 +1,21 @@
 ﻿#if ASPNET50
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Common.Logging;
+using Common.Logging.Simple;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Framework.Logging;
 using OmniSharp.Services;
-using System.Reflection;
-using System.IO;
-using System.Linq;
 using ScriptCs;
-using Common.Logging;
 using ScriptCs.Contracts;
-using System.Collections.Generic;
+using ScriptCs.Contracts.Exceptions;
 using ScriptCs.Hosting;
 using LogLevel = ScriptCs.Contracts.LogLevel;
-using System;
-using Common.Logging.Simple;
-using Autofac;
-using ScriptCs.Contracts.Exceptions;
 
 namespace OmniSharp.ScriptCs
 {
@@ -49,10 +48,6 @@ namespace OmniSharp.ScriptCs
 
             _logger.WriteInformation($"Found {allCsxFiles.Length} CSX files.");
             LogManager.Adapter = new ConsoleOutLoggerFactoryAdapter();
-
-            //todo: initialize assembly redirects or not?
-            //var initializationServices = new InitializationServices(scriptcsLogger);
-            //initializationServices.GetAppDomainAssemblyResolver().Initialize();
 
             //script name is added here as a fake one (dir path not even a real file); this is OK though -> it forces MEF initialization
             var scriptServicesBuilder = new ScriptServicesBuilder(new ScriptConsole(), LogManager.GetCurrentClassLogger()).

--- a/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
+++ b/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
@@ -38,7 +38,7 @@ namespace OmniSharp.ScriptCs
                 _logger.WriteInformation(string.Format("Using CSX files at '{0}'.", csxPath));
 
                 var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.Parse,
-    SourceCodeKind.Script, null);
+    SourceCodeKind.Script);
                 var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
 
                 var fs = new FileSystem();
@@ -52,7 +52,8 @@ namespace OmniSharp.ScriptCs
 
                 var mscorlib = MetadataReference.CreateFromAssembly(typeof(object).GetTypeInfo().Assembly);
                 var systemCore = MetadataReference.CreateFromAssembly(typeof(Enumerable).GetTypeInfo().Assembly);
-                var references = new List<MetadataReference> { mscorlib, systemCore };
+                var scriptcsContracts = MetadataReference.CreateFromAssembly(typeof(IScriptHost).Assembly);
+                var references = new List<MetadataReference> { mscorlib, systemCore, scriptcsContracts };
 
                 var baseAssemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
                 foreach (var importedReference in processResult.References)
@@ -69,7 +70,7 @@ namespace OmniSharp.ScriptCs
 
                 var projectId = ProjectId.CreateNewId("ScriptCs");
                 var project = ProjectInfo.Create(projectId, VersionStamp.Create(), "ScriptCs", "ScriptCs.dll", LanguageNames.CSharp, null, null,
-                                                        compilationOptions, parseOptions, null, null, references, null, null, true, null); //todo add refs & host object
+                                                        compilationOptions, parseOptions, null, null, references, null, null, true, typeof(IScriptHost)); //todo add refs & host object
                 _workspace.AddProject(project);
 
                 AddFile(csxPath, projectId);

--- a/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
+++ b/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
@@ -11,14 +11,49 @@ using ScriptCs;
 using Common.Logging;
 using ScriptCs.Contracts;
 using System.Collections.Generic;
+using ScriptCs.Hosting;
+using LogLevel = ScriptCs.Contracts.LogLevel;
+using System;
+using Common.Logging.Simple;
+using Autofac;
 
 namespace OmniSharp.ScriptCs
 {
+    public class NullScriptEngine : IScriptEngine
+    {
+        public string BaseDirectory
+        {
+            get;
+
+            set;
+        }
+
+        public string CacheDirectory
+        {
+            get;
+
+            set;
+        }
+
+        public string FileName
+        {
+            get;
+            set;
+        }
+
+        public ScriptResult Execute(string code, string[] scriptArgs, AssemblyReferences references, IEnumerable<string> namespaces, ScriptPackSession scriptPackSession)
+        {
+            return new ScriptResult();
+        }
+    }
+
     public class ScriptCsProjectSystem : IProjectSystem
     {
+        private static string baseAssemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
         private readonly OmnisharpWorkspace _workspace;
         private readonly IOmnisharpEnvironment _env;
         private readonly ILogger _logger;
+        private ScriptServices _scriptServices;
 
         public ScriptCsProjectSystem(OmnisharpWorkspace workspace, IOmnisharpEnvironment env, ILoggerFactory loggerFactory)
         {
@@ -37,36 +72,74 @@ namespace OmniSharp.ScriptCs
             {
                 _logger.WriteInformation(string.Format("Using CSX files at '{0}'.", csxPath));
 
-                var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.Parse,
-    SourceCodeKind.Script);
-                var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+                LogManager.Adapter = new ConsoleOutLoggerFactoryAdapter();
+                var scriptcsLogger = LogManager.GetCurrentClassLogger();
 
-                var fs = new FileSystem();
-                var scriptCsPreProcessor = new FilePreProcessor(fs, LogManager.GetCurrentClassLogger(), new ILineProcessor[] {
-                        new LoadLineProcessor(fs),
-                        new UsingLineProcessor(),
-                        new ReferenceLineProcessor(fs)
-                    });
+                //var initializationServices = new InitializationServices(scriptcsLogger);
+                //initializationServices.GetAppDomainAssemblyResolver().Initialize();
 
-                var processResult = scriptCsPreProcessor.ProcessFile(csxPath);
+                var scriptServicesBuilder = new ScriptServicesBuilder(new ScriptConsole(), scriptcsLogger).
+                    LogLevel(LogLevel.Info).Cache(false).Repl(false).ScriptName(csxPath).ScriptEngine<NullScriptEngine>();
+
+                                _scriptServices = scriptServicesBuilder.Build();
+
+
+                var runtimeField = typeof(ScriptServicesBuilder).GetField("_runtimeServices", BindingFlags.NonPublic |
+                                              BindingFlags.Instance);
+                var autofacContainer = ((RuntimeServices)runtimeField.GetValue(scriptServicesBuilder)).Container;
 
                 var mscorlib = MetadataReference.CreateFromAssembly(typeof(object).GetTypeInfo().Assembly);
                 var systemCore = MetadataReference.CreateFromAssembly(typeof(Enumerable).GetTypeInfo().Assembly);
                 var scriptcsContracts = MetadataReference.CreateFromAssembly(typeof(IScriptHost).Assembly);
                 var references = new List<MetadataReference> { mscorlib, systemCore, scriptcsContracts };
+                var usings = new List<string>();
 
-                var baseAssemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
-                foreach (var importedReference in processResult.References)
-                {
-                    if (fs.FileExists(importedReference))
-                    {
-                        references.Add(MetadataReference.CreateFromFile(importedReference));
-                    }
-                    else
-                    {
-                        references.Add(MetadataReference.CreateFromFile(Path.Combine(baseAssemblyPath, importedReference.ToLower().EndsWith(".dll") ? importedReference : importedReference + ".dll")));
-                    }
-                }
+                var processResult = _scriptServices.FilePreProcessor.ProcessFile(csxPath);
+
+                //file usings
+                usings.AddRange(processResult.Namespaces);
+
+                //#r references
+                ImportReferences(references, processResult.References);
+
+                var assemblyPaths = _scriptServices.AssemblyResolver.GetAssemblyPaths(_env.Path);
+                //nuget references
+                ImportReferences(references, assemblyPaths);
+
+                //script packs
+                //var scriptPacks = _scriptServices.ScriptPackResolver.GetPacks().ToList();
+                var scriptPackTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes()).
+                    Where(t => t.GetInterfaces().Any(i => i.FullName == "ScriptCs.Contracts.IScriptPack")).ToArray();
+
+                usings.AddRange(scriptPackTypes.Select(x => x.Namespace));
+
+                //foreach (var scriptPackType in scriptPackTypes)
+                //{
+                //    try
+                //    {
+                //        scriptPacks.Add(Activator.CreateInstance(scriptPackType) as IScriptPack);
+                //    }
+                //    catch (Exception e)
+                //    {
+                //        scriptcsLogger.Error("Error activiatig script pack", e);
+                //    }
+                //}
+
+                //if (scriptPacks != null && scriptPacks.Any())
+                //{
+                //    var scriptPackSession = new ScriptPackSession(scriptPacks, new string[0]);
+                //    scriptPackSession.InitializePacks();
+
+                //    //script pack references
+                //    ImportReferences(references, scriptPackSession.References);
+
+                //    //script pack usings
+                //    usings.AddRange(scriptPackSession.Namespaces);
+                //}
+
+                var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp6, DocumentationMode.Parse,
+SourceCodeKind.Script);
+                var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, usings: usings.Distinct());
 
                 var projectId = ProjectId.CreateNewId("ScriptCs");
                 var project = ProjectInfo.Create(projectId, VersionStamp.Create(), "ScriptCs", "ScriptCs.dll", LanguageNames.CSharp, null, null,
@@ -86,9 +159,24 @@ namespace OmniSharp.ScriptCs
             }
         }
 
+        private void ImportReferences(List<MetadataReference> listOfReferences, IEnumerable<string> referencesToImport)
+        {
+            foreach (var importedReference in referencesToImport)
+            {
+                if (_scriptServices.FileSystem.IsPathRooted(importedReference))
+                {
+                    if (_scriptServices.FileSystem.FileExists(importedReference))
+                        listOfReferences.Add(MetadataReference.CreateFromFile(importedReference));
+                }
+                else
+                {
+                    listOfReferences.Add(MetadataReference.CreateFromFile(Path.Combine(baseAssemblyPath, importedReference.ToLower().EndsWith(".dll") ? importedReference : importedReference + ".dll")));
+                }
+            }
+        }
+
         private void AddFile(string filePath, ProjectId projectId)
         {
-
             using (var stream = File.OpenRead(filePath))
             using (var reader = new StreamReader(stream))
             {
@@ -100,10 +188,7 @@ namespace OmniSharp.ScriptCs
         .WithSourceCodeKind(SourceCodeKind.Script)
        .WithTextLoader(TextLoader.From(TextAndVersion.Create(SourceText.From(csxFile), VersionStamp.Create())));
                 _workspace.AddDocument(documentInfo);
-
             }
-
-
         }
     }
 }

--- a/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
+++ b/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
@@ -141,15 +141,21 @@ SourceCodeKind.Script);
 
                 var projectId = ProjectId.CreateNewId("ScriptCs");
                 var project = ProjectInfo.Create(projectId, VersionStamp.Create(), "ScriptCs", "ScriptCs.dll", LanguageNames.CSharp, null, null,
-                                                        compilationOptions, parseOptions, null, null, references, null, null, true, typeof(IScriptHost)); //todo add refs & host object
+                                                        compilationOptions, parseOptions, null, null, references, null, null, true, typeof(IScriptHost));
                 _workspace.AddProject(project);
 
                 AddFile(csxPath, projectId);
 
-                //foreach (var filePath in processResult.LoadedScripts.Distinct())
-                //{
-                //    AddFile(filePath, projectId);
-                //}
+                foreach (var filePath in processResult.LoadedScripts.Distinct().Except(new[] { csxPath }))
+                {
+                    var loadedFileProjectId = ProjectId.CreateNewId(Guid.NewGuid().ToString());
+                    var loadedFileSubmissionProject = ProjectInfo.Create(loadedFileProjectId, VersionStamp.Create(), "ScriptCs", "ScriptCs.dll", LanguageNames.CSharp, null, null,
+                                        compilationOptions, parseOptions, null, null, references, null, null, true, typeof(IScriptHost));
+
+                    _workspace.AddProject(loadedFileSubmissionProject);
+                    AddFile(filePath, loadedFileProjectId);
+                    _workspace.AddProjectReference(projectId, new ProjectReference(loadedFileProjectId));
+                }
             }
             else
             {

--- a/src/OmniSharp/Startup.cs
+++ b/src/OmniSharp/Startup.cs
@@ -16,6 +16,7 @@ using OmniSharp.Middleware;
 using OmniSharp.MSBuild;
 using OmniSharp.Options;
 using OmniSharp.Roslyn;
+using OmniSharp.ScriptCs;
 using OmniSharp.Services;
 using OmniSharp.Settings;
 using OmniSharp.Stdio.Logging;

--- a/src/OmniSharp/Startup.cs
+++ b/src/OmniSharp/Startup.cs
@@ -76,12 +76,13 @@ namespace OmniSharp
             // Add the project systems
             services.AddInstance(new AspNet5Context());
             services.AddInstance(new MSBuildContext());
+            services.AddInstance(new ScriptCs.ScriptCsContext());
 
             services.AddSingleton<IProjectSystem, AspNet5ProjectSystem>();
             services.AddSingleton<IProjectSystem, MSBuildProjectSystem>();
 
 #if ASPNET50
-            services.AddSingleton<IProjectSystem, OmniSharp.ScriptCs.ScriptCsProjectSystem>();
+            services.AddSingleton<IProjectSystem, ScriptCs.ScriptCsProjectSystem>();
 #endif
 
             // Add the file watcher

--- a/src/OmniSharp/Startup.cs
+++ b/src/OmniSharp/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.AspNet.Builder;
@@ -79,6 +79,7 @@ namespace OmniSharp
 
             services.AddSingleton<IProjectSystem, AspNet5ProjectSystem>();
             services.AddSingleton<IProjectSystem, MSBuildProjectSystem>();
+            services.AddSingleton<IProjectSystem, ScriptCsProjectSystem>();
 
             // Add the file watcher
             services.AddSingleton<IFileSystemWatcher, ManualFileSystemWatcher>();

--- a/src/OmniSharp/Startup.cs
+++ b/src/OmniSharp/Startup.cs
@@ -80,7 +80,10 @@ namespace OmniSharp
 
             services.AddSingleton<IProjectSystem, AspNet5ProjectSystem>();
             services.AddSingleton<IProjectSystem, MSBuildProjectSystem>();
-            services.AddSingleton<IProjectSystem, ScriptCsProjectSystem>();
+
+#if ASPNET50
+            services.AddSingleton<IProjectSystem, OmniSharp.ScriptCs.ScriptCsProjectSystem>();
+#endif
 
             // Add the file watcher
             services.AddSingleton<IFileSystemWatcher, ManualFileSystemWatcher>();

--- a/src/OmniSharp/Startup.cs
+++ b/src/OmniSharp/Startup.cs
@@ -16,7 +16,6 @@ using OmniSharp.Middleware;
 using OmniSharp.MSBuild;
 using OmniSharp.Options;
 using OmniSharp.Roslyn;
-using OmniSharp.ScriptCs;
 using OmniSharp.Services;
 using OmniSharp.Settings;
 using OmniSharp.Stdio.Logging;

--- a/src/OmniSharp/project.json
+++ b/src/OmniSharp/project.json
@@ -25,8 +25,8 @@
                "ScriptCs.Hosting.KpmTemp": "0.14.1"
             },
             "frameworkAssemblies": {
-				"System.Globalization": "",
-				"System.Reflection":  "",
+                "System.Globalization": "",
+                "System.Reflection":  "",
                 "Microsoft.Build": "",
                 "Microsoft.Build.Engine": "",
                 "Microsoft.Build.Framework": ""

--- a/src/OmniSharp/project.json
+++ b/src/OmniSharp/project.json
@@ -22,7 +22,7 @@
         "aspnet50": {
             "dependencies": {
                "ICSharpCode.NRefactory": "6.0.0-alpha3",  
-               "ScriptCs.Core": "0.13.2"
+               "ScriptCs.Hosting": "0.13.2"
             },
             "frameworkAssemblies": {
 				"System.Globalization": "",

--- a/src/OmniSharp/project.json
+++ b/src/OmniSharp/project.json
@@ -21,7 +21,8 @@
     "frameworks": {
         "aspnet50": {
             "dependencies": {
-               "ICSharpCode.NRefactory": "6.0.0-alpha3"  
+               "ICSharpCode.NRefactory": "6.0.0-alpha3",  
+               "ScriptCs.Core": "0.13.2"
             },
             "frameworkAssemblies": {
 				"System.Globalization": "",

--- a/src/OmniSharp/project.json
+++ b/src/OmniSharp/project.json
@@ -24,7 +24,8 @@
                "ICSharpCode.NRefactory": "6.0.0-alpha3"  
             },
             "frameworkAssemblies": {
-                "System.Globalization": "",
+				"System.Globalization": "",
+				"System.Reflection":  "",
                 "Microsoft.Build": "",
                 "Microsoft.Build.Engine": "",
                 "Microsoft.Build.Framework": ""

--- a/src/OmniSharp/project.json
+++ b/src/OmniSharp/project.json
@@ -22,7 +22,7 @@
         "aspnet50": {
             "dependencies": {
                "ICSharpCode.NRefactory": "6.0.0-alpha3",  
-               "ScriptCs.Hosting": "0.13.2"
+               "ScriptCs.Hosting.KpmTemp": "0.14.1"
             },
             "frameworkAssemblies": {
 				"System.Globalization": "",

--- a/tests/OmniSharp.Tests/CurrentProjectFacts.cs
+++ b/tests/OmniSharp.Tests/CurrentProjectFacts.cs
@@ -37,7 +37,7 @@ namespace OmniSharp.Tests
 
         private AspNet5Project GetProjectContainingSourceFile(string name)
         {
-            var controller = new ProjectSystemController(_context, null, _workspace);
+            var controller = new ProjectSystemController(_context, null, null, _workspace);
 
             var request = new Request
             {


### PR DESCRIPTION
This introduces a 3rd project system - `ScriptCsProjectSystem`. It's ifdef-ed since it will not work on Core.

It finds CSX files in the directory and uses scriptcs assemblies to retrieve all the necessary information about the runtime - what usings are in the context, what DLLs are references and all other scriptcs-specific things. 

It then creates scripting projects in the workspace. After that, all Omnisharp endpoints work normally against the incoming requests as if you were working with any other type of project.

Example:

![screenshot 2015-04-30 12 21 08](https://cloud.githubusercontent.com/assets/1710369/7411164/a1a8240e-ef35-11e4-9cb5-78613db289f3.png)

Note: I currently suppress `CS1024` error for scriptcs projects - this is to prevent treating `#load` directive as error (which is valid in scriptcs). Roslyn will introduce it later too, so this is temporary.
