### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,32 +16,30 @@ rm -rf artifacts
 mkdir -p $build_tools
 
 header "Installing dotnet"
-_dotnet_install_script_source="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.sh"
-_dotnet_install_script=$build_tools/install.sh
 
-curl -o $_dotnet_install_script $_dotnet_install_script_source -s
-chmod +x $_dotnet_install_script
-
-DONTET_CHANNEL="beta"
+DOTNET_CHANNEL="beta"
 DOTNET_VERSION="Latest"
+DOTNET_INSTALL="$work_dir/.dotnet"
+DOTNET_SCRIPT="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.sh"
+DOTNET="$work_dir/.dotnet/cli/dotnet"
 
 if [ `uname` == "Linux" ]; then
     # dotnet build on Ubuntu is currently broken, pin to the 001793 build and install script
     DOTNET_VERSION="1.0.0.001793"
-    _dotnet_install_script_source="https://raw.githubusercontent.com/dotnet/cli/42a0eec967f878c4a374d2b297aaedb0f14c20d2/scripts/obtain/install.sh"
+    DOTNET_INSTALL="https://raw.githubusercontent.com/dotnet/cli/42a0eec967f878c4a374d2b297aaedb0f14c20d2/scripts/obtain/install.sh"
+    DOTNET="$work_dir/.dotnet/bin/dotnet"
 fi
 
-if [ "$TRAVIS" == true ]; then
-    echo "Installing dotnet from beta channel for CI environment ..."
-    $_dotnet_install_script -c "$DOTNET_CHANNEL" -v "$DOTNET_VERSION" -d "$work_dir/.dotnet" 
-    dotnet="$work_dir/.dotnet/cli/dotnet"
-else
-    echo "Installing dotnet from beta channel for local environment ..."
-    $_dotnet_install_script -c "$DOTNET_CHANNEL" -v "$DOTNET_VERSION"
-    dotnet="dotnet"
-fi
+echo "Installing dotnet from $DOTNET_CHANNEL channel for version $DOTNET_VERSION"
+echo "Execute install script"
+echo "   source: $DOTNET_SCRIPT"
+echo "  version: $DOTNET_VERSION"
+echo "  channel: $DOTNET_CHANNEL"
+echo "  install: $DOTNET_INSTALL"
 
-$dotnet --version
+sh -c "`curl -s $DOTNET_SCRIPT`" "install.sh" "-c" "$DOTNET_CHANNEL" "-v" "$DOTNET_VERSION" "-d" "$DOTNET_INSTALL"
+
+$DOTNET --version # || { echo >&2 "dotnet is not installed correctly" && exit 1 }
 
 # Handle to many files on osx
 if [ "$TRAVIS_OS_NAME" == "osx" ] || [ `uname` == "Darwin" ]; then
@@ -50,9 +48,10 @@ fi
 
 # Build 
 header "Building"
-$dotnet restore tools
-$dotnet publish ./tools/PublishProject -o $build_tools/PublishProject/
+$DOTNET restore tools
+$DOTNET publish ./tools/PublishProject -o $build_tools/PublishProject/
 $build_tools/PublishProject/PublishProject
 
 # OmniSharp.Roslyn.CSharp.Tests is skipped on dnx451 target because an issue in MEF assembly load on xunit
 # Failure repo: https://github.com/troydai/loaderfailure
+

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ DOTNET="$work_dir/.dotnet/cli/dotnet"
 if [ `uname` == "Linux" ]; then
     # dotnet build on Ubuntu is currently broken, pin to the 001793 build and install script
     DOTNET_VERSION="1.0.0.001793"
-    DOTNET_INSTALL="https://raw.githubusercontent.com/dotnet/cli/42a0eec967f878c4a374d2b297aaedb0f14c20d2/scripts/obtain/install.sh"
+    DOTNET_SCRIPT="https://raw.githubusercontent.com/dotnet/cli/42a0eec967f878c4a374d2b297aaedb0f14c20d2/scripts/obtain/install.sh"
     DOTNET="$work_dir/.dotnet/bin/dotnet"
 fi
 


### PR DESCRIPTION
Further simplify and unify build.sh

1. Install to `.dotnet` folder all the time. This helps to pin dotnet version
2. Download and run install script in same command.