### PR TITLE
Trick to make Roslyn keep the indentation for format on enter

### DIFF
--- a/src/OmniSharp/Api/Formatting/OmnisharpController.Format.cs
+++ b/src/OmniSharp/Api/Formatting/OmnisharpController.Format.cs
@@ -40,7 +40,7 @@ namespace OmniSharp
             var lines = (await document.GetSyntaxTreeAsync()).GetText().Lines;
             var start = lines.GetPosition(new LinePosition(request.Line - 1, request.Column - 1));
             var end = lines.GetPosition(new LinePosition(request.EndLine - 1, request.EndColumn - 1));
-            var changes = await Formatting.GetFormattingChangesForRange(_workspace, Options, document, start, end);
+            var changes = await Formatting.GetFormattingChangesForRange(Options, document, start, end);
 
             return new FormatRangeResponse()
             {
@@ -57,7 +57,7 @@ namespace OmniSharp
                 return null;
             }
 
-            var newText = await Formatting.GetFormattedDocument(_workspace, Options, document);
+            var newText = await Formatting.GetFormattedDocument(Options, document);
             return new CodeFormatResponse()
             {
                 Buffer = newText

--- a/src/OmniSharp/MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp/MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -156,7 +156,10 @@ namespace OmniSharp.MSBuild.ProjectFile
                 projectFileInfo.AssemblyName = properties["AssemblyName"].FinalValue;
                 projectFileInfo.Name = Path.GetFileNameWithoutExtension(projectFilePath);
                 projectFileInfo.TargetFramework = new FrameworkName(properties["TargetFrameworkMoniker"].FinalValue);
-                projectFileInfo.SpecifiedLanguageVersion = ToLanguageVersion(properties["LangVersion"].FinalValue);
+                if (properties.ContainsKey("LangVersion"))
+                {
+                    projectFileInfo.SpecifiedLanguageVersion = ToLanguageVersion(properties["LangVersion"].FinalValue);
+                }
                 projectFileInfo.ProjectId = new Guid(properties["ProjectGuid"].FinalValue.TrimStart('{').TrimEnd('}'));
                 projectFileInfo.TargetPath = properties["TargetPath"].FinalValue;
 


### PR DESCRIPTION
when having this
```
1:........
2:........// this is a comment
3:........<cursor>
```

we don't want the last line to be removed. OmniSharp will tell Roslyn to format only line 2 but since all is trivia lines 1 to 3 will be formatted - that includes removing the indentation for line 3. The ideal would be to ask Roslyn after the formatting operation what the proper indentation for line #3 is but that API is internal. So, this PR does a simple trick by adding ```;``` at the position in which format on enter was triggered. The outcome will be:

```
1:
2:........// this is a comment
3:........<cursor>
```
