### PR TITLE
added comment about CS1024

### DIFF
--- a/src/OmniSharp/Api/Diagnostics/OmnisharpController.Diagnostics.cs
+++ b/src/OmniSharp/Api/Diagnostics/OmnisharpController.Diagnostics.cs
@@ -24,6 +24,8 @@ namespace OmniSharp
                 var semanticModel = await document.GetSemanticModelAsync();
                 IEnumerable<Diagnostic> diagnostics = semanticModel.GetDiagnostics();
 
+                //script files can have custom directives such as #load which will be deemed invalid by Roslyn
+                //we suppress the CS1024 diagnostic for script files for this reason. Roslyn will fix it later too, so this is temporary.
                 if (document.SourceCodeKind != SourceCodeKind.Regular)
                 {
                     diagnostics = diagnostics.Where(diagnostic => diagnostic.Id != "CS1024");


### PR DESCRIPTION
Added comment from PR #199 to the source code.

The `#load` directive, valid for script files (mentioned here https://github.com/dotnet/roslyn/issues/122) is currently not recognized by Roslyn so [CS1024](https://msdn.microsoft.com/en-us/library/ww43bwhw%28v=vs.90%29.aspx) need to be suppressed