### PR TITLE
Allow to send file specific edits with a request

### DIFF
--- a/src/OmniSharp/Api/v1/Buffer/OmnisharpController.Buffer.cs
+++ b/src/OmniSharp/Api/v1/Buffer/OmnisharpController.Buffer.cs
@@ -7,9 +7,9 @@ namespace OmniSharp
     public partial class OmnisharpController
     {
         [HttpPost("updatebuffer")]
-        public ObjectResult UpdateBuffer(UpdateBufferRequest request)
+        public async Task<ObjectResult> UpdateBuffer(UpdateBufferRequest request)
         {
-            _workspace.BufferManager.UpdateBuffer(request);
+            await _workspace.BufferManager.UpdateBuffer(request);
             return new ObjectResult(true);
         }
 

--- a/src/OmniSharp/Filters/UpdateBufferFilter.cs
+++ b/src/OmniSharp/Filters/UpdateBufferFilter.cs
@@ -17,14 +17,14 @@ namespace OmniSharp.Filters
         {
         }
 
-        public void OnActionExecuting(ActionExecutingContext context)
+        public async void OnActionExecuting(ActionExecutingContext context)
         {
             if (context.ActionArguments.Any())
             {
                 var request = context.ActionArguments.FirstOrDefault(arg => arg.Value is Request);
                 if (request.Value != null)
                 {
-                    _workspace.BufferManager.UpdateBuffer((Request)request.Value);
+                    await _workspace.BufferManager.UpdateBuffer((Request)request.Value);
                 }
             }
         }

--- a/src/OmniSharp/Models/v1/Request.cs
+++ b/src/OmniSharp/Models/v1/Request.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace OmniSharp.Models
 {
@@ -9,6 +10,7 @@ namespace OmniSharp.Models
         public int Line { get; set; }
         public int Column { get; set; }
         public string Buffer { get; set; }
+        public IEnumerable<LinePositionSpanTextChange> Changes { get; set; }
         public string FileName
         {
             get

--- a/src/OmniSharp/Roslyn/BufferManager.cs
+++ b/src/OmniSharp/Roslyn/BufferManager.cs
@@ -22,33 +22,54 @@ namespace OmniSharp.Roslyn
             _workspace.WorkspaceChanged += OnWorkspaceChanged;
         }
 
-        public void UpdateBuffer(Request request)
+        public async Task UpdateBuffer(Request request)
         {
-            string buffer = request.Buffer;
-            
-            var updateRequest = request as UpdateBufferRequest;
+            var buffer = request.Buffer;
+            var changes = request.Changes;
 
+            var updateRequest = request as UpdateBufferRequest;
             if (updateRequest != null && updateRequest.FromDisk)
             {
                 buffer = File.ReadAllText(updateRequest.FileName);
             }
 
-            if (buffer == null || request.FileName == null)
+            if (request.FileName == null || (buffer == null && changes == null))
             {
                 return;
             }
 
             var documentIds = _workspace.CurrentSolution.GetDocumentIdsWithFilePath(request.FileName);
- 
             if (!documentIds.IsEmpty)
             {
-                var sourceText = SourceText.From(buffer);
-                foreach (var documentId in documentIds)
+                if (changes == null)
                 {
-                    _workspace.OnDocumentChanged(documentId, sourceText);
+                    var sourceText = SourceText.From(buffer);
+                    foreach (var documentId in documentIds)
+                    {
+                        _workspace.OnDocumentChanged(documentId, sourceText);
+                    }
+                }
+                else
+                {
+                    foreach (var documentId in documentIds)
+                    {
+                        var document = _workspace.CurrentSolution.GetDocument(documentId);
+                        var sourceText = await document.GetTextAsync();
+
+                        foreach (var change in request.Changes)
+                        {
+                            var startOffset = sourceText.Lines.GetPosition(new LinePosition(change.StartLine - 1, change.StartColumn - 1));
+                            var endOffset = sourceText.Lines.GetPosition(new LinePosition(change.EndLine - 1, change.EndColumn - 1));
+
+                            sourceText = sourceText.WithChanges(new[] {
+                                new TextChange(new TextSpan(startOffset, endOffset - startOffset), change.NewText)
+                            });
+                        }
+                        _workspace.OnDocumentChanged(documentId, sourceText);
+                    }
                 }
             }
-            else
+            else if(buffer != null)
             {
                 TryAddTransientDocument(request.FileName, buffer);
             }


### PR DESCRIPTION
Simliar to requests containing a new [buffer](https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp/Models/v1/Request.cs#L11) this PR adds support for attaching incremental buffer updates to a request. This allows you get around an explicit call to ```/changebuffer``` and also has the neat side effect that clients don't have to process requests one after the other but send them in parallel - given they know what they do ;-)