### PR TITLE
Updated RID logic to remove need for dotnet-info

### DIFF
--- a/build.json
+++ b/build.json
@@ -26,11 +26,5 @@
         "net451",
         "netcoreapp1.0"
     ],
-    "Rids": [
-        "osx.10.11-x64",
-        "win7-x64",
-        "win7-x86",
-        "ubuntu.14.04-x64"
-    ],
     "MainProject": "OmniSharp"
 }

--- a/build.ps1
+++ b/build.ps1
@@ -1,2 +1,3 @@
+$Env:OMNISHARP_PACKAGE_OSNAME = "win-x64"
 .\scripts\cake-bootstrap.ps1 --experimental @args
 exit $LASTEXITCODE

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 # Handle to many files on osx
-
 if [ "$TRAVIS_OS_NAME" == "osx" ] || [ `uname` == "Darwin" ]; then
   ulimit -n 4096
+fi
+
+if [ "$TRAVIS_OS_NAME" == "osx" ] || [ `uname` == "Darwin" ]; then
+  export OMNISHARP_PACKAGE_OSNAME=osx-x64
+else
+  export OMNISHARP_PACKAGE_OSNAME=linux-x64
 fi
 bash ./scripts/cake-bootstrap.sh "$@"


### PR DESCRIPTION
New virtual RID within the build script called `default`. When targeting `default`, `dotnet publish` is called with no explicit runtime, thus allowing it to select the best match based on the list specified in `project.json`. When targeting `default` and trying to package, the environment variable `OMNISHARP_PACKAGE_OSNAME` is used instead of the short runtime identifier. `default` should always be in the list of Rids! The targets `Install` and `TestPublished` use `default` as it is the only one guaranteed to work locally.

RestrictToLocal sets the runtime list to `default`.

RestrictToEnvironment was changed to PopulateRuntimes and should populate the list of Rids, based on the OS. For now it sets the runtime list to `default` + `win7-x86` on Windows. Better logic could be used in the future, but this works for now without `dotnet --info`.