### PR TITLE
Add support for DotNetProjectSystem.GetInformationModel(...)

### DIFF
--- a/src/OmniSharp.DotNet/Cache/ProjectStatesCache.cs
+++ b/src/OmniSharp.DotNet/Cache/ProjectStatesCache.cs
@@ -20,9 +20,11 @@ namespace OmniSharp.DotNet.Cache
             _logger = loggerFactory?.CreateLogger<ProjectStatesCache>() ?? new DummyLogger<ProjectStatesCache>();
         }
 
-        public IReadOnlyCollection<ProjectState> Values
+        public IReadOnlyCollection<ProjectState> GetValues()
         {
-            get { return _projects.Select(p=>p.Value).SelectMany(entry=>entry.ProjectStates).ToList(); }
+            return _projects.Select(p => p.Value)
+                            .SelectMany(entry => entry.ProjectStates)
+                            .ToList();
         }
 
         public void Update(string projectDirectory,

--- a/src/OmniSharp.DotNet/DotNetProjectSystem.cs
+++ b/src/OmniSharp.DotNet/DotNetProjectSystem.cs
@@ -63,7 +63,12 @@ namespace OmniSharp.DotNet
 
         public Task<object> GetInformationModel(WorkspaceInformationRequest request)
         {
-            return Task.FromResult<object>(new DotNetWorkspaceInformation());
+            var workspaceInfo = new DotNetWorkspaceInformation(
+                projectContexts: _projectStates.GetValues().Select(state => state.ProjectContext),
+                configuration: _compilationConfiguration,
+                includeSourceFiles: !request.ExcludeSourceFiles);
+
+            return Task.FromResult<object>(workspaceInfo);
         }
 
         public Task<object> GetProjectModel(string path)
@@ -125,7 +130,7 @@ namespace OmniSharp.DotNet
             }
 
             _logger.LogInformation("Resolving projects references");
-            foreach (var state in _projectStates.Values)
+            foreach (var state in _projectStates.GetValues())
             {
                 _logger.LogInformation($"  Processing {state}");
 

--- a/src/OmniSharp.DotNet/Models/DotNetProjectInformation.cs
+++ b/src/OmniSharp.DotNet/Models/DotNetProjectInformation.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.DotNet.ProjectModel;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using Microsoft.DotNet.ProjectModel;
 
 namespace OmniSharp.DotNet.Models
 {
@@ -9,7 +9,11 @@ namespace OmniSharp.DotNet.Models
         {
             this.Path = projectContext.RootProject.Path;
             this.Name = projectContext.ProjectFile.Name;
-            this.CompilationOutputPath = projectContext.GetOutputPaths(configuration).CompilationOutputPath;
+
+            var outputPaths = projectContext.GetOutputPaths(configuration);
+            this.CompilationOutputPath = outputPaths.CompilationOutputPath;
+            this.CompilationOutputAssemblyFile = outputPaths.CompilationFiles.Assembly;
+            this.CompilationOutputPdbFile = outputPaths.CompilationFiles.PdbPath;
 
             var sourceFiles = new List<string>();
 
@@ -23,7 +27,11 @@ namespace OmniSharp.DotNet.Models
 
         public string Path { get; }
         public string Name { get; }
+
         public string CompilationOutputPath { get; }
+        public string CompilationOutputAssemblyFile { get; }
+        public string CompilationOutputPdbFile { get; }
+
         public IReadOnlyList<string> SourceFiles { get; }
 
         //public DotNetProjectInformation(string projectPath, ProjectInformation info)

--- a/src/OmniSharp.DotNet/Models/DotNetProjectInformation.cs
+++ b/src/OmniSharp.DotNet/Models/DotNetProjectInformation.cs
@@ -1,9 +1,31 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.DotNet.ProjectModel;
+using System.Collections.Generic;
 
 namespace OmniSharp.DotNet.Models
 {
     internal class DotNetProjectInformation
     {
+        public DotNetProjectInformation(ProjectContext projectContext, string configuration, bool includeSourceFiles = false)
+        {
+            this.Path = projectContext.RootProject.Path;
+            this.Name = projectContext.ProjectFile.Name;
+            this.CompilationOutputPath = projectContext.GetOutputPaths(configuration).CompilationOutputPath;
+
+            var sourceFiles = new List<string>();
+
+            if (includeSourceFiles)
+            {
+                sourceFiles.AddRange(projectContext.ProjectFile.Files.SourceFiles);
+            }
+
+            this.SourceFiles = sourceFiles;
+        } 
+
+        public string Path { get; }
+        public string Name { get; }
+        public string CompilationOutputPath { get; }
+        public IReadOnlyList<string> SourceFiles { get; }
+
         //public DotNetProjectInformation(string projectPath, ProjectInformation info)
         //{
         //    Path = projectPath;
@@ -15,14 +37,10 @@ namespace OmniSharp.DotNet.Models
         //    GlobalJsonPath = info.GlobalJsonPath;
         //}
 
-        public string Path { get; }
-        public string Name { get; }
-        public IDictionary<string, string> Commands { get; }
-        public IEnumerable<string> Configurations { get; }
-        public IEnumerable<string> ProjectSearchPaths { get; }
-        public IEnumerable<DotNetFramework> Frameworks { get; }
-        public string GlobalJsonPath { get; }
-
-        //public IList<string> SourceFiles { get; set; }
+        //public IDictionary<string, string> Commands { get; }
+        //public IEnumerable<string> Configurations { get; }
+        //public IEnumerable<string> ProjectSearchPaths { get; }
+        //public IEnumerable<DotNetFramework> Frameworks { get; }
+        //public string GlobalJsonPath { get; }
     }
 }

--- a/src/OmniSharp.DotNet/Models/DotNetWorkspaceInformation.cs
+++ b/src/OmniSharp.DotNet/Models/DotNetWorkspaceInformation.cs
@@ -1,9 +1,22 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.DotNet.ProjectModel;
+using System.Collections.Generic;
 
 namespace OmniSharp.DotNet.Models
 {
     internal class DotNetWorkspaceInformation
     {
-        public IEnumerable<DotNetProjectInformation> Projects { get; } = new List<DotNetProjectInformation>();
+        public DotNetWorkspaceInformation(IEnumerable<ProjectContext> projectContexts, string configuration, bool includeSourceFiles = false)
+        {
+            var projects = new List<DotNetProjectInformation>();
+
+            foreach (var projectContext in projectContexts)
+            {
+                projects.Add(new DotNetProjectInformation(projectContext, configuration, includeSourceFiles));
+            }
+
+            this.Projects = projects;
+        }
+
+        public IEnumerable<DotNetProjectInformation> Projects { get; }
     }
 }

--- a/src/OmniSharp.Roslyn/WorkspaceInformationService.cs
+++ b/src/OmniSharp.Roslyn/WorkspaceInformationService.cs
@@ -26,8 +26,8 @@ namespace OmniSharp
 
             foreach (var projectSystem in _projectSystems)
             {
-                var project = await projectSystem.GetInformationModel(request);
-                response.Add(projectSystem.Key, project);
+                var informationModel = await projectSystem.GetInformationModel(request);
+                response.Add(projectSystem.Key, informationModel);
             }
 
             return response;


### PR DESCRIPTION
This is necessary for the DotNetProjectSystem to handle the /projects end point.

cc @troydai, @david-driscoll 