### PR TITLE
Read DefineConstants from MsBuild file

### DIFF
--- a/src/OmniSharp/MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp/MSBuild/MSBuildProjectSystem.cs
@@ -236,9 +236,15 @@ namespace OmniSharp.MSBuild
                 }
             }
 
-            if (projectFileInfo.SpecifiedLanguageVersion.HasValue)
+            if (projectFileInfo.SpecifiedLanguageVersion.HasValue || projectFileInfo.DefineConstants != null)
             {
-                var parseOptions = new CSharpParseOptions(projectFileInfo.SpecifiedLanguageVersion.Value);
+                var parseOptions = projectFileInfo.SpecifiedLanguageVersion.HasValue
+                    ? new CSharpParseOptions(projectFileInfo.SpecifiedLanguageVersion.Value)
+                    : new CSharpParseOptions();
+                if (projectFileInfo.DefineConstants != null && projectFileInfo.DefineConstants.Any())
+                {
+                    parseOptions.WithPreprocessorSymbols(projectFileInfo.DefineConstants);
+                }
                 _workspace.SetParseOptions(project.Id, parseOptions);
             }
 

--- a/src/OmniSharp/MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp/MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -45,7 +45,7 @@ namespace OmniSharp.MSBuild.ProjectFile
 
         public IList<string> Analyzers { get; private set; }
 
-        public IList<string> DefinedConstants { get; private set; }
+        public IList<string> DefineConstants { get; private set; }
 
         public static ProjectFileInfo Create(MSBuildOptions options, ILogger logger, string solutionDirectory, string projectFilePath, ICollection<MSBuildDiagnosticsMessage> diagnostics)
         {
@@ -112,10 +112,10 @@ namespace OmniSharp.MSBuild.ProjectFile
                                    .Select(p => p.GetMetadataValue("FullPath"))
                                    .ToList();
 
-                var definedConstants = projectInstance.GetPropertyValue("DefineConstants");
-                if (!string.IsNullOrWhiteSpace(definedConstants))
+                var defineConstants = projectInstance.GetPropertyValue("DefineConstants");
+                if (!string.IsNullOrWhiteSpace(defineConstants))
                 {
-                    projectFileInfo.DefinedConstants = definedConstants.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                    projectFileInfo.DefineConstants = defineConstants.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Distinct().ToList();
                 }
             }
             else
@@ -184,10 +184,10 @@ namespace OmniSharp.MSBuild.ProjectFile
                     .Select(p => Path.GetFullPath(Path.Combine(projectFileInfo.ProjectDirectory, p.FinalItemSpec)))
                     .ToList();
 
-                var definedConstants = properties["DefineConstants"].FinalValue;
-                if (!string.IsNullOrWhiteSpace(definedConstants))
+                var defineConstants = properties["DefineConstants"].FinalValue;
+                if (!string.IsNullOrWhiteSpace(defineConstants))
                 {
-                    projectFileInfo.DefinedConstants = definedConstants.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                    projectFileInfo.DefineConstants = defineConstants.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Distinct().ToList();
                 }
             }
 #else


### PR DESCRIPTION
While Omnisharp doesn't support msbuild configuration switches at the moment - and always defaults to `Debug` configuration, this PR at least introduces the capability of reading its `<DefineConstants>` into the `CSharpCompilationOptions` which would allow the language services to properly respect them.

Based on #226 