### PR TITLE
[Don't merge yet]: Fix strong naming support in dnx projects

### DIFF
--- a/src/OmniSharp/Dnx/DnxProjectSystem.cs
+++ b/src/OmniSharp/Dnx/DnxProjectSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -325,9 +326,17 @@ namespace OmniSharp.Dnx
                                 specificDiagnosticOptions: specificDiagnosticOptions
                             );
 
+                        // Handle strong naming
+                        csharpOptions = csharpOptions.WithCryptoKeyFile(options.CryptoKeyFile)
+                                                     .WithDelaySign(options.DelaySign);
+
+                        if (options.CryptoPublicKey != null)
+                        {
+                            csharpOptions = csharpOptions.WithCryptoPublicKey(ImmutableArray.Create(options.CryptoPublicKey));
+                        }
+
                         var parseOptions = new CSharpParseOptions(val.CompilationOptions.LanguageVersion,
                                                                   preprocessorSymbols: val.CompilationOptions.Defines);
-
                         _workspace.SetCompilationOptions(projectId, csharpOptions);
                         _workspace.SetParseOptions(projectId, parseOptions);
                     }

--- a/src/OmniSharp/Dnx/OutgoingMessages/CompilationSettings.cs
+++ b/src/OmniSharp/Dnx/OutgoingMessages/CompilationSettings.cs
@@ -41,6 +41,9 @@ namespace Microsoft.Framework.Runtime.Roslyn
         public int WarningLevel { get; set; }
         public bool ConcurrentBuild { get; set; }
         public int GeneralDiagnosticOption { get; set; }
+        public string CryptoKeyFile { get; set; }
+        public bool? DelaySign { get; set; }
+        public byte[] CryptoPublicKey { get; set; }
         public Dictionary<string, int> SpecificDiagnosticOptions { get; set; }
     }
 }


### PR DESCRIPTION
- Flow compilation options to the workspace

There's a missing feature with respect to strong naming support for dnx projects. VsCode is still based off 1.5.5 so I made a branch to enable fixing this specific thing. VSCode can't take 1.6.0 because it still has a bunch of bugs that need to be worked out (I've filed some myself). 

This is mostly a for code review. I'll send out another one based on 1.6.0 soon. The port should be trivial.

/cc @jrieken 