### PR TITLE
Fix setting up PreprocessorSymbols for MSBuild project.

### DIFF
--- a/scripts/Omnisharp.cmd
+++ b/scripts/Omnisharp.cmd
@@ -1,3 +1,3 @@
 SETLOCAL
 
-%USERPROFILE%\.dnx\runtimes\dnx-clr-win-x86.1.0.0-beta4\bin\dnx %~dp0..\src\OmniSharp run %*
+"%USERPROFILE%\.dnx\runtimes\dnx-clr-win-x86.1.0.0-beta4\bin\dnx" %~dp0..\src\OmniSharp run %*

--- a/src/OmniSharp/MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp/MSBuild/MSBuildProjectSystem.cs
@@ -243,7 +243,7 @@ namespace OmniSharp.MSBuild
                     : new CSharpParseOptions();
                 if (projectFileInfo.DefineConstants != null && projectFileInfo.DefineConstants.Any())
                 {
-                    parseOptions.WithPreprocessorSymbols(projectFileInfo.DefineConstants);
+                    parseOptions = parseOptions.WithPreprocessorSymbols(projectFileInfo.DefineConstants);
                 }
                 _workspace.SetParseOptions(project.Id, parseOptions);
             }


### PR DESCRIPTION
There was incorrect usage of CSharpParseOptions.WithPreprocessorSymbols. Fixed after reading sources of roslyn - https://github.com/dotnet/roslyn/blob/6d228445c972c67259dbfa1aa203395cccb6f92e/src/Compilers/CSharp/Portable/CSharpParseOptions.cs