### PR TITLE
Added /stopserver

### DIFF
--- a/src/OmniSharp/Api/v1/ProjectSystem/OmnisharpController.Status.cs
+++ b/src/OmniSharp/Api/v1/ProjectSystem/OmnisharpController.Status.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Mvc;
+using Microsoft.Framework.Runtime;
+
+namespace OmniSharp
+{
+    public class StatusController
+    {
+        private readonly IApplicationShutdown _applicationShutdown;
+
+        public StatusController(IApplicationShutdown applicationShutdown)
+        {
+            _applicationShutdown = applicationShutdown;
+        }
+
+        [HttpPost("/stopserver")]
+        public bool StopServer()
+        {
+            Task.Run(() => {
+                Thread.Sleep(200);
+                _applicationShutdown.RequestShutdown();
+            });
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Works in stdio, unlike https://github.com/OmniSharp/omnisharp-roslyn/pull/190.

Run needs to returns for RequestShutdown to shutdown the server in stdio mode.

RequestShutdown is requested in the background to avoid an error which sometime occurs if it is ran in an action.