### PR TITLE
Use local nuget over PATH based nuget

### DIFF
--- a/scripts/cake-bootstrap.ps1
+++ b/scripts/cake-bootstrap.ps1
@@ -85,17 +85,6 @@ if (!(Test-Path $PACKAGES_CONFIG)) {
     }
 }
 
-# Try find NuGet.exe in path if not exists
-if (!(Test-Path $NUGET_EXE)) {
-    Write-Verbose -Message "Trying to find nuget.exe in PATH..."
-    $existingPaths = $Env:Path -Split ';' | Where-Object { Test-Path $_ }
-    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
-    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
-        Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
-        $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
-    }
-}
-
 # Try download NuGet.exe if not exists
 if (!(Test-Path $NUGET_EXE)) {
     Write-Verbose -Message "Downloading NuGet.exe..."


### PR DESCRIPTION
It seems like if someone has a `nuget.exe` from the v2 erra, that when installing cake the destination folder is incorrect, it includes the Version in the folder name.

We don't see this on CI because the CI server doesn't come with `nuget.exe` by default, and locally I'm sure I don't have any V2 nuget.exe in my path.

fixes #484 

cc @troydai @danroth27
