### PR TITLE
Conditionally apply changes for rename server side.

### DIFF
--- a/src/OmniSharp/Api/v1/Refactoring/OmnisharpController.Rename.cs
+++ b/src/OmniSharp/Api/v1/Refactoring/OmnisharpController.Rename.cs
@@ -73,8 +73,15 @@ namespace OmniSharp
                     }
                 }
 
-                // Attempt to update the workspace
-                if (_workspace.TryApplyChanges(solution))
+                if (request.ApplyTextChanges)
+                {
+                    // Attempt to update the workspace
+                    if (_workspace.TryApplyChanges(solution))
+                    {
+                        response.Changes = changes.Values;
+                    }
+                }
+                else
                 {
                     response.Changes = changes.Values;
                 }

--- a/src/OmniSharp/Models/v1/RenameRequest.cs
+++ b/src/OmniSharp/Models/v1/RenameRequest.cs
@@ -2,7 +2,15 @@
 {
     public class RenameRequest : Request
     {
+        /// <summary>
+        ///  When true, return just the text changes.
+        /// </summary>
         public bool WantsTextChanges { get; set; }
+
+        /// <summary>
+        ///  When true, apply changes immediately on the server.
+        /// </summary>
+        public bool ApplyTextChanges { get; set; } = true;
 
         public string RenameTo { get; set; }
     }


### PR DESCRIPTION
Added a new flag to the request. Ideally, we would have used
WantsTextChanges to both return text changes and also to not apply
them at immediately at the server.

The assumption here is that new text changes will be returned to the
server as they are applied to the editor.