### PR TITLE
Update build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ osx_image: xcode7.1
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install jq; fi
-install: curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh
-  | sh && source ~/.dnx/dnvm/dnvm.sh && dnvm upgrade
 before_script:
   - chmod +x build.sh
 script:
@@ -29,7 +27,6 @@ addons:
       - libunwind8
       - zlib1g
       - curl
-      - tree
 deploy:
   provider: releases
   api_key:

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,6 @@ work_dir=`pwd`
 build_tools=$work_dir/.build
 nuget_path=$build_tools/nuget.exe
 configuration="Debug"
-dotnet=$work_dir/.dotnet/bin/dotnet
 
 artifacts=$work_dir/artifacts
 log_output=$artifacts/logs
@@ -21,6 +20,7 @@ if [ "$1" == "--quick" ]; then
 fi
 
 if [ "$1" == "--install" ]; then
+    install_dotnet
     if [ -d ~/.omnisharp/local ]; then
         echo "Removing local omnisharp ..."
         rm -rf ~/.omnisharp/local

--- a/build.sh
+++ b/build.sh
@@ -7,157 +7,62 @@ configuration="Debug"
 dotnet=$work_dir/.dotnet/bin/dotnet
 
 artifacts=$work_dir/artifacts
-publish_output=$artifacts/publish
 log_output=$artifacts/logs
 
-_header() {
-  if [ "$TRAVIS" == true ]; then 
-    printf "%b\n" "*** $1 ***"
-  else
-    printf "%b\n" "\e[1;32m*** $1 ***\e[0m"
-  fi
-}
-
-_test() {
-  cd $work_dir/tests/$1 
-
-  $dotnet build --configuration $configuration \
-    >$log_output/$1-build.log 2>&1 \
-    || { echo >&2 "Failed to build $1"; cat $log_output/$1-build.log; exit 1; }
-
-  if [ "$2" != "-skipdnxcore50" ]; then
-    $dotnet test -xml $log_output/$1-dnxcore50-result.xml -notrait category=failing \
-      || { echo >&2 "Test failed: $1 / dnxcore50"; exit 1; }
-  fi
-
-  if [ "$2" != "-skipdnx451" ]; then
-    test_output="$(dirname `ls ./bin/$configuration/dnx451/*/$1.dll`)"
-    cp $build_tools/xunit.runner.console/tools/* $test_output
-    mono $test_output/xunit.console.x86.exe $test_output/$1.dll \
-      -xml $log_output/$1-dnx451-result.xml -notrait category=failing \
-      || { echo >&2 "Test failed: $1 / dnx451"; exit 1; }
-  fi
-
-  cd $work_dir
-}
-
-_publish() {
-  local _src="src/$1"
-  local _output="artifacts/publish/$1"
-
-  $dotnet publish $_src --framework dnxcore50 -o $_output/dnxcore50/ --configuration $configuration
-  $dotnet publish $_src --framework dnx451 -o $_output/dnx451/ --configuration $configuration
-
-  # copy binding redirect configuration respectively to mitigate dotnet publish bug
-  cp $_src/bin/$configuration/dnx451/*/$1.exe.config $_output/dnx451/
-}
-
-_prerequisite() {
-  _header "Installing dotnet from beta channel"
-  mkdir -p .dotnet
-
-  local dotnet_install_script_source="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.sh"
-  local dotnet_install_script=.dotnet/install.sh
-
-  curl -o $dotnet_install_script $dotnet_install_script_source -s
-  chmod +x $dotnet_install_script
-  $dotnet_install_script -c beta -d .dotnet
-
-  _header "Installing NuGet"
-  mkdir -p $build_tools
-
-  nuget_version=latest
-  nuget_download_url=https://dist.nuget.org/win-x86-commandline/$nuget_version/nuget.exe
-  if [ "$TRAVIS" == true ]; then
-    echo "get nuget.exe under travis"
-    wget -O $nuget_path $nuget_download_url 2>/dev/null || curl -o $nuget_path --location $nuget_download_url /dev/null
-  else
-    # Ensure NuGet is downloaded to .build folder
-    if test ! -f $nuget_path; then
-      if test `uname` = Darwin; then
-        cachedir=~/Library/Caches/OmniSharpBuild
-      else
-        if test -z $XDG_DATA_HOME; then
-          cachedir=$HOME/.local/share
-        else
-          cachedir=$XDG_DATA_HOME
-        fi
-      fi
-      mkdir -p $cachedir
-      cache_nuget=$cachedir/nuget.$nuget_version.exe
-
-      if test ! -f $cache_nuget; then
-        wget -O $cache_nuget $nuget_download_url 2>/dev/null || curl -o $cache_nuget --location $nuget_download_url /dev/null
-      fi
-
-      cp $cache_nuget $nuget_path
-    fi
-  fi
-
-  _header "Download xunit console runner"
-  # Download xunit console runner for CLR based tests
-  if test ! -d $build_tools/xunit.runner.console; then
-    mono $nuget_path install xunit.runner.console -ExcludeVersion -o $build_tools -nocache -pre
-  fi
-
-  xunit_clr_runner=$build_tools/xunit.runner.console/tools
-
-  # Handle to many files on osx
-  if [ "$TRAVIS_OS_NAME" == "osx" ] || [ `uname` == "Darwin" ]; then
-    ulimit -n 4096
-  fi
-  
-  mkdir -p $log_output
-
-  # set the DOTNET_REFERENCE_ASSEMBLIES_PATH to mono reference assemblies folder
-  # https://github.com/dotnet/cli/issues/531
-  if [ -z "$DOTNET_REFERENCE_ASSEMBLIES_PATH" ]; then
-    if [ $(uname) == Darwin ] && [ -d "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks" ]; then
-        export DOTNET_REFERENCE_ASSEMBLIES_PATH="/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks"
-    elif [ -d "/usr/local/lib/mono/xbuild-frameworks" ]; then
-        export DOTNET_REFERENCE_ASSEMBLIES_PATH="/usr/local/lib/mono/xbuild-frameworks"
-    elif [ -d "/usr/lib/mono/xbuild-frameworks" ]; then
-        export DOTNET_REFERENCE_ASSEMBLIES_PATH="/usr/lib/mono/xbuild-frameworks"
-    fi
-  fi
-}
-
-_restore() {
-  _header "Restoring packages"
-  if [ "$TRAVIS" == true ]; then 
-    $dotnet restore -v Warning || { echo >&2 "Failed to restore packages."; exit 1; }
-  else
-    $dotnet restore || { echo >&2 "Failed to restore packages."; exit 1; }
-  fi
-}
+. ./scripts/tasks.sh
 
 #########################
 # Main
+
 if [ "$1" == "--quick" ]; then
-  _publish "OmniSharp" || { echo >&2 "Failed to quick build. Try to build the OmniSharp without --quick switch."; exist 1; }
-  exit 0
+    install_dotnet
+    publish "OmniSharp" || { echo >&2 "Failed to quick build. Try to build the OmniSharp without --quick switch."; exit 1; }
+    exit 0
+fi
+
+if [ "$1" == "--install" ]; then
+    if [ -d ~/.omnisharp/local ]; then
+        echo "Removing local omnisharp ..."
+        rm -rf ~/.omnisharp/local
+    fi
+
+    mkdir -p ~/.omnisharp/local
+
+    publish "OmniSharp" "~/.omnisharp/local" || \
+        { echo >&2 "Failed to quick build. Try to build the OmniSharp without --install switch."; exit 1; }
+    
+    exit 0
 fi
 
 # Clean up
-_header "Cleanup"
+header "Cleanup"
 rm -rf artifacts
 
-# Set up pre-requisite
-_prerequisite
+# Set up
+mkdir -p $build_tools
+mkdir -p $log_output
+
+install_dotnet
+install_nuget
+install_xunit_runner
+set_dotnet_reference_path
 
 # Restore
-_restore
+restore_packages
 
 # Testing
-_header "Testing"
+run_test OmniSharp.Bootstrap.Tests
+run_test OmniSharp.MSBuild.Tests       -skipdnxcore50
+run_test OmniSharp.Roslyn.CSharp.Tests -skipdnx451
+run_test OmniSharp.Stdio.Tests
 
-_test OmniSharp.Bootstrap.Tests
-_test OmniSharp.MSBuild.Tests       -skipdnxcore50
-_test OmniSharp.Roslyn.CSharp.Tests -skipdnx451
-_test OmniSharp.Stdio.Tests
+# Packaging
+for project in `ls src`; do
+    package "OmniSharp.Abstractions"
+done
 
 # OmniSharp.Roslyn.CSharp.Tests is skipped on dnx451 target because an issue in MEF assembly load on xunit
 # Failure repo: https://github.com/troydai/loaderfailure
 
 # Publish
-_publish "OmniSharp"
+publish "OmniSharp"

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ if [ "$1" == "--install" ]; then
 
     mkdir -p ~/.omnisharp/local
 
-    publish "OmniSharp" "~/.omnisharp/local" || \
+    publish "OmniSharp" "$HOME/.omnisharp/local" || \
         { echo >&2 "Failed to quick build. Try to build the OmniSharp without --install switch."; exit 1; }
     
     exit 0

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -1,0 +1,158 @@
+# Major build tasks
+
+header() {
+    if [ "$TRAVIS" == true ]; then
+        printf "%b\n" "*** $1 ***"
+    else
+        printf "%b\n" "\e[1;32m*** $1 ***\e[0m"
+    fi
+}
+
+run_test() {
+    header "Running tests: $1"
+    cd $work_dir/tests/$1
+
+    $dotnet build --configuration $configuration \
+        >$log_output/$1-build.log 2>&1 \
+        || { echo >&2 "Failed to build $1"; cat $log_output/$1-build.log; exit 1; }
+
+    if [ "$2" != "-skipdnxcore50" ]; then
+        $dotnet test -xml $log_output/$1-dnxcore50-result.xml -notrait category=failing \
+            || { echo >&2 "Test failed: $1 / dnxcore50"; exit 1; }
+    fi
+
+    if [ "$2" != "-skipdnx451" ]; then
+        test_output="$(dirname `ls ./bin/$configuration/dnx451/*/$1.dll`)"
+        cp $build_tools/xunit.runner.console/tools/* $test_output
+        mono $test_output/xunit.console.x86.exe $test_output/$1.dll \
+        -xml $log_output/$1-dnx451-result.xml -notrait category=failing \
+            || { echo >&2 "Test failed: $1 / dnx451"; exit 1; }
+    fi
+
+    cd $work_dir
+}
+
+restore_packages() {
+    header "Restoring packages"
+    
+    # Handle to many files on osx
+    if [ "$TRAVIS_OS_NAME" == "osx" ] || [ `uname` == "Darwin" ]; then
+        ulimit -n 4096
+    fi
+  
+    if [ "$TRAVIS" == true ]; then
+        $dotnet restore -v Warning || { echo >&2 "Failed to restore packages."; exit 1; }
+    else
+        $dotnet restore || { echo >&2 "Failed to restore packages."; exit 1; }
+    fi
+}
+
+install_dotnet() {
+    header "Installing dotnet"
+    local _dotnet_install_script_source="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.sh"
+    local _dotnet_install_script=$build_tools/install.sh
+
+    curl -o $_dotnet_install_script $_dotnet_install_script_source -s
+    chmod +x $_dotnet_install_script
+
+    if [ "$TRAVIS" == true ]; then
+        echo "Installing dotnet from beta channel for CI environment ..."
+
+        $_dotnet_install_script -c beta -d "$build_tools/.dotnet"
+        dotnet="$build_tools/.dotnet/bin/dotnet"
+    else
+        echo "Installing dotnet from beta channel for local environment ..."
+
+        $_dotnet_install_script -c beta
+        dotnet="dotnet"
+    fi
+}
+
+install_nuget() {
+    header "Installing NuGet"
+    nuget_version=latest
+    nuget_download_url=https://dist.nuget.org/win-x86-commandline/$nuget_version/nuget.exe
+
+    if [ "$TRAVIS" == true ]; then
+        echo "get nuget.exe under travis"
+        wget -O $nuget_path $nuget_download_url 2>/dev/null || curl -o $nuget_path --location $nuget_download_url /dev/null
+    else
+        # Ensure NuGet is downloaded to .build folder
+        if test ! -f $nuget_path; then
+        if test `uname` = Darwin; then
+            cachedir=~/Library/Caches/OmniSharpBuild
+        else
+            if test -z $XDG_DATA_HOME; then
+            cachedir=$HOME/.local/share
+            else
+            cachedir=$XDG_DATA_HOME
+            fi
+        fi
+        mkdir -p $cachedir
+        cache_nuget=$cachedir/nuget.$nuget_version.exe
+
+        if test ! -f $cache_nuget; then
+            wget -O $cache_nuget $nuget_download_url 2>/dev/null || curl -o $cache_nuget --location $nuget_download_url /dev/null
+        fi
+
+        cp $cache_nuget $nuget_path
+        fi
+    fi
+}
+
+# Install xunit console runner for CLR
+install_xunit_runner() {
+    header "Downloading xunit console runner"
+    
+    if test ! -d $build_tools/xunit.runner.console; then
+        mono $nuget_path install xunit.runner.console -ExcludeVersion -o $build_tools -nocache -pre
+    fi
+
+    xunit_clr_runner=$build_tools/xunit.runner.console/tools
+}
+
+set_dotnet_reference_path() { 
+    # set the DOTNET_REFERENCE_ASSEMBLIES_PATH to mono reference assemblies folder
+    # https://github.com/dotnet/cli/issues/531
+    if [ -z "$DOTNET_REFERENCE_ASSEMBLIES_PATH" ]; then
+        if [ $(uname) == Darwin ] && [ -d "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks" ]; then
+            export DOTNET_REFERENCE_ASSEMBLIES_PATH="/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks"
+        elif [ -d "/usr/local/lib/mono/xbuild-frameworks" ]; then
+            export DOTNET_REFERENCE_ASSEMBLIES_PATH="/usr/local/lib/mono/xbuild-frameworks"
+        elif [ -d "/usr/lib/mono/xbuild-frameworks" ]; then
+            export DOTNET_REFERENCE_ASSEMBLIES_PATH="/usr/lib/mono/xbuild-frameworks"
+        fi
+    fi
+
+    header "Set DOTNET_REFERENCE_ASSEMBLIES_PATH to $DOTNET_REFERENCE_ASSEMBLIES_PATH"
+}
+
+publish() {
+    header "Publishing $1"
+    
+    _output="$artifacts/publish/$1"
+    if [ -n "$2" ]; then
+        _output="$2"
+    fi
+    
+    echo "Publish project to $_output"
+    for framework in dnx451 dnxcore50; do
+        $dotnet publish $work_dir/src/$1 \
+                --framework $framework \
+                --output $_output/$framework \
+                --configuration $configuration
+    done
+
+    # copy binding redirect configuration respectively to mitigate dotnet publish bug
+    cp $work_dir/src/$1/bin/$configuration/dnx451/*/$1.exe.config $_output/dnx451/
+}
+
+package() {
+    header "Packaging $1"
+    
+    for c in Release Debug; do
+        $dotnet pack $work_dir/src/$1 \
+                --output $artifacts/packages/$c/ \
+                --configuration $c
+    done
+}

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -74,7 +74,6 @@ install_nuget() {
     nuget_download_url=https://dist.nuget.org/win-x86-commandline/$nuget_version/nuget.exe
 
     if [ "$TRAVIS" == true ]; then
-        echo "get nuget.exe under travis"
         wget -O $nuget_path $nuget_download_url 2>/dev/null || curl -o $nuget_path --location $nuget_download_url /dev/null
     else
         # Ensure NuGet is downloaded to .build folder
@@ -105,7 +104,7 @@ install_xunit_runner() {
     header "Downloading xunit console runner"
     
     if test ! -d $build_tools/xunit.runner.console; then
-        mono $nuget_path install xunit.runner.console -ExcludeVersion -o $build_tools -nocache -pre
+        mono $nuget_path install xunit.runner.console -ExcludeVersion -o $build_tools -nocache -pre -Source https://api.nuget.org/v3/index.json
     fi
 
     xunit_clr_runner=$build_tools/xunit.runner.console/tools


### PR DESCRIPTION
Move tasks to their own scripts so as to clean up the main build scripts
and enable sharing in the future.

Add packaging to the build process.