### PR TITLE
correctly flow formatting options

### DIFF
--- a/src/OmniSharp/Options/FormattingOptions.cs
+++ b/src/OmniSharp/Options/FormattingOptions.cs
@@ -2,6 +2,15 @@ namespace OmniSharp.Options
 {
     public class FormattingOptions 
     {
+        public FormattingOptions()
+        {
+            //just defaults
+            NewLine = "\n";
+            UseTabs = false;
+            TabSize = 4;
+            IndentationSize = 4;
+        }
+
         public string NewLine { get; set; }
         
         public bool UseTabs { get; set; }

--- a/src/OmniSharp/Workers/Format/Formatting.cs
+++ b/src/OmniSharp/Workers/Format/Formatting.cs
@@ -65,7 +65,7 @@ namespace OmniSharp
 
         public static async Task<IEnumerable<LinePositionSpanTextChange>> GetFormattingChangesForRange(Workspace workspace, OptionSet options, Document document, int start, int end)
         {
-            var changedDocument = await Formatter.FormatAsync(document, TextSpan.FromBounds(start, end));
+            var changedDocument = await Formatter.FormatAsync(document, TextSpan.FromBounds(start, end), options);
             var textChanges = await changedDocument.GetTextChangesAsync(document);
 
             return (await LinePositionSpanTextChange.Convert(document, textChanges)).Select(change =>


### PR DESCRIPTION
I noticed another bug in formatting code - the formatting options are not flown correctly into `FormatAsync` when using `GetFormattingChangesForRange`.

On the other hand, when using `GetFormattedDocument`, the options are applied ([see here](https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp/Workers/Format/Formatting.cs#L80)).

This looks like a clear bug, because when formatting **the entire document**, the options (i.e. the new indentation size I added yesterday or use of tabs) are applied as expected, but on stroke or range formatting they are not falling back to the defaults, resulting in two different types of behavior in the document :)

This PR fixes it and correctly applies formatting also on stroke/range:
![format](https://cloud.githubusercontent.com/assets/1710369/10304850/fdda5468-6c1c-11e5-9393-69d43246d469.gif)
