### PR TITLE
Added exception handling to project initialization

### DIFF
--- a/src/OmniSharp/MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp/MSBuild/MSBuildProjectSystem.cs
@@ -87,7 +87,7 @@ namespace OmniSharp.MSBuild
                 }
             }
 
-            _logger.WriteInformation(string.Format("Detecting projects in '{0}'.", solutionFilePath));
+            _logger.WriteInformation($"Detecting projects in '{solutionFilePath}'.");
 
             foreach (var block in solutionFile.ProjectBlocks)
             {
@@ -107,7 +107,7 @@ namespace OmniSharp.MSBuild
 
                 var projectFilePath = Path.GetFullPath(Path.GetFullPath(Path.Combine(_env.Path, block.ProjectPath.Replace('\\', Path.DirectorySeparatorChar))));
 
-                _logger.WriteInformation(string.Format("Loading project from '{0}'.", projectFilePath));
+                _logger.WriteInformation($"Loading project from '{projectFilePath}'.");
 
                 var projectFileInfo = CreateProject(projectFilePath);
 
@@ -169,12 +169,12 @@ namespace OmniSharp.MSBuild
 
                 if (projectFileInfo == null)
                 {
-                    _logger.WriteWarning(string.Format("Failed to process project file '{0}'.", projectFilePath));
+                    _logger.WriteWarning($"Failed to process project file '{projectFilePath}'.");
                 }
             }
             catch (Exception ex)
             {
-                _logger.WriteWarning(string.Format("Failed to process project file '{0}'.", projectFilePath), ex);
+                _logger.WriteWarning($"Failed to process project file '{projectFilePath}'.", ex);
                 _emitter.Emit(EventTypes.Error, new ErrorMessage()
                 {
                     FileName = projectFilePath,
@@ -267,7 +267,7 @@ namespace OmniSharp.MSBuild
                 }
                 else
                 {
-                    _logger.WriteWarning(string.Format("Unable to resolve project reference '{0}' for '{1}'.", projectReferencePath, projectFileInfo.ProjectFilePath));
+                    _logger.WriteWarning($"Unable to resolve project reference '{projectReferencePath}' for '{projectFileInfo}'.");
                 }
             }
 
@@ -282,7 +282,7 @@ namespace OmniSharp.MSBuild
             {
                 if (!File.Exists(analyzerPath))
                 {
-                    _logger.WriteWarning(string.Format("Unable to resolve assembly '{0}'", analyzerPath));
+                    _logger.WriteWarning($"Unable to resolve assembly '{analyzerPath}'");
                 }
                 else
                 {
@@ -308,7 +308,7 @@ namespace OmniSharp.MSBuild
             {
                 if (!File.Exists(referencePath))
                 {
-                    _logger.WriteWarning(string.Format("Unable to resolve assembly '{0}'", referencePath));
+                    _logger.WriteWarning($"Unable to resolve assembly '{referencePath}'");
                 }
                 else
                 {
@@ -319,7 +319,7 @@ namespace OmniSharp.MSBuild
                         continue;
                     }
 
-                    _logger.WriteVerbose(string.Format("Adding reference '{0}' to '{1}'.", referencePath, projectFileInfo.ProjectFilePath));
+                    _logger.WriteVerbose($"Adding reference '{referencePath}' to '{projectFileInfo.ProjectFilePath}'.");
                     _workspace.AddMetadataReference(project.Id, metadataReference);
                 }
             }

--- a/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
+++ b/src/OmniSharp/ScriptCs/ScriptCsProjectSystem.cs
@@ -5,16 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Common.Logging;
-using Common.Logging.Simple;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Framework.Logging;
-using OmniSharp.MSBuild.ProjectFile;
 using OmniSharp.Services;
 using ScriptCs;
 using ScriptCs.Contracts;
-using ScriptCs.Contracts.Exceptions;
 using ScriptCs.Hosting;
 using LogLevel = ScriptCs.Contracts.LogLevel;
 
@@ -134,9 +131,9 @@ namespace OmniSharp.ScriptCs
                     }
 
                 }
-                catch (InvalidDirectiveUseException ex)
+                catch (Exception ex)
                 {
-                    _logger.WriteError($"{csxPath} will be ignored due to the following error: {ex.Message}", ex);
+                    _logger.WriteError($"{csxPath} will be ignored due to the following error:", ex);
                 }
             }
         }

--- a/src/OmniSharp/Startup.cs
+++ b/src/OmniSharp/Startup.cs
@@ -151,18 +151,11 @@ namespace OmniSharp
 
             // Initialize everything!
             var projectSystems = app.ApplicationServices.GetRequiredService<IEnumerable<IProjectSystem>>();
-
-            var successfullyInitialized = false;
             foreach (var projectSystem in projectSystems)
             {
                 try
                 {
                     projectSystem.Initalize();
-
-                    if (!successfullyInitialized)
-                    {
-                        successfullyInitialized = true;
-                    }
                 }
                 catch (Exception e)
                 {
@@ -170,12 +163,6 @@ namespace OmniSharp
                     //it should not crash the entire server
                     logger.WriteError($"The project system '{projectSystem.GetType().Name}' threw an exception.", e);
                 }
-            }
-
-            if (!successfullyInitialized)
-            {
-                logger.WriteInformation("None of the project systems produced a result");
-                return;
             }
 
             // Mark the workspace as initialized


### PR DESCRIPTION
 - wrapped the call to `Initialize()` on project system collection in try/catch since any unhandled exception that spills from project systems (file IO but also other) will crash the server. now at least other project systems have a chance to take over
 
 - before, the only CSX exception handled was `InvalidDirectiveUseException`, but really any exception should be caught, and the processing should move to the next CSX file