### PR TITLE
Update build scripts

### DIFF
--- a/build.json
+++ b/build.json
@@ -2,7 +2,7 @@
     "DotNetFolder": ".dotnet",
     "BuildToolsFolder": ".build",
     "ArtifactsFolder": "artifacts",
-    "SkipPackaging": true,
+    "SkipPackaging": false,
     "TestProjects": {
         "OmniSharp.Bootstrap.Tests": [
             "dnxcore50",

--- a/build.json
+++ b/build.json
@@ -2,6 +2,7 @@
     "DotNetFolder": ".dotnet",
     "BuildToolsFolder": ".build",
     "ArtifactsFolder": "artifacts",
+    "SkipPackaging": true,
     "TestProjects": {
         "OmniSharp.Bootstrap.Tests": [
             "dnxcore50",

--- a/build.ps1
+++ b/build.ps1
@@ -6,22 +6,23 @@ function _header($title) {
 _header "Cleanup"
 rm -r -force artifacts -ErrorAction SilentlyContinue
 
-_header "Installing dotnet"
 $build_tools="$pwd\.build"
 mkdir $build_tools -ErrorAction SilentlyContinue | Out-Null
-invoke-webrequest -uri 'https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.ps1' -outfile $build_tools\install.ps1
 
 if ($env:APPVEYOR -eq "True")
 {
+    _header "Installing dotnet"
+    invoke-webrequest -uri 'https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.ps1' -outfile $build_tools\install.ps1
     $env:DOTNET_INSTALL_DIR=$PWD.Path+"\.dotnet"
     $env:PATH=$env:PATH+";$pwd\.dotnet\cli"
+    & $build_tools\install.ps1 beta
 }
 else
 {
-    $env:PATH=$env:PATH+";$env:LocalAppData\Microsoft\dotnet\cli"
+    _header "Use local dotnet"
 }
 
-& $build_tools\install.ps1 beta
+& dotnet --version
 
 _header "Build tools"
 & dotnet restore tools 

--- a/tools/PublishProject/BuildPlan.cs
+++ b/tools/PublishProject/BuildPlan.cs
@@ -38,6 +38,8 @@ namespace OmniSharp.Tools.PublishProject
 
         public string MainProject { get; set; }
 
+        public bool SkipPackaging { get; set; }
+
         [JsonIgnore]
         public string Root { get; set; }
     }

--- a/tools/PublishProject/Program.cs
+++ b/tools/PublishProject/Program.cs
@@ -67,7 +67,10 @@ namespace OmniSharp.Tools.PublishProject
                         return 1;
                     }
 
-                    Package(publish, packageOutput, buildPlan.MainProject, rid, framework);
+                    if (!buildPlan.SkipPackaging)
+                    {
+                        Package(publish, packageOutput, buildPlan.MainProject, rid, framework);
+                    }
                 }
             }
 


### PR DESCRIPTION
1. Enable stop packing through modify `build.json`
2. Skip install `dotnet` on Windows. Use the local one.