### PR TITLE
Updated to new frameworks and CLI + extra sugaring in build script

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -275,7 +275,7 @@ Task("BuildEnvironment")
     {
         StartProcess("chmod",
             new ProcessSettings
-            { 
+            {
                 Arguments = $"+x {scriptPath}"
             });
     }

--- a/build.cake
+++ b/build.cake
@@ -1,8 +1,9 @@
-#addin "Cake.FileHelpers"
-#addin "Cake.Json"
+#addin "Newtonsoft.Json"
 
 using System.Text.RegularExpressions;
 using System.ComponentModel;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 // Basic arguments
 var target = Argument("target", "Default");
@@ -38,7 +39,8 @@ public class BuildPlan
     public string MainProject { get; set; }
 }
 
-var buildPlan = DeserializeJsonFromFile<BuildPlan>($"{workingDirectory}/build.json");
+var buildPlan = JsonConvert.DeserializeObject<BuildPlan>(
+    System.IO.File.ReadAllText($"{workingDirectory}/build.json"));
 
 // Folders and tools
 var dotnetFolder = $"{workingDirectory}/{buildPlan.DotNetFolder}";
@@ -64,18 +66,14 @@ string GetLocalRuntimeID(string dotnetcli)
 {
     var process = StartAndReturnProcess(dotnetcli,
         new ProcessSettings
-        {
-            // Soon to be --info
-            // Arguments = "--info",
-            Arguments = "--version",
+        { 
+            Arguments = "--info",
             RedirectStandardOutput = true
         });
     process.WaitForExit();
     foreach (var line in process.GetStandardOutput())
     {
-        // Soon to be RID
-        // if (!line.Contains("RID"))
-        if (!line.Contains("Runtime Id"))
+        if (!line.Contains("RID"))
         {
             continue;
         }
@@ -273,31 +271,23 @@ Task("BuildEnvironment")
     CreateDirectory(dotnetFolder);
     var scriptPath = new FilePath($"{dotnetFolder}/{installScript}");
     DownloadFile($"{buildPlan.DotNetInstallScriptURL}/{installScript}", scriptPath);
-    string installArgs = "";
-
-    if (IsRunningOnWindows())
-    {
-        installArgs = $"{buildPlan.DotNetChannel}";
-        if (!String.IsNullOrEmpty(buildPlan.DotNetVersion))
-            installArgs = $"{installArgs} -version {buildPlan.DotNetVersion}";
-        if (!buildPlan.UseSystemDotNetPath)
-            installArgs = $"{installArgs} -InstallDir {dotnetFolder}";
-    }
-    else
+    if (!IsRunningOnWindows())
     {
         StartProcess("chmod",
             new ProcessSettings
-            {
+            { 
                 Arguments = $"+x {scriptPath}"
             });
-
-        installArgs = $"-c {buildPlan.DotNetChannel}";
-        if (!String.IsNullOrEmpty(buildPlan.DotNetVersion))
-            installArgs = $"{installArgs} -v {buildPlan.DotNetVersion}";
-        if (!buildPlan.UseSystemDotNetPath)
-            installArgs = $"{installArgs} -i {dotnetFolder}";
     }
-
+    var installArgs = $"-Channel {buildPlan.DotNetChannel}";
+    if (!String.IsNullOrEmpty(buildPlan.DotNetVersion))
+    {
+      installArgs = $"{installArgs} -Version {buildPlan.DotNetVersion}";
+    } 
+    if (!buildPlan.UseSystemDotNetPath)
+    {
+        installArgs = $"{installArgs} -InstallDir {dotnetFolder}";
+    }
     StartProcess(shell,
         new ProcessSettings
         {
@@ -308,7 +298,7 @@ Task("BuildEnvironment")
         StartProcess(dotnetcli,
             new ProcessSettings
             {
-                Arguments = "--version"
+                Arguments = "--info"
             });
 
     }
@@ -367,7 +357,7 @@ Task("BuildTest")
                     RedirectStandardOutput = true
                 });
             process.WaitForExit();
-            FileWriteLines($"{logFolder}/{project}-{framework}-build.log", process.GetStandardOutput().ToArray());
+            System.IO.File.WriteAllLines($"{logFolder}/{project}-{framework}-build.log", process.GetStandardOutput().ToArray());
         }
     }
 });
@@ -385,7 +375,7 @@ Task("TestCore")
     {
         foreach (var framework in pair.Value)
         {
-            if (!framework.Equals("dnxcore50"))
+            if (!framework.Contains("netcoreapp"))
             {
                 continue;
             }
@@ -394,7 +384,7 @@ Task("TestCore")
             var exitCode = StartProcess(dotnetcli,
                 new ProcessSettings
                 {
-                    Arguments = $"test -xml {logFolder}/{project}-{framework}-result.xml -notrait category=failing",
+                    Arguments = $"test --framework {framework} -xml {logFolder}/{project}-{framework}-result.xml -notrait category=failing",
                     WorkingDirectory = $"{testFolder}/{project}"
                 });
             if (exitCode != 0)
@@ -418,7 +408,7 @@ Task("Test")
         foreach (var framework in pair.Value)
         {
             // Testing against core happens in TestCore
-            if (framework.Equals("dnxcore50"))
+            if (framework.Contains("netcoreapp"))
             {
                 continue;
             }
@@ -479,13 +469,13 @@ Task("OnlyPublish")
             // Simplify Ubuntu to Linux
             runtimeShort = runtimeShort.Replace("ubuntu", "linux");
             var buildIdentifier = $"{runtimeShort}-{framework}";
-            // Linux + dnx451 is renamed to Mono
-            if (runtimeShort.Contains("linux-") && framework.Equals("dnx451"))
+            // Linux + net451 is renamed to Mono
+            if (runtimeShort.Contains("linux-") && framework.Equals("net451"))
             {
                 buildIdentifier ="linux-mono";
             }
-            // No need to package OSX + dnx451
-            else if (runtimeShort.Contains("osx-") && framework.Equals("dnx451"))
+            // No need to package OSX + net451
+            else if (runtimeShort.Contains("osx-") && framework.Equals("net451"))
             {
                 continue;
             }
@@ -532,7 +522,7 @@ Task("TestPublished")
     foreach (var framework in buildPlan.Frameworks)
     {
         // Skip testing mono executables
-        if (!IsRunningOnWindows() && !framework.Equals("dnxcore50"))
+        if (!IsRunningOnWindows() && !framework.Equals("netcoreapp"))
         {
             continue;
         }
@@ -623,7 +613,36 @@ Task("Local")
 {
 });
 
+/// <summary>
+///  Update the package versions within project.json files.
+///  Uses depversion.json file as input.
+/// </summary>
+Task("SetPackageVersions")
+    .Does(() =>
+{
+    var jDepVersion = JObject.Parse(System.IO.File.ReadAllText($"{workingDirectory}/depversion.json"));
+    var projects = GetFiles($"{workingDirectory}/src/*/project.json");
+    projects.Add(GetFiles($"{workingDirectory}/tests/*/project.json"));
+    foreach (var project in projects)
+    {
+        var jProject = JObject.Parse(System.IO.File.ReadAllText(project.FullPath));
+        var dependencies = jProject.SelectTokens("dependencies")
+                            .Union(jProject.SelectTokens("frameworks.*.dependencies"))
+                            .SelectMany(dependencyToken => dependencyToken.Children<JProperty>());
+        foreach (JProperty dependency in dependencies)
+        {
+            if (jDepVersion[dependency.Name] != null)
+            {
+                dependency.Value = jDepVersion[dependency.Name];
+            }
+        }
+        System.IO.File.WriteAllText(project.FullPath, JsonConvert.SerializeObject(jProject, Formatting.Indented));
+    }
+});
 
+/// <summary>
+///  Default Task aliases to Local.
+/// </summary>
 Task("Default")
     .IsDependentOn("Local")
     .Does(() =>

--- a/build.json
+++ b/build.json
@@ -1,30 +1,30 @@
 {
     "UseSystemDotNetPath" : "false",
     "DotNetFolder": ".dotnet",
-    "DotNetInstallScriptURL": "https://raw.githubusercontent.com/dotnet/cli/78e60bcb8b06c7787a9eb0356cf9ab3f1e76b86e/scripts/obtain",
+    "DotNetInstallScriptURL": "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain",
     "DotNetChannel": "beta",
-    "DotNetVersion": "1.0.0.001897",
+    "DotNetVersion": "Latest",
     "BuildToolsFolder": ".tools",
     "ArtifactsFolder": "artifacts",
     "TestProjects": {
         "OmniSharp.Bootstrap.Tests": [
-            "dnxcore50",
-            "dnx451"
+            "netcoreapp1.0",
+            "net451"
         ],
         "OmniSharp.MSBuild.Tests": [
-            "dnx451"
+            "net451"
         ],
         "OmniSharp.Roslyn.CSharp.Tests": [
-            "dnxcore50"
+            "netcoreapp1.0"
         ],
         "OmniSharp.Stdio.Tests": [
-            "dnxcore50",
-            "dnx451"
+            "netcoreapp1.0",
+            "net451"
         ]
     },
     "Frameworks": [
-        "dnx451",
-        "dnxcore50"
+        "net451",
+        "netcoreapp1.0"
     ],
     "Rids": [
         "osx.10.11-x64",

--- a/depversion.json
+++ b/depversion.json
@@ -1,16 +1,16 @@
 {
-  "NETStandard.Library": "1.5.0-*",
+  "NETStandard.Library": "1.5.0-rc2*",
   
   "Microsoft.DotNet.ProjectModel": "1.0.0-beta-*",
   "Microsoft.DotNet.InternalAbstractions": "1.0.0-beta-*",
   "Microsoft.Extensions.DependencyModel": "1.0.0-beta-*",
   
-  "System.Diagnostics.Process": "4.1.0-*",
-  "System.IO.FileSystem.Watcher": "4.0.0-*",
-  "System.Threading.Thread": "4.0.0-*",
-  "System.Dynamic.Runtime": "4.0.11-*",
-  "System.Security.Cryptography.Algorithms": "4.1.0-*",
-  "System.Runtime.Serialization.Primitives": "4.1.0-*",
-  "System.Linq.Parallel": "4.0.1-*",
-  "System.Threading.Tasks.Parallel": "4.0.1-*"
+  "System.Diagnostics.Process": "4.1.0-rc2*",
+  "System.IO.FileSystem.Watcher": "4.0.0-rc2*",
+  "System.Threading.Thread": "4.0.0-rc2*",
+  "System.Dynamic.Runtime": "4.0.11-rc2*",
+  "System.Runtime.Serialization.Primitives": "4.1.0-rc2*",
+  "System.Linq.Parallel": "4.0.1-rc2*",
+  "System.Threading.Tasks.Parallel": "4.0.1-rc2*",
+  "System.Security.Cryptography.Algorithms": "4.1.0-rc2*"
 }

--- a/depversion.json
+++ b/depversion.json
@@ -1,0 +1,16 @@
+{
+  "NETStandard.Library": "1.5.0-*",
+  
+  "Microsoft.DotNet.ProjectModel": "1.0.0-beta-*",
+  "Microsoft.DotNet.InternalAbstractions": "1.0.0-beta-*",
+  "Microsoft.Extensions.DependencyModel": "1.0.0-beta-*",
+  
+  "System.Diagnostics.Process": "4.1.0-*",
+  "System.IO.FileSystem.Watcher": "4.0.0-*",
+  "System.Threading.Thread": "4.0.0-*",
+  "System.Dynamic.Runtime": "4.0.11-*",
+  "System.Security.Cryptography.Algorithms": "4.1.0-*",
+  "System.Runtime.Serialization.Primitives": "4.1.0-*",
+  "System.Linq.Parallel": "4.0.1-*",
+  "System.Threading.Tasks.Parallel": "4.0.1-*"
+}

--- a/scripts/cake-bootstrap.ps1
+++ b/scripts/cake-bootstrap.ps1
@@ -45,7 +45,7 @@ Param(
 Write-Host "Preparing to run build script..."
 
 $PS_SCRIPT_ROOT = split-path -parent $MyInvocation.MyCommand.Definition;
-$TOOLS_DIR = Join-Path $PSScriptRoot ".tools"
+$TOOLS_DIR = Join-Path $PSScriptRoot "..\.tools"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
 $NUGET_URL = "http://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 $CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"

--- a/scripts/cake-bootstrap.sh
+++ b/scripts/cake-bootstrap.sh
@@ -6,7 +6,7 @@
 
 # Define directories.
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-TOOLS_DIR=$SCRIPT_DIR/.tools
+TOOLS_DIR=$SCRIPT_DIR/../.tools
 export NUGET_EXE=$TOOLS_DIR/nuget.exe
 CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
 

--- a/src/OmniSharp.Abstractions/project.json
+++ b/src/OmniSharp.Abstractions/project.json
@@ -13,7 +13,8 @@
     "Microsoft.Extensions.Configuration.Binder": "1.0.0-rc2-20143",
     "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-20143",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20143",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20143"
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20143",
+    "System.Reflection.Metadata": "1.2.0"
   },
   "frameworks": {
     "net451": {

--- a/src/OmniSharp.Abstractions/project.json
+++ b/src/OmniSharp.Abstractions/project.json
@@ -11,14 +11,12 @@
     "Microsoft.Extensions.Caching.Memory": "1.0.0-rc2-20143",
     "Microsoft.Extensions.Configuration": "1.0.0-rc2-20143",
     "Microsoft.Extensions.Configuration.Binder": "1.0.0-rc2-20143",
-    "Microsoft.Extensions.DependencyModel": "1.0.0-beta-001718",
     "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-20143",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20143",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20143",
-    "System.Reflection.Metadata": "1.2.0"
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20143"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "frameworkAssemblies": {
         "System.Runtime": "",
         "System.Threading": "",
@@ -33,14 +31,17 @@
         "System.Xml.Linq": ""
       }
     },
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4",
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23910",
-        "System.Dynamic.Runtime": "4.0.11-rc2-23911",
-        "System.Diagnostics.Process": "4.1.0-rc2-23911",
-        "System.IO.FileSystem.Watcher": "4.0.0-rc2-23911",
-        "System.Threading.Thread": "4.0.0-rc2-23911"
+        "NETStandard.Library": "1.5.0-*",
+        "System.Diagnostics.Process": "4.1.0-*",
+        "System.IO.FileSystem.Watcher": "4.0.0-*",
+        "System.Threading.Thread": "4.0.0-*"
       }
     }
   }

--- a/src/OmniSharp.Abstractions/project.json
+++ b/src/OmniSharp.Abstractions/project.json
@@ -13,8 +13,7 @@
     "Microsoft.Extensions.Configuration.Binder": "1.0.0-rc2-20143",
     "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-20143",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20143",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20143",
-    "System.Reflection.Metadata": "1.2.0"
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20143"
   },
   "frameworks": {
     "net451": {
@@ -39,10 +38,10 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*",
-        "System.Diagnostics.Process": "4.1.0-*",
-        "System.IO.FileSystem.Watcher": "4.0.0-*",
-        "System.Threading.Thread": "4.0.0-*"
+        "NETStandard.Library": "1.5.0-rc2*",
+        "System.Diagnostics.Process": "4.1.0-rc2*",
+        "System.IO.FileSystem.Watcher": "4.0.0-rc2*",
+        "System.Threading.Thread": "4.0.0-rc2*"
       }
     }
   }

--- a/src/OmniSharp.Bootstrap/project.json
+++ b/src/OmniSharp.Bootstrap/project.json
@@ -13,19 +13,21 @@
     "omnisharp.bootstrap": "run"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "frameworkAssemblies": {
         "System.Runtime": ""
       }
     },
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
+    "netstandard1.5": {
+      "imports": [
+        "dotnet5.6",
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23910",
-        "System.Dynamic.Runtime": "4.0.11-rc2-23911",
-        "System.Linq.Expressions": "4.0.11-rc2-23911",
-        "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23907",
-        "System.Xml.XDocument": "4.0.11-rc2-23911"
+        "NETStandard.Library": "1.5.0-*",
+        "System.Dynamic.Runtime": "4.0.11-*",
+        "System.Security.Cryptography.Algorithms": "4.1.0-*"
       }
     }
   }

--- a/src/OmniSharp.Bootstrap/project.json
+++ b/src/OmniSharp.Bootstrap/project.json
@@ -25,9 +25,9 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*",
-        "System.Dynamic.Runtime": "4.0.11-*",
-        "System.Security.Cryptography.Algorithms": "4.1.0-*"
+        "NETStandard.Library": "1.5.0-rc2*",
+        "System.Dynamic.Runtime": "4.0.11-rc2*",
+        "System.Security.Cryptography.Algorithms": "4.1.0-rc2*"
       }
     }
   }

--- a/src/OmniSharp.DotNet/project.json
+++ b/src/OmniSharp.DotNet/project.json
@@ -24,7 +24,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*"
+        "NETStandard.Library": "1.5.0-rc2*"
       }
     }
   }

--- a/src/OmniSharp.DotNet/project.json
+++ b/src/OmniSharp.DotNet/project.json
@@ -8,23 +8,23 @@
     "OmniSharp.Roslyn": "1.0.0-*",
     "Microsoft.CodeAnalysis": "1.1.1",
     "Microsoft.CodeAnalysis.Common": "1.1.1",
-    "Microsoft.DotNet.ProjectModel": "1.0.0-beta-001718",
+    "Microsoft.DotNet.ProjectModel": "1.0.0-beta-*",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20143"
   },
   "frameworks": {
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
-      "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23910",
-        "System.IO.Compression": "4.1.0-rc2-23911",
-        "System.Runtime.Loader": "4.0.0-rc2-23911",
-        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23911",
-        "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23907"
-      }
-    },
-    "dnx451": {
+    "net451": {
       "frameworkAssemblies": {
         "System.IO": ""
+      }
+    },
+    "netstandard1.5": {
+      "imports": [
+        "dotnet5.6",
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-*"
       }
     }
   }

--- a/src/OmniSharp.Host/Startup.cs
+++ b/src/OmniSharp.Host/Startup.cs
@@ -130,12 +130,12 @@ namespace OmniSharp
         {
             Func<RuntimeLibrary, bool> shouldLoad = lib => lib.Dependencies.Any(dep => dep.Name == "OmniSharp.Abstractions" ||
                                                                                        dep.Name == "OmniSharp.Roslyn");
-                       
+
             var assemblies = DependencyContext.Default
                                               .RuntimeLibraries
                                               .Where(shouldLoad)
-                                              .SelectMany(lib => lib.Assemblies)
-                                              .Select(each => loader.Load(each.Name))
+                                              .SelectMany(lib => lib.RuntimeAssemblyGroups.GetDefaultGroup().AssetPaths)
+                                              .Select(each => loader.Load(each))
                                               .ToList();
 
             PluginHost = ConfigureMef(serviceProvider, optionsAccessor.Value, assemblies);
@@ -152,6 +152,7 @@ namespace OmniSharp
             }
 
             var logger = loggerFactory.CreateLogger<Startup>();
+
             foreach (var assembly in assemblies)
             {
                 logger.LogDebug($"Loaded {assembly.FullName}");

--- a/src/OmniSharp.Host/project.json
+++ b/src/OmniSharp.Host/project.json
@@ -37,7 +37,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*"
+        "NETStandard.Library": "1.5.0-rc2*"
       }
     }
   }

--- a/src/OmniSharp.Host/project.json
+++ b/src/OmniSharp.Host/project.json
@@ -13,10 +13,10 @@
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-rc2-20143",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20143",
     "Microsoft.Composition": "1.0.30",
-    "Microsoft.DotNet.ProjectModel": "1.0.0-beta-001718",
+    "Microsoft.DotNet.ProjectModel": "1.0.0-beta-*",
     "Microsoft.Extensions.Caching.Memory": "1.0.0-rc2-20143",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-20143",
-    "Microsoft.Extensions.DependencyModel": "1.0.0-beta-001718",
+    "Microsoft.Extensions.DependencyModel": "1.0.0-beta-*",
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-20143",
     "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-20143",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20143",
@@ -24,18 +24,20 @@
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0-rc2-20143"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "frameworkAssemblies": {
         "System.ComponentModel.Composition": ""
       },
       "dependencies": {}
     },
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
+    "netstandard1.5": {
+      "imports": [
+        "dotnet5.6",
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23910",
-        "System.Runtime.Loader": "4.0.0-rc2-23911",
-        "System.IO.Compression": "4.1.0-rc2-23911"
+        "NETStandard.Library": "1.5.0-*"
       }
     }
   }

--- a/src/OmniSharp.MSBuild/Analyzers/SimpleAnalyzerAssemblyLoader.cs
+++ b/src/OmniSharp.MSBuild/Analyzers/SimpleAnalyzerAssemblyLoader.cs
@@ -1,5 +1,4 @@
-﻿#if DNX451
-using System;
+﻿using System;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 
@@ -18,4 +17,3 @@ namespace OmniSharp.MSBuild.Analyzers
         }
     }
 }
-#endif

--- a/src/OmniSharp.MSBuild/project.json
+++ b/src/OmniSharp.MSBuild/project.json
@@ -10,7 +10,7 @@
     "Microsoft.Extensions.Options": "1.0.0-rc2-20143"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "frameworkAssemblies": {
         "Microsoft.Build": "",
         "Microsoft.Build.Engine": "",

--- a/src/OmniSharp.Nuget/project.json
+++ b/src/OmniSharp.Nuget/project.json
@@ -9,7 +9,7 @@
     "OmniSharp.Roslyn": "1.0.0-*"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "dependencies": {
         "NuGet.Configuration": "3.4.0-rtm-0733",
         "NuGet.Protocol.Core.v2": "3.3.0",
@@ -30,10 +30,13 @@
         "System.Security": ""
       }
     },
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23910"
+        "NETStandard.Library": "1.5.0-*"
       }
     }
   }

--- a/src/OmniSharp.Nuget/project.json
+++ b/src/OmniSharp.Nuget/project.json
@@ -36,7 +36,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*"
+        "NETStandard.Library": "1.5.0-rc2*"
       }
     }
   }

--- a/src/OmniSharp.Plugins/project.json
+++ b/src/OmniSharp.Plugins/project.json
@@ -26,7 +26,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*"
+        "NETStandard.Library": "1.5.0-rc2*"
       }
     }
   }

--- a/src/OmniSharp.Plugins/project.json
+++ b/src/OmniSharp.Plugins/project.json
@@ -14,15 +14,19 @@
     "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "1.1.1"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "frameworkAssemblies": {
         "System.Collections.Concurrent": ""
       }
     },
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4",
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23910"
+        "NETStandard.Library": "1.5.0-*"
       }
     }
   }

--- a/src/OmniSharp.Roslyn.CSharp/project.json
+++ b/src/OmniSharp.Roslyn.CSharp/project.json
@@ -12,7 +12,7 @@
     "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.1.1"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "dependencies": {
         "ICSharpCode.NRefactory": "6.0.0-alpha3"
       },
@@ -29,11 +29,14 @@
         "System.Xml": ""
       }
     },
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23910",
-        "System.Threading.Tasks.Parallel": "4.0.1-rc2-23911"
+        "NETStandard.Library": "1.5.0-*",
+        "System.Threading.Tasks.Parallel": "4.0.1-*"
       }
     }
   }

--- a/src/OmniSharp.Roslyn.CSharp/project.json
+++ b/src/OmniSharp.Roslyn.CSharp/project.json
@@ -35,8 +35,8 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*",
-        "System.Threading.Tasks.Parallel": "4.0.1-*"
+        "NETStandard.Library": "1.5.0-rc2*",
+        "System.Threading.Tasks.Parallel": "4.0.1-rc2*"
       }
     }
   }

--- a/src/OmniSharp.Roslyn/project.json
+++ b/src/OmniSharp.Roslyn/project.json
@@ -10,7 +10,7 @@
     "Microsoft.CodeAnalysis": "1.1.1"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "dependencies": {
         "ICSharpCode.NRefactory": "6.0.0-alpha3"
       },
@@ -28,12 +28,13 @@
         "System.IO": ""
       }
     },
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23910",
-        "System.Reflection.TypeExtensions": "4.1.0-rc2-23911",
-        "System.Xml.XDocument": "4.0.11-rc2-23911"
+        "NETStandard.Library": "1.5.0-*"
       }
     }
   }

--- a/src/OmniSharp.Roslyn/project.json
+++ b/src/OmniSharp.Roslyn/project.json
@@ -34,7 +34,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*"
+        "NETStandard.Library": "1.5.0-rc2*"
       }
     }
   }

--- a/src/OmniSharp.ScriptCs/project.json
+++ b/src/OmniSharp.ScriptCs/project.json
@@ -9,7 +9,7 @@
     "OmniSharp.Roslyn.CSharp": "1.0.0-*"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "dependencies": {
         "ScriptCs.Hosting": "0.14.1",
         "Microsoft.Web.Xdt": "2.1.1",

--- a/src/OmniSharp.Stdio/project.json
+++ b/src/OmniSharp.Stdio/project.json
@@ -12,11 +12,16 @@
     "Newtonsoft.Json": "8.0.2"
   },
   "frameworks": {
-    "dnx451": {},
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
+    "net451": {},
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4",
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23910"
+        "NETStandard.Library": "1.5.0-*",
+        "System.Runtime.Serialization.Primitives": "4.1.0-*"
       }
     }
   }

--- a/src/OmniSharp.Stdio/project.json
+++ b/src/OmniSharp.Stdio/project.json
@@ -20,8 +20,8 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*",
-        "System.Runtime.Serialization.Primitives": "4.1.0-*"
+        "NETStandard.Library": "1.5.0-rc2*",
+        "System.Runtime.Serialization.Primitives": "4.1.0-rc2*"
       }
     }
   }

--- a/src/OmniSharp/project.json
+++ b/src/OmniSharp/project.json
@@ -8,19 +8,24 @@
   "dependencies": {
     "OmniSharp.Host": "1.0.0-*",
     "OmniSharp.Roslyn.CSharp": "1.0.0-*",
-    "OmniSharp.DotNet": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-rc2-23911"
+    "OmniSharp.DotNet": "1.0.0-*"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "dependencies": {
         "OmniSharp.MSBuild": "1.0.0-*",
         "OmniSharp.ScriptCs": "1.0.0-*"
       }
     },
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
-      "dependencies": {}
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-*",
+        "Microsoft.DotNet.ProjectModel": "1.0.0-beta-*"
+      }
     }
   },
   "content": [

--- a/src/OmniSharp/project.json
+++ b/src/OmniSharp/project.json
@@ -23,7 +23,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*",
+        "NETStandard.Library": "1.5.0-rc2*",
         "Microsoft.DotNet.ProjectModel": "1.0.0-beta-*"
       }
     }

--- a/tests/OmniSharp.Bootstrap.Tests/project.json
+++ b/tests/OmniSharp.Bootstrap.Tests/project.json
@@ -6,34 +6,32 @@
   "dependencies": {
     "OmniSharp.Bootstrap": "1.0.0-*",
     "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.1.1",
-    "System.Reflection.Metadata": "1.2.0",
+    "Microsoft.Extensions.DependencyModel": "1.0.0-beta-*",
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-79755-47",
-        "Microsoft.DotNet.InternalAbstractions": "1.0.0-beta-001718",
-        "Microsoft.DotNet.ProjectModel": "1.0.0-beta-001718",
-        "Microsoft.NETCore.Platforms": "1.0.1-rc2-23911",
-        "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-20143",
-        "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-20143",
-        "NuGet.Packaging": "3.4.0-rtm-0733",
-        "System.Diagnostics.Process": "4.1.0-rc2-23911",
-        "System.IO.Compression": "4.1.0-rc2-23911",
-        "System.Linq.Expressions": "4.0.11-rc2-23911",
-        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23911",
-        "System.Runtime.Loader": "4.0.0-rc2-23911",
-        "System.Threading.Thread": "4.0.0-rc2-23911",
-        "System.Threading.ThreadPool": "4.0.10-rc2-23911"
+        "NETStandard.Library": "1.5.0-*",
+        "Microsoft.DotNet.ProjectModel": "1.0.0-beta-*",
+        "dotnet-test-xunit": "1.0.0-dev-91790-12"
       }
     },
-    "dnx451": {
+    "net451": {
       "dependencies": {
         "xunit.runner.console": "2.1.0"
       }
     }
+  },
+  "runtimes": {
+    "win7-x64": {},
+    "win7-x86": {},
+    "osx.10.11-x64": {},
+    "ubuntu.14.04-x64": {}
   },
   "testRunner": "xunit"
 }

--- a/tests/OmniSharp.Bootstrap.Tests/project.json
+++ b/tests/OmniSharp.Bootstrap.Tests/project.json
@@ -7,7 +7,6 @@
     "OmniSharp.Bootstrap": "1.0.0-*",
     "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.1.1",
     "Microsoft.Extensions.DependencyModel": "1.0.0-beta-*",
-    "System.Reflection.Metadata": "1.2.0",
     "xunit": "2.1.0"
   },
   "frameworks": {
@@ -17,7 +16,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*",
+        "NETStandard.Library": "1.5.0-rc2*",
         "Microsoft.DotNet.ProjectModel": "1.0.0-beta-*",
         "dotnet-test-xunit": "1.0.0-dev-91790-12"
       }

--- a/tests/OmniSharp.Bootstrap.Tests/project.json
+++ b/tests/OmniSharp.Bootstrap.Tests/project.json
@@ -7,6 +7,7 @@
     "OmniSharp.Bootstrap": "1.0.0-*",
     "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.1.1",
     "Microsoft.Extensions.DependencyModel": "1.0.0-beta-*",
+    "System.Reflection.Metadata": "1.2.0",
     "xunit": "2.1.0"
   },
   "frameworks": {

--- a/tests/OmniSharp.MSBuild.Tests/project.json
+++ b/tests/OmniSharp.MSBuild.Tests/project.json
@@ -9,12 +9,18 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "dependencies": {
         "OmniSharp.MSBuild": "1.0.0-*",
         "xunit.runner.console": "2.1.0"
       }
     }
+  },
+  "runtimes": {
+    "win7-x64": {},
+    "win7-x86": {},
+    "osx.10.11-x64": {},
+    "ubuntu.14.04-x64": {}
   },
   "testRunner": "xunit"
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/MetadataFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/MetadataFacts.cs
@@ -67,7 +67,7 @@ class Foo {
             var controller = new MetadataService(workspace, new MetadataHelper(_loader));
             var response = await controller.Handle(new MetadataRequest
             {
-#if DNXCORE50
+#if NETCOREAPP1_0
                 AssemblyName = "System.Linq",
 #else
                 AssemblyName = "System.Core",

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/project.json
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/project.json
@@ -16,9 +16,9 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*",
-        "System.Linq.Parallel": "4.0.1-*",
-        "System.Threading.Tasks.Parallel": "4.0.1-*",
+        "NETStandard.Library": "1.5.0-rc2*",
+        "System.Linq.Parallel": "4.0.1-rc2*",
+        "System.Threading.Tasks.Parallel": "4.0.1-rc2*",
         "dotnet-test-xunit": "1.0.0-dev-91790-12"
       }
     },

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/project.json
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/project.json
@@ -10,21 +10,29 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1-rc2-23911",
-        "System.Linq.Parallel": "4.0.1-rc2-23911",
-        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23911",
-        "System.Threading.Tasks.Parallel": "4.0.1-rc2-23911",
-        "dotnet-test-xunit": "1.0.0-dev-79755-47"
+        "NETStandard.Library": "1.5.0-*",
+        "System.Linq.Parallel": "4.0.1-*",
+        "System.Threading.Tasks.Parallel": "4.0.1-*",
+        "dotnet-test-xunit": "1.0.0-dev-91790-12"
       }
     },
-    "dnx451": {
+    "net451": {
       "dependencies": {
         "xunit.runner.console": "2.1.0"
       }
     }
+  },
+  "runtimes": {
+    "win7-x64": {},
+    "win7-x86": {},
+    "osx.10.11-x64": {},
+    "ubuntu.14.04-x64": {}
   },
   "testRunner": "xunit"
 }

--- a/tests/OmniSharp.Stdio.Tests/project.json
+++ b/tests/OmniSharp.Stdio.Tests/project.json
@@ -9,25 +9,28 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-79755-47",
-        "Microsoft.DotNet.ProjectModel": "1.0.0-beta-001718",
-        "Microsoft.NETCore.Platforms": "1.0.1-rc2-23911",
-        "NuGet.Packaging": "3.4.0-rtm-0733",
-        "System.IO.Compression": "4.1.0-rc2-23911",
-        "System.Runtime.Loader": "4.0.0-rc2-23911",
-        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23911",
-        "System.Threading.ThreadPool": "4.0.10-rc2-23911",
-        "System.Xml.XDocument": "4.0.11-rc2-23911"
+        "NETStandard.Library": "1.5.0-*",
+        "Microsoft.DotNet.ProjectModel": "1.0.0-beta-*",
+        "dotnet-test-xunit": "1.0.0-dev-91790-12"
       }
     },
-    "dnx451": {
+    "net451": {
       "dependencies": {
         "xunit.runner.console": "2.1.0"
       }
     }
+  },
+  "runtimes": {
+    "win7-x64": {},
+    "win7-x86": {},
+    "osx.10.11-x64": {},
+    "ubuntu.14.04-x64": {}
   },
   "testRunner": "xunit"
 }

--- a/tests/OmniSharp.Stdio.Tests/project.json
+++ b/tests/OmniSharp.Stdio.Tests/project.json
@@ -15,7 +15,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*",
+        "NETStandard.Library": "1.5.0-rc2*",
         "Microsoft.DotNet.ProjectModel": "1.0.0-beta-*",
         "dotnet-test-xunit": "1.0.0-dev-91790-12"
       }

--- a/tests/OmniSharp.Tests/project.json
+++ b/tests/OmniSharp.Tests/project.json
@@ -18,7 +18,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*",
+        "NETStandard.Library": "1.5.0-rc2*",
         "Microsoft.DotNet.ProjectModel": "1.0.0-beta-*",
         "dotnet-test-xunit": "1.0.0-dev-91790-12"
       }

--- a/tests/OmniSharp.Tests/project.json
+++ b/tests/OmniSharp.Tests/project.json
@@ -7,25 +7,33 @@
     "OmniSharp.Host": "1.0.0-*",
     "OmniSharp.Roslyn.CSharp": "1.0.0-*",
     "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.1.1",
-    "Microsoft.DotNet.InternalAbstractions": "1.0.0-beta-001718",
-    "Microsoft.Extensions.DependencyModel": "1.0.0-beta-001718",
+    "Microsoft.DotNet.InternalAbstractions": "1.0.0-beta-*",
+    "Microsoft.Extensions.DependencyModel": "1.0.0-beta-*",
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-79755-47",
-        "Microsoft.NETCore.Platforms": "1.0.1-rc2-23911",
-        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23911",
-        "System.IO.Compression": "4.1.0-rc2-23911"
+        "NETStandard.Library": "1.5.0-*",
+        "Microsoft.DotNet.ProjectModel": "1.0.0-beta-*",
+        "dotnet-test-xunit": "1.0.0-dev-91790-12"
       }
     },
-    "dnx451": {
+    "net451": {
       "dependencies": {
         "xunit.runner.console": "2.1.0"
       }
     }
+  },
+  "runtimes": {
+    "win7-x64": {},
+    "win7-x86": {},
+    "osx.10.11-x64": {},
+    "ubuntu.14.04-x64": {}
   },
   "testRunner": "xunit"
 }


### PR DESCRIPTION
Updated to the latest CLI and new framework names/packages.

Updating to the most recent CLI requires updating the version of `"Microsoft.Extensions.DependencyModel"`, which brings with itself dependencies on a newer NETStandard library. Since changes were required to the `project.json`, I decided to also update the framework monikers.

Changes:

- dnx451->net451

- dnxcore50->netcoreapp1.0 for OmniSharp and tests and appropriate netstandard for the others

- netstandard projects depend on `NETStandard.Library` (and other libraries if needed)

- netcoreapp1.0 projects depend on `NETStandard.Library` and `Microsoft.DotNet.ProjectModel` (and other libraries if needed)
    - NETCore.App brings extra unneeded dependencies including conflicting CodeAnalysis

- Changed `NETStandard.Library`, `Microsoft.DotNet.*`, `Microsoft.Extensions.DependencyModel` , `System.*` dependency versions to use wild-cards for now (see below)

- Fixed issues rising from new libraries

- Tried to eliminate some of the unnecessary dependencies in the `project.json` files

- Clean-up of `build.cake`
    - I also removed Cake addins as they are third-party components targeting .NET 4.5, thus might not be available on a .NET Core version of Cake

- Updated `.tools` path to match the recent change in moving `cake-bootstrap.*` into `scripts`

- New utility target in `build.cake` named `SetPackageVersions`


Things to fix long-term:
- Eliminate imports for netstandard, especially dnxcore50

     - Newtonsoft.Json only targets dnxcore50, this should change as soon as rc2 is released

     - `Microsoft.Extensions.DependencyModel` pulls in `NuGet.Packaging`, which pulls in `System.Security.Cryptography.Hashing.Algorithms`, which only targets `dnxcore50` @troydai do you know any plans about this one?

**SetPackageVersions**

It uses a new file called `depversion.json` as a central dictionary to replace all the dependency versions from `project.json` files across the different folders with the one specified within the file. This can be used to quickly migrate to new package versions. Dependencies without entries in `depversion.json` are left alone.

This target is not executed as part of the build, but can be called separately, by using `-target=SetPackageVersions` with `build.{ps1|sh}`.

For now `depversion.json` contains the packages that I specified with wild-card in this PR. This allows the wildcards to be quickly replaced by any version you guys prefer. Long-term the other dependencies can also be added here.
