### PR TITLE
filter sources message by ending and only allow .cs files

### DIFF
--- a/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
+++ b/src/OmniSharp/AspNet5/AspNet5ProjectSystem.cs
@@ -333,14 +333,16 @@ namespace OmniSharp.AspNet5
                         // The sources to feed to the language service
                         var val = m.Payload.ToObject<SourcesMessage>();
 
-                        project.SourceFiles = val.Files;
+                        project.SourceFiles = val.Files
+                            .Where(fileName => Path.GetExtension(fileName) == ".cs")
+                            .ToList();
 
                         var frameworkProject = project.ProjectsByFramework[val.Framework.FrameworkName];
                         var projectId = frameworkProject.ProjectId;
 
                         var unprocessed = new HashSet<string>(frameworkProject.Documents.Keys);
 
-                        foreach (var file in val.Files)
+                        foreach (var file in project.SourceFiles)
                         {
                             if (unprocessed.Remove(file))
                             {


### PR DESCRIPTION
DTH is language agnostic and with some project.json configuration^ OmniSharp ends up loading random files into roslyn. This PR fixes #230 by only feeding CS-files into roslyn. 

^https://github.com/aspnet/Home/wiki/Project.json-file#sources