### PR TITLE
Fix build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Handle to many files on osx
-if [ "$TRAVIS_OS_NAME" == "osx" ] || [uname== "Darwin" ]; then
+
+if [ "$TRAVIS_OS_NAME" == "osx" ] || [ `uname` == "Darwin" ]; then
   ulimit -n 4096
 fi
 bash ./scripts/cake-bootstrap.sh "$@"


### PR DESCRIPTION
```
✔ ~/code/omnisharp-roslyn [dev|✔] 
11:55 $ ./build.sh 
./build.sh: line 4: [: uname==: unary operator expected
```