### PR TITLE
Design Time Host changes to improve socket connection and monitoring

### DIFF
--- a/src/OmniSharp.Dnx/DnxProjectSystem.cs
+++ b/src/OmniSharp.Dnx/DnxProjectSystem.cs
@@ -108,10 +108,11 @@ namespace OmniSharp.Dnx
             _designTimeHostManager.Start(_context.HostId, port =>
             {
                 var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-                socket.Connect(new IPEndPoint(IPAddress.Loopback, port));
-
+                
+                new SocketConnection(socket, port, "DnxProjectSystem" , _logger);
+                
                 var networkStream = new NetworkStream(socket);
-
+                
                 _logger.LogInformation("Connected");
 
                 _context.DesignTimeHostPort = port;
@@ -647,5 +648,6 @@ namespace OmniSharp.Dnx
         {
             return Task.FromResult<object>(new DnxWorkspaceInformation(_context));
         }
+        
     }
 }

--- a/src/OmniSharp.Dnx/Utilities/SocketConnection.cs
+++ b/src/OmniSharp.Dnx/Utilities/SocketConnection.cs
@@ -8,71 +8,71 @@ namespace OmniSharp
 {
     public class SocketConnection
     {
-        public ILogger Logger { get; private set; }
-        public string ContextFlag { get; private set; }
-        
+        public ILogger Logger { get; }
+        private string ContextFlag { get; }
+
         public bool dthConnectSuccess = false;
-        
-        public SocketConnection( Socket socket, int port, string contextFlag, ILogger logger )
+
+        public SocketConnection(Socket socket, int port, string contextFlag, ILogger logger)
         {
             Logger = logger;
             ContextFlag = contextFlag;
-            Initialize(socket, port);        
+            Initialize(socket, port);
         }
-        
-        private void Initialize( Socket socket, int port)
+
+        private void Initialize(Socket socket, int port)
         {
-                    
+
             socket.NoDelay = true;
             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-                    
+
             SocketAsyncEventArgs connect = new SocketAsyncEventArgs();
-                    
+
             connect.Completed += new EventHandler<SocketAsyncEventArgs>(SocketEventArg_Completed);
             connect.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, port);
             connect.UserToken = socket;
-                    
+
             Thread.Sleep(500);
-                try
-                {
-                socket.ConnectAsync(connect);                
-                }
-                catch (SocketException)
-                {
+            try
+            {
+                socket.ConnectAsync(connect);
+            }
+            catch (SocketException)
+            {
                 // this happens when the DTH isn't listening yet
-                Logger.LogVerbose("[SocketConnection]: Socket Connection failed");
-                }                        
+                Logger.LogError("[SocketConnection]: Socket Connection failed");
+            }
         }
-        
+
         public void SocketEventArg_Completed(object sender, SocketAsyncEventArgs e)
         {
             switch (e.LastOperation)
             {
                 case SocketAsyncOperation.Connect:
-                    
+
                     var t1 = DateTime.UtcNow;
                     var dthTimeout = TimeSpan.FromSeconds(30);
-                   
-                   while(DateTime.UtcNow - t1 < dthTimeout && !dthConnectSuccess && ContextFlag == "DnxProjectSystem")
-                   {
+
+                    while (DateTime.UtcNow - t1 < dthTimeout && !dthConnectSuccess && ContextFlag == "DnxProjectSystem")
+                    {
                         Thread.Sleep(1000);
-                        Logger.LogInformation("Socket State: "+e.SocketError.ToString());
-                        
+                        Logger.LogInformation("Socket State: " + e.SocketError.ToString());
+
                         if (e.SocketError == SocketError.Success)
                         {
                             dthConnectSuccess = true;
                         }
-                   }
-                   
-                   if(!dthConnectSuccess && ContextFlag == "DnxProjectSystem")
-                   {
-                       Logger.LogError("Connection Timed Out");
-                       throw new SocketException((int)e.SocketError);
-                   }
-                  break;
+                    }
+
+                    if (!dthConnectSuccess && ContextFlag == "DnxProjectSystem")
+                    {
+                        Logger.LogError("Connection Timed Out");
+                        throw new SocketException((int)e.SocketError);
+                    }
+                    break;
             }
         }
-        
-}
+
+    }
 
 }

--- a/src/OmniSharp.Dnx/Utilities/SocketConnection.cs
+++ b/src/OmniSharp.Dnx/Utilities/SocketConnection.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using Microsoft.Framework.Logging;
+
+namespace OmniSharp
+{
+    public class SocketConnection
+    {
+        public ILogger Logger { get; private set; }
+        public string ContextFlag { get; private set; }
+        
+        public bool dthConnectSuccess = false;
+        
+        public SocketConnection( Socket socket, int port, string contextFlag, ILogger logger )
+        {
+            Logger = logger;
+            ContextFlag = contextFlag;
+            Initialize(socket, port);        
+        }
+        
+        private void Initialize( Socket socket, int port)
+        {
+                    
+            socket.NoDelay = true;
+            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+                    
+            SocketAsyncEventArgs connect = new SocketAsyncEventArgs();
+                    
+            connect.Completed += new EventHandler<SocketAsyncEventArgs>(SocketEventArg_Completed);
+            connect.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, port);
+            connect.UserToken = socket;
+                    
+            Thread.Sleep(500);
+                try
+                {
+                socket.ConnectAsync(connect);                
+                }
+                catch (SocketException)
+                {
+                // this happens when the DTH isn't listening yet
+                Logger.LogVerbose("[SocketConnection]: Socket Connection failed");
+                }                        
+        }
+        
+        public void SocketEventArg_Completed(object sender, SocketAsyncEventArgs e)
+        {
+            switch (e.LastOperation)
+            {
+                case SocketAsyncOperation.Connect:
+                    
+                    var t1 = DateTime.UtcNow;
+                    var dthTimeout = TimeSpan.FromSeconds(30);
+                   
+                   while(DateTime.UtcNow - t1 < dthTimeout && !dthConnectSuccess && ContextFlag == "DnxProjectSystem")
+                   {
+                        Thread.Sleep(1000);
+                        Logger.LogInformation("Socket State: "+e.SocketError.ToString());
+                        
+                        if (e.SocketError == SocketError.Success)
+                        {
+                            dthConnectSuccess = true;
+                        }
+                   }
+                   
+                   if(!dthConnectSuccess && ContextFlag == "DnxProjectSystem")
+                   {
+                       Logger.LogError("Connection Timed Out");
+                       throw new SocketException((int)e.SocketError);
+                   }
+                  break;
+            }
+        }
+        
+}
+
+}


### PR DESCRIPTION
Original socket connection was exceeding it's timeout checking the connection before the socket was bound. Socket status is checked and logged asynchronously. 