### PR TITLE
Ignore new line differences in tests

### DIFF
--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FixUsingsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FixUsingsFacts.cs
@@ -433,14 +433,11 @@ namespace OmniSharp
         private async Task AssertBufferContents(string fileContents, string expectedFileContents)
         {
             var response = await RunFixUsings(fileContents);
-            if (PlatformServices.Default.Runtime.OperatingSystem == "Windows")
-            {
-                Assert.Equal(expectedFileContents, response.Buffer);
-            }
-            else
-            {
-                Assert.Equal(expectedFileContents, response.Buffer.Replace("\r\n", "\n"));
-            }
+            Assert.Equal(FlattenNewLines(expectedFileContents), FlattenNewLines(response.Buffer));
+        }
+
+        private string FlattenNewLines(string input) {
+            return input.Replace("\r\n", "\n");
         }
 
         private async Task AssertUnresolvedReferences(string fileContents, List<QuickFix> expectedUnresolved)


### PR DESCRIPTION
If the test source, and thus the test contents is using a different new
line sequence than the system, these tests will fail because the output
will differ by the new lines. Flatten new lines into a single new line
format before testing for equality.

Closes #376 (code via @mispencer)