### PR TITLE
Added IndentationSize to formatting options

### DIFF
--- a/src/OmniSharp/Api/v1/Formatting/OmnisharpController.Format.cs
+++ b/src/OmniSharp/Api/v1/Formatting/OmnisharpController.Format.cs
@@ -70,7 +70,8 @@ namespace OmniSharp
                 return _workspace.Options
                     .WithChangedOption(Microsoft.CodeAnalysis.Formatting.FormattingOptions.NewLine, LanguageNames.CSharp, _options.FormattingOptions.NewLine)
                     .WithChangedOption(Microsoft.CodeAnalysis.Formatting.FormattingOptions.UseTabs, LanguageNames.CSharp, _options.FormattingOptions.UseTabs)
-                    .WithChangedOption(Microsoft.CodeAnalysis.Formatting.FormattingOptions.TabSize, LanguageNames.CSharp, _options.FormattingOptions.TabSize);
+                    .WithChangedOption(Microsoft.CodeAnalysis.Formatting.FormattingOptions.TabSize, LanguageNames.CSharp, _options.FormattingOptions.TabSize)
+                    .WithChangedOption(Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentationSize, LanguageNames.CSharp, _options.FormattingOptions.IndentationSize);
             }
         }
     }

--- a/src/OmniSharp/Options/FormattingOptions.cs
+++ b/src/OmniSharp/Options/FormattingOptions.cs
@@ -7,5 +7,7 @@ namespace OmniSharp.Options
         public bool UseTabs { get; set; }
         
         public int TabSize { get; set; }
+
+        public int IndentationSize { get; set; }
     }   
 }

--- a/src/OmniSharp/config.json
+++ b/src/OmniSharp/config.json
@@ -8,6 +8,7 @@
     "formattingOptions": {
         "newLine": "\n",
         "useTabs": false,
-        "tabSize": 4
+        "tabSize": 4,
+        "indentationSize": 2
     }
 }

--- a/src/OmniSharp/config.json
+++ b/src/OmniSharp/config.json
@@ -9,6 +9,6 @@
         "newLine": "\n",
         "useTabs": false,
         "tabSize": 4,
-        "indentationSize": 2
+        "indentationSize": 4
     }
 }

--- a/tests/OmniSharp.Tests/FormattingFacts.cs
+++ b/tests/OmniSharp.Tests/FormattingFacts.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -192,6 +194,32 @@ class C {
             var controller = new OmnisharpController(workspace, null);
 
             return (await controller.FormatRange(req)).Changes;
+        }
+
+        [Fact]
+        public async Task FormatRespectsIndentationSize()
+        {
+            var source = "namespace Bar\n{\n    class Foo {}\n}";
+
+            var workspace = TestHelpers.CreateSimpleWorkspace(source);
+            var controller = new OmnisharpController(workspace, new FakeOmniSharpOptions
+            {
+                Options = new OmniSharpOptions
+                {
+                    FormattingOptions = new FormattingOptions
+                    {
+                        NewLine = "\n",
+                        IndentationSize = 1
+                    }
+                }
+            });
+
+            var result = await controller.FormatDocument(new Request
+            {
+                FileName = "dummy.cs"
+            });
+
+            Assert.Equal("namespace Bar\n{\n class Foo { }\n}", result.Buffer);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/266

Currently, omnisharp options expose `tabSize` which some of the users have been trying to use to control indentation (see https://github.com/OmniSharp/omnisharp-roslyn/issues/266).

However, it's only applicable to code formatting with Roslyn (and indeed it works with omnisharp now) when tabs are enabled - to determine the size of the tab. 

For regular indentation, Roslyn exposes another setting called `Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentationSize` which is the principal way of controlling how large the indentation should be.