### PR TITLE
Fix span used to determine whether signature help should be shown

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -86,12 +86,14 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
             var sourceText = await document.GetTextAsync();
             var position = sourceText.Lines.GetPosition(new LinePosition(request.Line - 1, request.Column - 1));
             var tree = await document.GetSyntaxTreeAsync();
-            var node = tree.GetRoot().FindToken(position).Parent;
+            var root = await tree.GetRootAsync();
+            var node = root.FindToken(position).Parent;
 
+            // Walk up until we find a node that we're interested in.
             while (node != null)
             {
                 var invocation = node as InvocationExpressionSyntax;
-                if (invocation != null && invocation.ArgumentList.FullSpan.IntersectsWith(position))
+                if (invocation != null && invocation.ArgumentList.Span.Contains(position))
                 {
                     return new InvocationContext()
                     {
@@ -103,7 +105,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
                 }
 
                 var objectCreation = node as ObjectCreationExpressionSyntax;
-                if (objectCreation != null && objectCreation.ArgumentList.FullSpan.IntersectsWith(position))
+                if (objectCreation != null && objectCreation.ArgumentList.Span.Contains(position))
                 {
                     return new InvocationContext()
                     {


### PR DESCRIPTION
OmniSharp used the full span of an argument list to determine whether signature help should be shown. However, that includes both leading and trailing trivia, which means that it would return signatures for positions outside of the argument list. In addition, I switched it to use `Contains(...)` rather than `IntersectsWith(...)` since checking the position against the argument list span should not include the outer positions (e.g. on the left or right of the parentheses).

This fixes https://github.com/OmniSharp/omnisharp-vscode/issues/64.

cc @david-driscoll, @troydai 