### PR TITLE
Do not show <global namespace> in type lookup

### DIFF
--- a/src/OmniSharp/Api/v1/Types/OmnisharpController.TypeLookup.cs
+++ b/src/OmniSharp/Api/v1/Types/OmnisharpController.TypeLookup.cs
@@ -24,7 +24,7 @@ namespace OmniSharp
                 if (symbol != null)
                 {
                     //non regular C# code semantics (interactive, script) don't allow namespaces
-                    if(document.SourceCodeKind == SourceCodeKind.Regular && symbol.Kind == SymbolKind.NamedType)
+                    if(document.SourceCodeKind == SourceCodeKind.Regular && symbol.Kind == SymbolKind.NamedType && !symbol.ContainingNamespace.IsGlobalNamespace)
                     {
                         response.Type = $"{symbol.ContainingNamespace.ToDisplayString()}.{symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)}";
                     }

--- a/tests/OmniSharp.Tests/TypeLookupFacts.cs
+++ b/tests/OmniSharp.Tests/TypeLookupFacts.cs
@@ -17,8 +17,26 @@ namespace OmniSharp.Tests
             var response = await controller.TypeLookup(new TypeLookupRequest { FileName = "dummy.csx", Line = 1, Column = 8 });
             
             Assert.Equal("Foo", response.Type);   
-        } 
-        
+        }
+
+        [Fact]
+        public async Task OmitsNamespaceForTypesInGlobalNamespace()
+        {
+            var source = @"namespace Bar {
+            class Foo {}
+            }
+            class Baz {}";
+
+            var workspace = TestHelpers.CreateSimpleWorkspace(source);
+
+            var controller = new OmnisharpController(workspace, new FakeOmniSharpOptions());
+            var responseInNormalNamespace = await controller.TypeLookup(new TypeLookupRequest { FileName = "dummy.cs", Line = 2, Column = 20 });
+            var responseInGlobalNamespace = await controller.TypeLookup(new TypeLookupRequest { FileName = "dummy.cs", Line = 4, Column = 20 });
+
+            Assert.Equal("Bar.Foo", responseInNormalNamespace.Type);
+            Assert.Equal("Baz", responseInGlobalNamespace.Type);
+        }
+
         [Fact]
         public async Task IncludesNamespaceForRegularCSharpSyntax()
         {


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/287
Fixes https://github.com/OmniSharp/omnisharp-atom/issues/275