### PR TITLE
Fix usings

### DIFF
--- a/src/OmniSharp/Api/v1/Refactoring/OmnisharpController.FixUsings.cs
+++ b/src/OmniSharp/Api/v1/Refactoring/OmnisharpController.FixUsings.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Mvc;
+using OmniSharp.Models;
+
+namespace OmniSharp
+{
+    public partial class OmnisharpController
+    {
+        [HttpPost("fixusings")]
+        public async Task<FixUsingsResponse> FixUsings(FixUsingsRequest request)
+        {
+            var document = _workspace.GetDocument(request.FileName);
+            var docText = await document.GetTextAsync();
+            var response = new FixUsingsResponse();
+
+            if (document != null)
+            {
+                var semanticModel = await document.GetSemanticModelAsync();
+                response = await FixUsingsWorker.FixUsings(_workspace, request.FileName, document, semanticModel, request.WantsTextChanges);
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/OmniSharp/Models/v1/FixUsingsRequest.cs
+++ b/src/OmniSharp/Models/v1/FixUsingsRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace OmniSharp.Models
+{
+    public class FixUsingsRequest : Request
+    {
+        public bool WantsTextChanges { get; set; }
+    }
+}

--- a/src/OmniSharp/Models/v1/FixUsingsResponse.cs
+++ b/src/OmniSharp/Models/v1/FixUsingsResponse.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace OmniSharp.Models
+{
+    public class FixUsingsResponse
+    {
+        public FixUsingsResponse()
+        {
+        }
+
+        public string Buffer { get; set; }
+        public IEnumerable<QuickFix> AmbiguousResults { get; set; }
+        public IEnumerable<LinePositionSpanTextChange> Changes { get; set; }
+    }
+}

--- a/src/OmniSharp/Workers/Refactoring/FixUsings.cs
+++ b/src/OmniSharp/Workers/Refactoring/FixUsings.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using OmniSharp.Models;
+using OmniSharp.Services;
+
+namespace OmniSharp
+{
+    public class FixUsingsWorker
+    {
+        public static async Task<FixUsingsResponse> FixUsings(OmnisharpWorkspace workspace, string fileName, Document document, SemanticModel semanticModel, bool wantsTextChanges)
+        {
+            var codeActionProvider = new RoslynCodeActionProvider();
+            var ambiguous = await AddMissingUsings(fileName, workspace, document, semanticModel, codeActionProvider);
+            await OrganizeUsings(fileName, workspace, document, semanticModel, codeActionProvider);
+            document = workspace.GetDocument(fileName);
+            var compilationUnitSyntax = (await AddLinqQuerySyntax(fileName, workspace, document, semanticModel));
+            document = document.WithSyntaxRoot(compilationUnitSyntax);
+
+            var response = new FixUsingsResponse();
+            response.AmbiguousResults = ambiguous;
+            if (!wantsTextChanges)
+            {
+                // return the new document
+                var docText = await document.GetTextAsync();
+                response.Buffer = docText.ToString();
+            }
+            else
+            {
+                // return the text changes
+                var changes = await workspace.CurrentSolution.GetDocument(document.Id).GetTextChangesAsync(document);
+                response.Changes = await LinePositionSpanTextChange.Convert(document, changes);
+            }
+
+            return response;
+        }
+
+        private static async Task<List<QuickFix>> AddMissingUsings(string fileName, OmnisharpWorkspace workspace, Document document, SemanticModel semanticModel, ICodeActionProvider codeActionProvider)
+        {
+            bool processMore = true;
+            var ambiguousNodes = new List<SimpleNameSyntax>();
+            var ambiguous = new List<QuickFix>();
+
+            while (processMore)
+            {
+                bool updated = false;
+
+                var syntaxNode = (await document.GetSyntaxTreeAsync()).GetRoot();
+                var nodes = syntaxNode.DescendantNodes()
+                    .OfType<SimpleNameSyntax>()
+                    .Where(x => semanticModel.GetSymbolInfo(x).Symbol == null && !ambiguousNodes.Contains(x)).ToList();
+
+                foreach (var node in nodes)
+                {
+                    document = workspace.GetDocument(fileName);
+                    semanticModel = await document.GetSemanticModelAsync();
+                    var sourceText = (await document.GetTextAsync());
+                    var diagnostics = semanticModel.GetDiagnostics();
+                    var location = node.Identifier.Span;
+                    var usingOperations = new Dictionary<string, CodeActionOperation>();
+                    //Restrict diagnostics only to missing usings
+                    var pointDiagnostics = diagnostics.Where(d => d.Location.SourceSpan.Contains(location) &&
+                            (d.Id == "CS0246" || d.Id == "CS1061" || d.Id == "CS0103")).ToImmutableArray();
+
+                    if (pointDiagnostics.Any())
+                    {
+                        var pointdiagfirst = pointDiagnostics.First().Location.SourceSpan;
+                        if (pointDiagnostics.Any(d => d.Location.SourceSpan != pointdiagfirst))
+                        {
+                            continue;
+                        }
+                        var usingActions = GetUsingActions(document, codeActionProvider, pointDiagnostics, "using");
+                        foreach (var action in usingActions)
+                        {
+                            var operations = await action.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
+                            if (operations != null)
+                            {
+                                foreach (var codeOperation in operations)
+                                {
+                                    usingOperations.Add(action.Title, codeOperation);
+                                }
+                            }
+                        }
+
+                        if (usingOperations.Count() == 1)
+                        {
+                            //Only one operation - apply it
+                            usingOperations.Single().Value.Apply(workspace, CancellationToken.None);
+                            updated = true;
+                        }
+                        else if (usingOperations.Count() > 1)
+                        {
+                            //More than one operation - ambiguous
+                            ambiguousNodes.Add(node);
+                            var unresolvedText = node.Identifier.ValueText;
+                            var unresolvedLocation = node.GetLocation().GetLineSpan().StartLinePosition;
+                            ambiguous.Add(new QuickFix
+                            {
+                                Line = unresolvedLocation.Line + 1,
+                                Column = unresolvedLocation.Character + 1,
+                                FileName = fileName,
+                                Text = "`" + unresolvedText + "`" + " is ambiguous"
+                            });
+                        }
+                    }
+                }
+
+                processMore = updated;
+            }
+
+            return ambiguous;
+        }
+
+        private static async Task OrganizeUsings(string fileName, OmnisharpWorkspace workspace, Document document, SemanticModel semanticModel, ICodeActionProvider codeActionProvider)
+        {
+            //Remove unneccessary usings
+            var syntaxNode = (await document.GetSyntaxTreeAsync()).GetRoot();
+            var nodes = syntaxNode.DescendantNodes().Where(x => x is UsingDirectiveSyntax);
+
+            foreach (var node in nodes)
+            {
+                document = workspace.GetDocument(fileName);
+                semanticModel = await document.GetSemanticModelAsync();
+                var sourceText = (await document.GetTextAsync());
+                var diagnostics = semanticModel.GetDiagnostics();
+                var location = node.Span;
+                var actions = new List<CodeAction>();
+                //Restrict diagnostics only to unneccessary and duplicate usings
+                var pointDiagnostics = diagnostics.Where(d => d.Location.SourceSpan.Contains(location) &&
+                        (d.Id == "CS0105" || d.Id == "CS8019")).ToImmutableArray();
+
+                if (pointDiagnostics.Any())
+                {
+                    var pointdiagfirst = pointDiagnostics.First().Location.SourceSpan;
+                    if (pointDiagnostics.Any(d => d.Location.SourceSpan != pointdiagfirst))
+                    {
+                        continue;
+                    }
+                    var usingActions = GetUsingActions(document, codeActionProvider, pointDiagnostics, "Remove Unnecessary Usings");
+                    foreach (var action in usingActions)
+                    {
+                        var operations = await action.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
+                        if (operations != null)
+                        {
+                            foreach (var codeOperation in operations)
+                            {
+                                if (codeOperation != null)
+                                {
+                                    codeOperation.Apply(workspace, CancellationToken.None);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            //Sort usings
+            //TODO: Sorting usings is not available as a public service in Roslyn yet.
+            //When it is, replace the NRefactory based provider with the Roslyn one.
+            var nRefactoryProvider = new NRefactoryCodeActionProvider();
+            var sortActions = new List<CodeAction>();
+            var refactoringContext = await GetRefactoringContext(document, sortActions);
+            if (refactoringContext != null)
+            {
+                foreach (var refactoring in nRefactoryProvider.Refactorings)
+                {
+                    if (refactoring.ToString() != "ICSharpCode.NRefactory6.CSharp.Refactoring.SortUsingsAction")
+                    {
+                        continue;
+                    }
+                    await refactoring.ComputeRefactoringsAsync(refactoringContext.Value);
+                }
+
+                foreach (var action in sortActions)
+                {
+                    var operations = await action.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
+                    if (operations != null)
+                    {
+                        foreach (var codeOperation in operations)
+                        {
+                            if (codeOperation != null)
+                            {
+                                codeOperation.Apply(workspace, CancellationToken.None);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return;
+        }
+
+        private static async Task<CodeRefactoringContext?> GetRefactoringContext(Document document, List<CodeAction> actionsDestination)
+        {
+            var firstUsing = (await document.GetSyntaxTreeAsync()).GetRoot().DescendantNodes().Where(n => n is UsingDirectiveSyntax);
+            if (firstUsing.Count() == 0)
+            {
+                return null;
+            }
+            var location = firstUsing.First().GetLocation().SourceSpan;
+
+            return new CodeRefactoringContext(document, location, (a) => actionsDestination.Add(a), CancellationToken.None);
+        }
+
+        private static List<CodeAction> GetUsingActions(Document document, ICodeActionProvider codeActionProvider,
+                ImmutableArray<Diagnostic> pointDiagnostics, string actionPrefix)
+        {
+
+            var actions = new List<CodeAction>();
+            var context = new CodeFixContext(document, pointDiagnostics.First().Location.SourceSpan, pointDiagnostics, (a, d) => actions.Add(a), CancellationToken.None);
+            var providers = codeActionProvider.CodeFixes;
+
+            //Disable await warning since we dont need the result of the call. Else we need to use a throwaway variable.
+#pragma warning disable 4014
+            foreach (var provider in providers)
+            {
+                provider.RegisterCodeFixesAsync(context);
+            }
+#pragma warning restore 4014
+
+            return actions.Where(a => a.Title.StartsWith(actionPrefix)).ToList();
+        }
+
+        private static async Task<CompilationUnitSyntax> AddLinqQuerySyntax(string fileName, OmnisharpWorkspace workspace, Document document, SemanticModel semanticModel)
+        {
+            var syntaxNode = (await document.GetSyntaxTreeAsync()).GetRoot();
+            var compilationUnitSyntax = (CompilationUnitSyntax)syntaxNode;
+            var usings = GetUsings(syntaxNode);
+            if (HasLinqQuerySyntax(semanticModel, syntaxNode) && !usings.Contains("using System.Linq;"))
+            {
+                var linqName = SyntaxFactory.QualifiedName(SyntaxFactory.IdentifierName("System"),
+                        SyntaxFactory.IdentifierName("Linq"));
+                var linq = SyntaxFactory.UsingDirective(linqName).NormalizeWhitespace()
+                            .WithTrailingTrivia(SyntaxFactory.Whitespace(Environment.NewLine));
+                compilationUnitSyntax = compilationUnitSyntax.AddUsings(linq);
+            }
+
+            return compilationUnitSyntax;
+        }
+
+        private static HashSet<string> GetUsings(SyntaxNode root)
+        {
+            var usings = root.DescendantNodes().OfType<UsingDirectiveSyntax>().Select(u => u.ToString().Trim());
+            return new HashSet<string>(usings);
+        }
+
+        private static bool HasLinqQuerySyntax(SemanticModel semanticModel, SyntaxNode syntaxNode)
+        {
+            return syntaxNode.DescendantNodes()
+                .Any(x => x.Kind() == SyntaxKind.QueryExpression
+                        || x.Kind() == SyntaxKind.QueryBody
+                        || x.Kind() == SyntaxKind.FromClause
+                        || x.Kind() == SyntaxKind.LetClause
+                        || x.Kind() == SyntaxKind.JoinClause
+                        || x.Kind() == SyntaxKind.JoinClause
+                        || x.Kind() == SyntaxKind.JoinIntoClause
+                        || x.Kind() == SyntaxKind.WhereClause
+                        || x.Kind() == SyntaxKind.OrderByClause
+                        || x.Kind() == SyntaxKind.AscendingOrdering
+                        || x.Kind() == SyntaxKind.DescendingOrdering
+                        || x.Kind() == SyntaxKind.SelectClause
+                        || x.Kind() == SyntaxKind.GroupClause
+                        || x.Kind() == SyntaxKind.QueryContinuation
+                    );
+        }
+    }
+}

--- a/tests/OmniSharp.Tests/Fakes/FakeOmniSharpOptions.cs
+++ b/tests/OmniSharp.Tests/Fakes/FakeOmniSharpOptions.cs
@@ -5,7 +5,7 @@ namespace OmniSharp.Tests
 {
     public class FakeOmniSharpOptions : IOptions<OmniSharpOptions>
     {
-        public OmniSharpOptions Options { get; }
+        public OmniSharpOptions Options { get; set; }
         public OmniSharpOptions GetNamedOptions(string name)
         {
             return new OmniSharpOptions();

--- a/tests/OmniSharp.Tests/FixUsingsFacts.cs
+++ b/tests/OmniSharp.Tests/FixUsingsFacts.cs
@@ -1,0 +1,431 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using OmniSharp.Models;
+using OmniSharp.Options;
+using Xunit;
+ 
+namespace OmniSharp.Tests
+{ 
+    public class FixUsingsFacts
+    {
+        string fileName = "test.cs";
+
+        [Fact]
+        public async Task FixUsings_AddsUsingSingle()
+        {
+            const string fileContents = @"namespace nsA 
+{
+    public class classX{}
+}
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public method1()
+        {
+            var c1 = new classX();
+        }
+    }
+}";
+            string expectedFileContents = @"using nsA;
+
+namespace nsA 
+{
+    public class classX{}
+}
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public method1()
+        {
+            var c1 = new classX();
+        }
+    }
+}";
+
+            await AssertBufferContents(fileContents, expectedFileContents);
+        }
+
+        [Fact]
+        public async Task FixUsings_AddsUsingSingleForFrameworkMethod()
+        {
+            const string fileContents = @"namespace OmniSharp
+{
+    public class class1 
+    {
+        public void method1()
+        {
+            Console.WriteLine(""abc"");
+        }
+    }
+}";
+            string expectedFileContents = @"using System;
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public void method1()
+        {
+            Console.WriteLine(""abc"");
+        }
+    }
+}";
+
+            await AssertBufferContents(fileContents, expectedFileContents);
+        }
+
+        [Fact]
+        public async Task FixUsings_AddsUsingSingleForFrameworkClass()
+        {
+            const string fileContents = @"namespace OmniSharp
+{
+    public class class1 
+    {
+        public void method1()()
+        {
+            var s = new StringBuilder();
+        }
+    }
+}";
+            string expectedFileContents = @"using System.Text;
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public void method1()()
+        {
+            var s = new StringBuilder();
+        }
+    }
+}";
+
+            await AssertBufferContents(fileContents, expectedFileContents);
+        }
+
+        [Fact]
+        public async Task FixUsings_AddsUsingMultiple()
+        {
+            const string fileContents = @"namespace nsA
+{
+    public class classX{}
+}
+
+namespace nsB
+{
+    public class classY{}
+}
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public method1()
+        {
+            var c1 = new classX();
+            var c2 = new classY();
+        }
+    }
+}";
+            string expectedFileContents = @"using nsA;
+using nsB;
+
+namespace nsA
+{
+    public class classX{}
+}
+
+namespace nsB
+{
+    public class classY{}
+}
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public method1()
+        {
+            var c1 = new classX();
+            var c2 = new classY();
+        }
+    }
+}";
+
+            await AssertBufferContents(fileContents, expectedFileContents);
+        }
+
+        [Fact]
+        public async Task FixUsings_AddsUsingMultipleForFramework()
+        {
+            const string fileContents = @"namespace OmniSharp
+{
+    public class class1 
+    {
+        public void method1()
+        {
+            Console.WriteLine(""abc"");
+            var sb = new StringBuilder();
+        }
+    }
+}";
+            string expectedFileContents = @"using System;
+using System.Text;
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public void method1()
+        {
+            Console.WriteLine(""abc"");
+            var sb = new StringBuilder();
+        }
+    }
+}";
+
+            await AssertBufferContents(fileContents, expectedFileContents);
+        }
+
+        [Fact]
+        public async Task FixUsings_ReturnsAmbiguousResult()
+        {
+            const string fileContents = @"
+namespace nsA
+{
+    public class classX{}
+}
+
+namespace nsB
+{
+    public class classX{}
+}
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public method1()
+        {
+            var c1 = new $classX();
+        }
+    }
+}";
+            var classLineColumn = TestHelpers.GetLineAndColumnFromDollar(TestHelpers.RemovePercentMarker(fileContents));
+            var fileContentNoDollarMarker = TestHelpers.RemoveDollarMarker(fileContents);
+            var expectedUnresolved = new List<QuickFix>();
+            expectedUnresolved.Add(new QuickFix()
+                {
+                    Line = classLineColumn.Line,
+                    Column = classLineColumn.Column,
+                    FileName = fileName,
+                    Text = "`classX` is ambiguous"
+
+                });
+            await AssertUnresolvedReferences(fileContentNoDollarMarker, expectedUnresolved);
+        }
+
+        [Fact]
+        public async Task FixUsings_ReturnsNoUsingsForAmbiguousResult()
+        {
+            const string fileContents = @"namespace nsA {
+    public class classX{}
+}
+
+namespace nsB {
+    public class classX{}
+}
+
+namespace OmniSharp {
+    public class class1 
+    {
+        public method1()
+        {
+            var c1 = new classX();
+        }
+    }
+}";
+            await AssertBufferContents(fileContents, fileContents);
+        }
+
+        [Fact]
+        public async Task FixUsings_AddsUsingForExtension()
+        {
+            const string fileContents = @"namespace nsA {
+    public static class StringExtension {
+        public static void Whatever(this string astring) {}
+    }
+}
+
+namespace OmniSharp {
+    public class class1 
+    {
+        public method1()
+        {
+            ""string"".Whatever();
+        }
+    }
+}";
+            string expectedFileContents = @"using nsA;
+
+namespace nsA {
+    public static class StringExtension {
+        public static void Whatever(this string astring) {}
+    }
+}
+
+namespace OmniSharp {
+    public class class1 
+    {
+        public method1()
+        {
+            ""string"".Whatever();
+        }
+    }
+}";
+
+            await AssertBufferContents(fileContents, expectedFileContents);
+        }
+
+
+        [Fact]
+        public async Task FixUsings_AddsUsingLinqMethodSyntax()
+        {
+            const string fileContents = @"namespace OmniSharp
+{
+    public class class1 
+    {
+        public void method1()
+        {
+            List<string> first = new List<string>();
+            var testing = first.Where(s => s == ""abc"");
+        }
+    }
+}";
+            string expectedFileContents = @"using System.Collections.Generic;
+using System.Linq;
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public void method1()
+        {
+            List<string> first = new List<string>();
+            var testing = first.Where(s => s == ""abc"");
+        }
+    }
+}";
+
+            await AssertBufferContents(fileContents, expectedFileContents);
+        }
+
+        [Fact]
+        public async Task FixUsings_RemoveDuplicateUsing()
+        {
+            const string fileContents = @"using System;
+using System;
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public void method1()
+        {
+            Console.WriteLine(""test"");
+        }
+    }
+}";
+
+            const string expectedFileContents = @"using System;
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public void method1()
+        {
+            Console.WriteLine(""test"");
+        }
+    }
+}";
+            await AssertBufferContents(fileContents, expectedFileContents);
+        }
+
+        [Fact]
+        public async Task FixUsings_RemoveUnusedUsing()
+        {
+            const string fileContents = @"using System;
+using System.Linq;
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public void method1()
+        {
+            Console.WriteLine(""test"");
+        }
+    }
+}";
+
+            const string expectedFileContents = @"using System;
+
+namespace OmniSharp
+{
+    public class class1 
+    {
+        public void method1()
+        {
+            Console.WriteLine(""test"");
+        }
+    }
+}";
+            await AssertBufferContents(fileContents, expectedFileContents);
+        }
+
+        private async Task AssertBufferContents(string fileContents, string expectedFileContents)
+        {
+            var response = await RunFixUsings(fileContents);
+            Assert.Equal(expectedFileContents, response.Buffer);
+        }
+
+        private async Task AssertUnresolvedReferences(string fileContents, List<QuickFix> expectedUnresolved)
+        {
+            var response = await RunFixUsings(fileContents);
+            var qfList = response.AmbiguousResults.ToList();
+            Assert.Equal(qfList.Count(), expectedUnresolved.Count());
+            var i = 0;
+            foreach (var expectedQuickFix in expectedUnresolved)
+            {
+                Assert.Equal(qfList[i].Line, expectedQuickFix.Line);
+                Assert.Equal(qfList[i].Column, expectedQuickFix.Column);
+                Assert.Equal(qfList[i].FileName, expectedQuickFix.FileName);
+                Assert.Equal(qfList[i].Text, expectedQuickFix.Text);
+                i++;
+            }
+        }
+
+        private async Task<FixUsingsResponse> RunFixUsings(string fileContents)
+        {
+            var workspace = TestHelpers.CreateSimpleWorkspace(fileContents, fileName);
+
+            var fakeOptions = new FakeOmniSharpOptions();
+            fakeOptions.Options = new OmniSharpOptions();
+            fakeOptions.Options.FormattingOptions = new FormattingOptions() {NewLine = "\n"};
+            var controller = new OmnisharpController(workspace, fakeOptions);
+            var request = new FixUsingsRequest
+            {
+                FileName = fileName,
+                Buffer = fileContents
+            };
+            return await controller.FixUsings(request);
+        }
+    }
+}


### PR DESCRIPTION
Second try on https://github.com/OmniSharp/omnisharp-roslyn/pull/150

The code can be optimized for speed (performance), for now to test may need to increase timeout from client editor.

1. Add missing usings
2. Send a dictionary of key-list for ambiguous usings
3. Remove redundant usings
TODO: 
1. Remove unused using statements
2. Sort using statements
3. If possible, replace RemoveRedundantUsings by something better from the framework