### PR TITLE
Add initial ability to generate metadata source from a symbol

### DIFF
--- a/src/OmniSharp/Api/v1/Navigation/OmnisharpController.GotoDefinition.cs
+++ b/src/OmniSharp/Api/v1/Navigation/OmnisharpController.GotoDefinition.cs
@@ -1,7 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Models;
@@ -27,17 +31,54 @@ namespace OmniSharp
                 
                 if (symbol != null)
                 {
-                    var lineSpan = symbol.Locations.First().GetMappedLineSpan();
-                    response = new GotoDefinitionResponse
+                    var location = symbol.Locations.First();
+
+                    if (location.IsInSource)
                     {
-                        FileName = lineSpan.Path,
-                        Line = lineSpan.StartLinePosition.Line + 1,
-                        Column = lineSpan.StartLinePosition.Character + 1
-                    };
+                        var lineSpan = symbol.Locations.First().GetMappedLineSpan();
+                        response = new GotoDefinitionResponse
+                        {
+                            FileName = lineSpan.Path,
+                            Line = lineSpan.StartLinePosition.Line + 1,
+                            Column = lineSpan.StartLinePosition.Character + 1
+                        };
+                    }
+#if DNX451
+                    else if (location.IsInMetadata)
+                    {
+                        var temporaryDocument = document.Project.AddDocument("foo", string.Empty);
+                        var topLevelSymbol = GetTopLevelContainingNamedType(symbol);
+
+                        var assembly = Assembly.Load("Microsoft.CodeAnalysis.CSharp.Features, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35");
+                        var type = assembly.GetType("Microsoft.CodeAnalysis.CSharp.MetadataAsSource.CSharpMetadataAsSourceService");
+                        
+                        object service = Activator.CreateInstance(type, new object[] { temporaryDocument.Project.LanguageServices });
+                        var method = type.GetMethod("AddSourceToAsync");
+                        
+                        var result = await (Task<Document>)method.Invoke(service, new object[] { temporaryDocument, topLevelSymbol, new CancellationToken() });
+                        var source = await result.GetTextAsync();
+                        response.MetadataSource = source.ToString();
+
+                        //TODO: Find the location of the symbol in the source
+                    }
+#endif
                 }
             }
 
             return new ObjectResult(response);
+        }
+
+        public static INamedTypeSymbol GetTopLevelContainingNamedType(ISymbol symbol)
+        {
+            // Traverse up until we find a named type that is parented by the namespace
+            var topLevelNamedType = symbol;
+            while (topLevelNamedType.ContainingSymbol != symbol.ContainingNamespace ||
+                topLevelNamedType.Kind != SymbolKind.NamedType)
+            {
+                topLevelNamedType = topLevelNamedType.ContainingSymbol;
+            }
+
+            return (INamedTypeSymbol)topLevelNamedType;
         }
     }
 }

--- a/src/OmniSharp/Models/v1/GotoDefinitionResponse.cs
+++ b/src/OmniSharp/Models/v1/GotoDefinitionResponse.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace OmniSharp.Models
 {
     public class GotoDefinitionResponse
@@ -5,5 +7,6 @@ namespace OmniSharp.Models
         public string FileName { get; set; }
         public int Line { get; set; }
         public int Column { get; set; }
+        public string MetadataSource { get; set; }
     }
 }

--- a/tests/OmniSharp.Tests/GoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Tests/GoToDefinitionFacts.cs
@@ -1,0 +1,152 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Mvc;
+using OmniSharp.Models;
+using Xunit;
+
+namespace OmniSharp.Tests
+{
+    public class GoToDefinitionFacts
+    {
+        [Fact]
+        public async Task ReturnsLocationSourceDefinition()
+        {
+            var source1 = @"using System;
+
+class Foo {
+}";
+            var source2 = @"class Bar {
+    private Foo foo;
+}";
+
+            var workspace = TestHelpers.CreateSimpleWorkspace(new Dictionary<string, string> {
+                { "foo.cs", source1 }, { "bar.cs", source2}
+            });
+            var controller = new OmnisharpController(workspace, null);
+            var response = await controller.GotoDefinition(new Request
+            {
+                FileName = "bar.cs",
+                Line = 2,
+                Column = 14
+            }) as ObjectResult;
+
+            var definitionResponse = response.Value as GotoDefinitionResponse;
+
+            Assert.Equal("foo.cs", definitionResponse.FileName);
+            Assert.Equal(3, definitionResponse.Line);
+            Assert.Equal(7, definitionResponse.Column);
+        }
+
+        [Fact]
+        public async Task ReturnsEmptyResultWhenDefinitionIsNotFound()
+        {
+            var source1 = @"using System;
+
+class Foo {
+}";
+            var source2 = @"class Bar {
+    private Baz foo;
+}";
+
+            var workspace = TestHelpers.CreateSimpleWorkspace(new Dictionary<string, string> {
+                { "foo.cs", source1 }, { "bar.cs", source2}
+            });
+            var controller = new OmnisharpController(workspace, null);
+            var response = await controller.GotoDefinition(new Request
+            {
+                FileName = "bar.cs",
+                Line = 2,
+                Column = 14
+            }) as ObjectResult;
+
+            var definitionResponse = response.Value as GotoDefinitionResponse;
+
+            Assert.Null(definitionResponse.FileName);
+            Assert.Equal(0, definitionResponse.Line);
+            Assert.Equal(0, definitionResponse.Column);
+        }
+        
+        [Fact]
+        public async Task ReturnsPositionInMetadata_WhenSymbolIsMethod()
+        {
+            var controller = new OmnisharpController(CreateTestWorkspace(), null);
+            var response = await controller.GotoDefinition(new Request
+            {
+                FileName = "bar.cs",
+                Line = 7,
+                Column = 20
+            }) as ObjectResult;
+
+            var definitionResponse = response.Value as GotoDefinitionResponse;
+
+            Assert.Null(definitionResponse.FileName);
+            Assert.Equal(0, definitionResponse.Line);
+            Assert.Equal(0, definitionResponse.Column);
+            Assert.Contains("public static class Console", definitionResponse.MetadataSource);
+            Assert.Contains("public static void WriteLine(string value)", definitionResponse.MetadataSource);
+        }
+
+        [Fact]
+        public async Task ReturnsPositionInMetadata_WhenSymbolIsExtensionMethod()
+        {
+            var controller = new OmnisharpController(CreateTestWorkspace(), null);
+            var response = await controller.GotoDefinition(new Request
+            {
+                FileName = "bar.cs",
+                Line = 10,
+                Column = 17
+            }) as ObjectResult;
+
+            var definitionResponse = response.Value as GotoDefinitionResponse;
+
+            Assert.Null(definitionResponse.FileName);
+            Assert.Equal(0, definitionResponse.Line);
+            Assert.Equal(0, definitionResponse.Column);
+            Assert.Contains("public static class Enumerable", definitionResponse.MetadataSource);
+            Assert.Contains("public static List<TSource> ToList<TSource>(this IEnumerable<TSource> source)", definitionResponse.MetadataSource);
+        }
+
+        [Fact]
+        public async Task ReturnsPositionInMetadata_WhenSymbolIsType()
+        {
+            var controller = new OmnisharpController(CreateTestWorkspace(), null);
+            var response = await controller.GotoDefinition(new Request
+            {
+                FileName = "bar.cs",
+                Line = 9,
+                Column = 25
+            }) as ObjectResult;
+
+            var definitionResponse = response.Value as GotoDefinitionResponse;
+
+            Assert.Null(definitionResponse.FileName);
+            Assert.Equal(0, definitionResponse.Line);
+            Assert.Equal(0, definitionResponse.Column);
+            Assert.Contains("public class List<T> : IList<T>, ICollection<T>", definitionResponse.MetadataSource);
+        }
+
+        OmnisharpWorkspace CreateTestWorkspace()
+        {
+            var source1 = @"using System;
+
+class Foo {
+}";
+            var source2 = @"using System;
+using System.Collections.Generic;
+using System.Linq;
+
+class Bar {
+    public void Baz() {
+        Console.WriteLine(""Stuff"");
+
+        var foo = new List<string>();
+        foo.ToList();
+    }
+}";
+
+            return TestHelpers.CreateSimpleWorkspace(new Dictionary<string, string> {
+                { "foo.cs", source1 }, { "bar.cs", source2}
+            });
+        }
+    }
+}

--- a/tests/OmniSharp.Tests/GoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Tests/GoToDefinitionFacts.cs
@@ -65,7 +65,7 @@ class Foo {
             Assert.Equal(0, definitionResponse.Line);
             Assert.Equal(0, definitionResponse.Column);
         }
-        
+
         [Fact]
         public async Task ReturnsPositionInMetadata_WhenSymbolIsMethod()
         {
@@ -122,7 +122,7 @@ class Foo {
             Assert.Null(definitionResponse.FileName);
             Assert.Equal(0, definitionResponse.Line);
             Assert.Equal(0, definitionResponse.Column);
-            Assert.Contains("public class List<T> : IList<T>, ICollection<T>", definitionResponse.MetadataSource);
+            Assert.Contains("public class List<T>", definitionResponse.MetadataSource);
         }
 
         OmnisharpWorkspace CreateTestWorkspace()

--- a/tests/OmniSharp.Tests/OmniSharp.Tests.xproj
+++ b/tests/OmniSharp.Tests/OmniSharp.Tests.xproj
@@ -17,6 +17,9 @@
     <SchemaVersion>2.0</SchemaVersion>
     <DevelopmentServerPort>3319</DevelopmentServerPort>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <ProjectExtensions>
     <VisualStudio>
       <UserProperties project_1json__JSONSchema="http://www.asp.net/media/4878834/project.json" />


### PR DESCRIPTION
This is using functionality from the Roslyn.Features assembly that aren't public