### PR TITLE
Do not report namespace for non-regular C# syntax

### DIFF
--- a/src/OmniSharp/Api/Types/OmnisharpController.TypeLookup.cs
+++ b/src/OmniSharp/Api/Types/OmnisharpController.TypeLookup.cs
@@ -11,7 +11,7 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("typelookup")]
-        public async Task<IActionResult> TypeLookup(TypeLookupRequest request)
+        public async Task<TypeLookupResponse> TypeLookup(TypeLookupRequest request)
         {
             var document = _workspace.GetDocument(request.FileName);
             var response = new TypeLookupResponse();
@@ -23,10 +23,10 @@ namespace OmniSharp
                 var symbol = SymbolFinder.FindSymbolAtPosition(semanticModel, position, _workspace);
                 if (symbol != null)
                 {
-                    if(symbol.Kind == SymbolKind.NamedType)
+                    //non regular C# code semantics (interactive, script) don't allow namespaces
+                    if(document.SourceCodeKind == SourceCodeKind.Regular && symbol.Kind == SymbolKind.NamedType)
                     {
-                        response.Type = symbol.ContainingNamespace.ToDisplayString() + "." 
-                                        + symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                        response.Type = $"{symbol.ContainingNamespace.ToDisplayString()}.{symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)}";
                     }
                     else
                     {
@@ -39,7 +39,7 @@ namespace OmniSharp
                     }
                 }
             }
-            return new ObjectResult(response);
+            return response;
         }
     }
 }

--- a/src/OmniSharp/ScriptCs/ScriptCsContext.cs
+++ b/src/OmniSharp/ScriptCs/ScriptCsContext.cs
@@ -11,4 +11,12 @@ namespace OmniSharp.ScriptCs
 
         public string Path { get; set; }
     }
+
+    public class Foo {
+        public class Bar {
+            public class Abc {
+
+            }
+        }
+    }
 }

--- a/src/OmniSharp/ScriptCs/ScriptCsContext.cs
+++ b/src/OmniSharp/ScriptCs/ScriptCsContext.cs
@@ -11,12 +11,4 @@ namespace OmniSharp.ScriptCs
 
         public string Path { get; set; }
     }
-
-    public class Foo {
-        public class Bar {
-            public class Abc {
-
-            }
-        }
-    }
 }

--- a/tests/OmniSharp.Tests/GoToFileFacts.cs
+++ b/tests/OmniSharp.Tests/GoToFileFacts.cs
@@ -1,43 +1,11 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using OmniSharp.Models;
 using Xunit;
 
 namespace OmniSharp.Tests
-{    
-    public class TypeLookupFacts
-    {
-        [Fact]
-        public async Task OmitsNamespaceForNonRegularCSharpSyntax()
-        {
-            var source1 = @"class Foo {}";
-            
-            var workspace = TestHelpers.CreateCsxWorkspace(source1);
-            
-            var controller = new OmnisharpController(workspace, null);
-            var response = await controller.TypeLookup(new TypeLookupRequest { FileName = "dummy.csx", Line = 1, Column = 8 });
-            
-            Assert.Equal("Foo", response.Type);   
-        } 
-        
-        [Fact]
-        public async Task IncludesNamespaceForRegularCSharpSyntax()
-        {
-            var source1 = @"namespace Bar {
-            class Foo {}
-            }";
-            
-            var workspace = TestHelpers.CreateSimpleWorkspace(source1);
-            
-            var controller = new OmnisharpController(workspace, null);
-            var response = await controller.TypeLookup(new TypeLookupRequest { FileName = "dummy.cs", Line = 2, Column = 20 });
-            
-            Assert.Equal("Bar.Foo", response.Type);   
-        } 
-    }
-        
+{            
     public class GoToFileFacts
     {
         [Fact]

--- a/tests/OmniSharp.Tests/GoToFileFacts.cs
+++ b/tests/OmniSharp.Tests/GoToFileFacts.cs
@@ -5,7 +5,7 @@ using OmniSharp.Models;
 using Xunit;
 
 namespace OmniSharp.Tests
-{            
+{
     public class GoToFileFacts
     {
         [Fact]

--- a/tests/OmniSharp.Tests/GoToFileFacts.cs
+++ b/tests/OmniSharp.Tests/GoToFileFacts.cs
@@ -1,11 +1,43 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using OmniSharp.Models;
 using Xunit;
 
 namespace OmniSharp.Tests
 {    
+    public class TypeLookupFacts
+    {
+        [Fact]
+        public async Task OmitsNamespaceForNonRegularCSharpSyntax()
+        {
+            var source1 = @"class Foo {}";
+            
+            var workspace = TestHelpers.CreateCsxWorkspace(source1);
+            
+            var controller = new OmnisharpController(workspace, null);
+            var response = await controller.TypeLookup(new TypeLookupRequest { FileName = "dummy.csx", Line = 1, Column = 8 });
+            
+            Assert.Equal("Foo", response.Type);   
+        } 
+        
+        [Fact]
+        public async Task IncludesNamespaceForRegularCSharpSyntax()
+        {
+            var source1 = @"namespace Bar {
+            class Foo {}
+            }";
+            
+            var workspace = TestHelpers.CreateSimpleWorkspace(source1);
+            
+            var controller = new OmnisharpController(workspace, null);
+            var response = await controller.TypeLookup(new TypeLookupRequest { FileName = "dummy.cs", Line = 2, Column = 20 });
+            
+            Assert.Equal("Bar.Foo", response.Type);   
+        } 
+    }
+        
     public class GoToFileFacts
     {
         [Fact]

--- a/tests/OmniSharp.Tests/TypeLookupFacts.cs
+++ b/tests/OmniSharp.Tests/TypeLookupFacts.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using OmniSharp.Models;
+using Xunit;
+
+namespace OmniSharp.Tests 
+{
+    public class TypeLookupFacts
+    {
+        [Fact]
+        public async Task OmitsNamespaceForNonRegularCSharpSyntax()
+        {
+            var source1 = @"class Foo {}";
+            
+            var workspace = TestHelpers.CreateCsxWorkspace(source1);
+            
+            var controller = new OmnisharpController(workspace, null);
+            var response = await controller.TypeLookup(new TypeLookupRequest { FileName = "dummy.csx", Line = 1, Column = 8 });
+            
+            Assert.Equal("Foo", response.Type);   
+        } 
+        
+        [Fact]
+        public async Task IncludesNamespaceForRegularCSharpSyntax()
+        {
+            var source1 = @"namespace Bar {
+            class Foo {}
+            }";
+            
+            var workspace = TestHelpers.CreateSimpleWorkspace(source1);
+            
+            var controller = new OmnisharpController(workspace, null);
+            var response = await controller.TypeLookup(new TypeLookupRequest { FileName = "dummy.cs", Line = 2, Column = 20 });
+            
+            Assert.Equal("Bar.Foo", response.Type);   
+        } 
+    }
+}


### PR DESCRIPTION
For `SourceCodeKind.Interactive` and `SourceCodeKind.Script`, do not report a namespace as part of type lookup.

Fixes #222.

Also added a helper for creating a CSX workspace which we can use for more tests in the future.