### PR TITLE
Handle unauthorized access exceptions when searching for projects

### DIFF
--- a/src/OmniSharp/Dnx/DnxProjectSystem.cs
+++ b/src/OmniSharp/Dnx/DnxProjectSystem.cs
@@ -22,6 +22,7 @@ using Newtonsoft.Json.Linq;
 using OmniSharp.Models;
 using OmniSharp.Options;
 using OmniSharp.Services;
+using OmniSharp.Utilities;
 
 namespace OmniSharp.Dnx
 {
@@ -38,6 +39,7 @@ namespace OmniSharp.Dnx
         private readonly IFileSystemWatcher _watcher;
         private readonly IEventEmitter _emitter;
         private readonly OmniSharpOptions _options;
+        private readonly DirectoryEnumerator _directoryEnumerator;
 
         public DnxProjectSystem(OmnisharpWorkspace workspace,
                                     IOmnisharpEnvironment env,
@@ -60,6 +62,7 @@ namespace OmniSharp.Dnx
             _context = context;
             _watcher = watcher;
             _emitter = emitter;
+            _directoryEnumerator = new DirectoryEnumerator(loggerFactory);
 
             lifetime.ApplicationStopping.Register(OnShutdown);
         }
@@ -551,12 +554,12 @@ namespace OmniSharp.Dnx
                 }
                 else
                 {
-                    paths = Directory.EnumerateFiles(_env.Path, "project.json", SearchOption.AllDirectories);
+                    paths = _directoryEnumerator.SafeEnumerateFiles(_env.Path, "project.json");
                 }
 #else
                 // The matcher works on CoreCLR but Omnisharp still targets aspnetcore50 instead of
                 // dnxcore50
-                paths = Directory.EnumerateFiles(_env.Path, "project.json", SearchOption.AllDirectories);
+                paths = _directoryEnumerator.SafeEnumerateFiles(_env.Path, "project.json");
 #endif 
                 foreach (var path in paths)
                 {

--- a/src/OmniSharp/Utilities/DirectoryEnumerator.cs
+++ b/src/OmniSharp/Utilities/DirectoryEnumerator.cs
@@ -25,11 +25,11 @@ namespace OmniSharp.Utilities
             while (directoryStack.Any())
             {
                 var current = directoryStack.Pop();
-                
+
                 try
                 {
                     allFiles = allFiles.Concat(GetFiles(current, pattern));
-                    
+
                     foreach (var subdirectory in GetSubdirectories(current))
                     {
                         directoryStack.Push(subdirectory);
@@ -48,7 +48,7 @@ namespace OmniSharp.Utilities
         {
             try
             {
-                return Directory.EnumerateFiles(path, pattern, SearchOption.TopDirectoryOnly);
+                return Directory.GetFiles(path, pattern, SearchOption.TopDirectoryOnly);
             }
             catch (PathTooLongException)
             {

--- a/src/OmniSharp/Utilities/DirectoryEnumerator.cs
+++ b/src/OmniSharp/Utilities/DirectoryEnumerator.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Framework.Logging;
+
+namespace OmniSharp.Utilities
+{
+    public class DirectoryEnumerator
+    {
+        private ILogger _logger;
+
+        public DirectoryEnumerator(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<DirectoryEnumerator>();
+        }
+
+        public IEnumerable<string> SafeEnumerateFiles(string path, string searchPattern)
+        {
+            if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+            {
+                yield break;
+            }
+            
+            string[] files = null;
+            string[] directories = null;
+            
+            try
+            {
+                // Get the files and directories now so we can get any exceptions up front
+                files = Directory.GetFiles(path, searchPattern);
+                directories = Directory.GetDirectories(path);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                _logger.LogWarning(string.Format("Unauthorized access to {0}, skipping", path));
+                yield break;
+            }
+            catch (PathTooLongException)
+            {
+                _logger.LogWarning(string.Format("Path {0} is too long, skipping", path));
+                yield break;
+            }
+
+            foreach (var file in files)
+            {
+                yield return file;
+            }
+
+            foreach (var file in directories.SelectMany(x => SafeEnumerateFiles(x, searchPattern)))
+            {
+                yield return file;
+            }
+        }
+    }
+}

--- a/src/OmniSharp/Utilities/DirectoryEnumerator.cs
+++ b/src/OmniSharp/Utilities/DirectoryEnumerator.cs
@@ -28,9 +28,10 @@ namespace OmniSharp.Utilities
 
                 try
                 {
-                    allFiles = allFiles.Concat(GetFiles(current, pattern));
+                    var files = Directory.GetFiles(current, pattern);
+                    allFiles = allFiles.Concat(files);
 
-                    foreach (var subdirectory in GetSubdirectories(current))
+                    foreach (var subdirectory in Directory.EnumerateDirectories(current))
                     {
                         directoryStack.Push(subdirectory);
                     }
@@ -39,35 +40,13 @@ namespace OmniSharp.Utilities
                 {
                     _logger.LogWarning(string.Format("Unauthorized access to {0}, skipping", current));
                 }
+                catch (PathTooLongException)
+                {
+                    _logger.LogWarning(string.Format("Path {0} is too long, skipping", current));
+                }
             }
 
             return allFiles;
-        }
-
-        private IEnumerable<string> GetFiles(string path, string pattern)
-        {
-            try
-            {
-                return Directory.GetFiles(path, pattern, SearchOption.TopDirectoryOnly);
-            }
-            catch (PathTooLongException)
-            {
-                _logger.LogWarning(string.Format("Path {0} is too long, skipping", path));
-                return Enumerable.Empty<string>();
-            }
-        }
-
-        private IEnumerable<string> GetSubdirectories(string path)
-        {
-            try
-            {
-                return Directory.EnumerateDirectories(path, "*", SearchOption.TopDirectoryOnly);
-            }
-            catch (PathTooLongException)
-            {
-                _logger.LogWarning(string.Format("Path {0} is too long, skipping", path));
-                return Enumerable.Empty<string>();
-            }
         }
     }
 }


### PR DESCRIPTION
This is an attempt to fix #192 by ignoring (and logging) any paths that are unauthorized while searching for project.json files.  I added a check for paths that are too long as well.  I've tested this on Windows and Linux with unauthorized paths and without.