### PR TITLE
Initial support for Protobuild modules

### DIFF
--- a/OmniSharp.sln
+++ b/OmniSharp.sln
@@ -42,6 +42,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OmniSharp.MSBuild", "src\Om
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OmniSharp.ScriptCs", "src\OmniSharp.ScriptCs\OmniSharp.ScriptCs.xproj", "{F52F6F60-AB29-414D-A24B-DE8EFFBA34C0}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OmniSharp.Protobuild", "src\OmniSharp.Protobuild\OmniSharp.Protobuild.xproj", "{9AF025CA-3706-401F-8D50-59FAD5AFE726}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -96,6 +98,10 @@ Global
 		{F52F6F60-AB29-414D-A24B-DE8EFFBA34C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F52F6F60-AB29-414D-A24B-DE8EFFBA34C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F52F6F60-AB29-414D-A24B-DE8EFFBA34C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9AF025CA-3706-401F-8D50-59FAD5AFE726}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9AF025CA-3706-401F-8D50-59FAD5AFE726}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9AF025CA-3706-401F-8D50-59FAD5AFE726}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9AF025CA-3706-401F-8D50-59FAD5AFE726}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -113,5 +119,6 @@ Global
 		{4F5FC4AF-3977-4ECB-9B58-D16E8024BC97} = {2C348365-A9D8-459E-9276-56FC46AAEE31}
 		{9AF025CA-3706-401F-8D50-59FAD5AFE725} = {2C348365-A9D8-459E-9276-56FC46AAEE31}
 		{F52F6F60-AB29-414D-A24B-DE8EFFBA34C0} = {2C348365-A9D8-459E-9276-56FC46AAEE31}
+		{9AF025CA-3706-401F-8D50-59FAD5AFE726} = {2C348365-A9D8-459E-9276-56FC46AAEE31}
 	EndGlobalSection
 EndGlobal

--- a/build.cmd
+++ b/build.cmd
@@ -64,6 +64,7 @@ popd
 call dnu build src/OmniSharp.Abstractions --configuration Release --out artifacts
 call dnu build src/OmniSharp.Dnx --configuration Release --out artifacts
 call dnu build src/OmniSharp.MSBuild --configuration Release --out artifacts
+call dnu build src/OmniSharp.Protobuild --configuration Release --out artifacts
 call dnu build src/OmniSharp.Nuget --configuration Release --out artifacts
 call dnu build src/OmniSharp.Roslyn --configuration Release --out artifacts
 call dnu build src/OmniSharp.Roslyn.CSharp --configuration Release --out artifacts

--- a/build.sh
+++ b/build.sh
@@ -67,6 +67,7 @@ dnu build src/OmniSharp.Abstractions --configuration Release --out artifacts
 dnu build src/OmniSharp.Bootstrap --configuration Release --out artifacts
 dnu build src/OmniSharp.Dnx --configuration Release --out artifacts
 dnu build src/OmniSharp.MSBuild --configuration Release --out artifacts
+dnu build src/OmniSharp.Protobuild --configuration Release --out artifacts
 dnu build src/OmniSharp.Nuget --configuration Release --out artifacts
 dnu build src/OmniSharp.Roslyn --configuration Release --out artifacts
 dnu build src/OmniSharp.Roslyn.CSharp --configuration Release --out artifacts

--- a/src/OmniSharp.Abstractions/Services/FileSystemWatcherWrapper.cs
+++ b/src/OmniSharp.Abstractions/Services/FileSystemWatcherWrapper.cs
@@ -8,6 +8,7 @@ namespace OmniSharp.Services
     {
         private readonly FileSystemWatcher _watcher;
         private readonly Dictionary<string, Action<string>> _callbacks = new Dictionary<string, Action<string>>();
+        private readonly List<Action<string>> _globalCallbacks = new List<Action<string>>();
 
         public FileSystemWatcherWrapper(IOmnisharpEnvironment env)
         {
@@ -37,11 +38,20 @@ namespace OmniSharp.Services
             {
                 callback(path);
             }
+            foreach (var globalCallback in _globalCallbacks)
+            {
+                globalCallback(path);
+            }
         }
 
         public void Watch(string path, Action<string> callback)
         {
             _callbacks[path] = callback;
+        }
+        
+        public void WatchGlobal(Action<string> callback)
+        {
+            _globalCallbacks.Add(callback);
         }
     }
 }

--- a/src/OmniSharp.Abstractions/Services/IFileSystemWatcher.cs
+++ b/src/OmniSharp.Abstractions/Services/IFileSystemWatcher.cs
@@ -6,6 +6,8 @@ namespace OmniSharp.Services
     public interface IFileSystemWatcher
     {
         void Watch(string path, Action<string> callback);
+        
+        void WatchGlobal(Action<string> callback);
 
         void TriggerChange(string path);
     }

--- a/src/OmniSharp.Abstractions/Services/ManualFileSystemWatcher.cs
+++ b/src/OmniSharp.Abstractions/Services/ManualFileSystemWatcher.cs
@@ -6,6 +6,7 @@ namespace OmniSharp.Services
     public class ManualFileSystemWatcher : IFileSystemWatcher
     {
         private readonly Dictionary<string, Action<string>> _callbacks = new Dictionary<string, Action<string>>();
+        private readonly List<Action<string>> _globalCallbacks = new List<Action<string>>();
 
         public void TriggerChange(string path)
         {
@@ -14,11 +15,20 @@ namespace OmniSharp.Services
             {
                 callback(path);
             }
+            foreach (var globalCallback in _globalCallbacks)
+            {
+                globalCallback(path);
+            }
         }
 
         public void Watch(string path, Action<string> callback)
         {
             _callbacks[path] = callback;
+        }
+        
+        public void WatchGlobal(Action<string> callback)
+        {
+            _globalCallbacks.Add(callback);
         }
     }
 }

--- a/src/OmniSharp.MSBuild/MSBuildContext.cs
+++ b/src/OmniSharp.MSBuild/MSBuildContext.cs
@@ -12,5 +12,6 @@ namespace OmniSharp.MSBuild
         public Dictionary<Guid, ProjectId> ProjectGuidToWorkspaceMapping { get; } = new Dictionary<Guid, ProjectId>();
         public Dictionary<string, ProjectFileInfo> Projects { get; } = new Dictionary<string, ProjectFileInfo>();
         public string SolutionPath { get; set; }
+        public bool AlreadyInitialised { get; set; }
     }
 }

--- a/src/OmniSharp.Protobuild/OmniSharp.Protobuild.xproj
+++ b/src/OmniSharp.Protobuild/OmniSharp.Protobuild.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>9af025ca-3706-401f-8d50-59fad5afe726</ProjectGuid>
+    <RootNamespace>OmniSharp.Protobuild</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/OmniSharp.Protobuild/ProtobuildProjectSystem.cs
+++ b/src/OmniSharp.Protobuild/ProtobuildProjectSystem.cs
@@ -1,0 +1,141 @@
+using System.Composition;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Framework.ConfigurationModel;
+using Microsoft.Framework.Logging;
+using OmniSharp.MSBuild;
+using OmniSharp.Services;
+
+namespace OmniSharp.Protobuild
+{
+    [Export(typeof(IProjectSystem))]
+    public class ProtobuildProjectSystem : MSBuildProjectSystem
+    {
+        private readonly IOmnisharpEnvironment _env;
+        private readonly MSBuildContext _context;
+        private readonly IFileSystemWatcher _watcher;
+        private FileSystemWatcher _fsWatcher;
+
+        [ImportingConstructor]
+        public ProtobuildProjectSystem(
+            OmnisharpWorkspace workspace,
+            IOmnisharpEnvironment env,
+            ILoggerFactory loggerFactory,
+            IEventEmitter emitter,
+            IMetadataFileReferenceCache metadataReferenceCache,
+            IFileSystemWatcher watcher,
+            MSBuildContext context) : base(
+                workspace,
+                env,
+                loggerFactory,
+                emitter,
+                metadataReferenceCache,
+                watcher,
+                context)
+        {
+            _env = env;
+            _logger = loggerFactory.CreateLogger<ProtobuildProjectSystem>();
+            _context = context;
+            _watcher = watcher;
+        }
+        
+        public override string Key { get { return "Protobuild"; } }
+
+        public override void Initalize(IConfiguration configuration)
+        {
+            _context.AlreadyInitialised = false;
+
+            _logger.LogInformation("Searching for Protobuild in this folder");
+
+            if (!File.Exists(Path.Combine(_env.Path, "Protobuild.exe")))
+            {
+                _logger.LogInformation("Protobuild.exe not detected in this folder");
+                return;
+            }
+
+            RunProtobuild();
+            
+            // Watch for definition file changes.
+            if (_watcher.GetType().FullName.Contains("Manual"))
+            {
+                // We must use a proper filesystem watcher so that we know
+                // when definition files change (at the very least, the manual
+                // watcher does not appear to work in Visual Studio Code).
+                if (_fsWatcher != null)
+                {
+                    _fsWatcher.Dispose();
+                }
+                _fsWatcher = new FileSystemWatcher(_env.Path);
+                _fsWatcher.IncludeSubdirectories = true;
+                _fsWatcher.EnableRaisingEvents = true;
+                _fsWatcher.Changed += OnChanged;
+                _fsWatcher.Created += OnChanged;
+                _fsWatcher.Deleted += OnChanged;
+                _fsWatcher.Renamed += (sender, e) =>
+                {
+                    OnFileChanged(e.OldFullPath);
+                    OnFileChanged(e.FullPath);
+                };
+            }
+            else
+            {
+                _watcher.WatchGlobal(OnFileChanged);
+            }
+
+            // Now just initialize the MSBuild project system.
+            base.Initalize(configuration);
+            _context.AlreadyInitialised = true;
+        }
+        
+        private void RunProtobuild()
+        {
+            // TODO: Offer the user some way of changing the current platform from IDEs.
+            // For now, just assume the host platform.
+            string hostPlatform;
+            if (Path.DirectorySeparatorChar == '/')
+            {
+                if (Directory.Exists("/Library"))
+                {
+                    hostPlatform = "MacOS";
+                }
+                else
+                {
+                    hostPlatform = "Linux";
+                }
+            }
+            else
+            {
+                hostPlatform = "Windows";
+            }
+            
+            _logger.LogInformation("Running Protobuild.exe with --generate " + hostPlatform);
+
+            var startInfo = new ProcessStartInfo();
+            startInfo.FileName = Path.Combine(_env.Path, "Protobuild.exe");
+            startInfo.Arguments = "--generate " + hostPlatform;
+            startInfo.UseShellExecute = false;
+            startInfo.WorkingDirectory = _env.Path;
+            var process = Process.Start(startInfo);
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                _logger.LogCritical("Protobuild did not exit successfully (check the log file for details)!");
+            }
+        }
+
+        private void OnChanged(object sender, FileSystemEventArgs e)
+        {
+            OnFileChanged(e.FullPath);
+        }
+        
+        private void OnFileChanged(string path)
+        {
+            if (new FileInfo(path).Extension == ".definition")
+            {
+                _logger.LogInformation("Detected definition file change; running Protobuild");
+                RunProtobuild();
+            }
+        }
+    }
+}

--- a/src/OmniSharp.Protobuild/project.json
+++ b/src/OmniSharp.Protobuild/project.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "warningsAsErrors": true
+  },
+  "dependencies": {
+    "OmniSharp.Abstractions": "1.0.0-*",
+    "OmniSharp.Roslyn.CSharp": "1.0.0-*",
+    "OmniSharp.MSBuild": "1.0.0-*",
+    "Microsoft.Framework.Logging.Console": "1.0.0-beta4"
+  },
+  "frameworks": {
+    "dnx451": {
+      "frameworkAssemblies": {
+        "Microsoft.Build": "",
+        "Microsoft.Build.Engine": "",
+        "Microsoft.Build.Framework": ""
+      }
+    }
+  }
+}

--- a/src/OmniSharp/project.json
+++ b/src/OmniSharp/project.json
@@ -24,6 +24,7 @@
   "frameworks": {
     "dnx451": {
       "dependencies": {
+        "OmniSharp.Protobuild": "1.0.0-*",
         "OmniSharp.MSBuild": "1.0.0-*",
         "OmniSharp.ScriptCs": "1.0.0-*"
       }


### PR DESCRIPTION
Addresses #341.  If you open a folder with Protobuild.exe inside it, it now automatically runs Protobuild with the host platform chosen.  When users edit definition files, Protobuild is automatically re-run.

One thing I'm not sure how to address yet is prompting the user what platform they want to generate for.  I don't know if there's an API to interact with the editor in such a way to prompt the user for an option.