### PR TITLE
Fix omnisharp.json configuration loading

### DIFF
--- a/src/OmniSharp.Abstractions/Services/IOmnisharpEnvironment.cs
+++ b/src/OmniSharp.Abstractions/Services/IOmnisharpEnvironment.cs
@@ -9,7 +9,6 @@ namespace OmniSharp.Services
         int HostPID { get; }
         string Path { get; }
         string SolutionFilePath { get; }
-        string ConfigurationPath { get; }
         TransportType TransportType { get; }
     }
 }

--- a/src/OmniSharp.Host/Services/OmnisharpEnvironment.cs
+++ b/src/OmniSharp.Host/Services/OmnisharpEnvironment.cs
@@ -21,7 +21,6 @@ namespace OmniSharp.Services
             HostPID = hostPid;
             TraceType = traceType;
             TransportType = transportType;
-            ConfigurationPath = System.IO.Path.Combine(Path, "omnisharp.json");
             OtherArgs = otherArgs;
         }
 
@@ -34,8 +33,6 @@ namespace OmniSharp.Services
         public string Path { get; }
 
         public string SolutionFilePath { get; }
-        
-        public string ConfigurationPath { get; }
 
         public TransportType TransportType { get; }
 

--- a/src/OmniSharp.Host/Startup.cs
+++ b/src/OmniSharp.Host/Startup.cs
@@ -42,7 +42,7 @@ namespace OmniSharp
             configBuilder.AddJsonFile(source =>
             {
                 source.Path = "omnisharp.json";
-                source.Optional = false;
+                source.Optional = true;
                 source.FileProvider = new PhysicalFileProvider(Program.Environment.Path);
             });
 


### PR DESCRIPTION
Currently, when `omnisharp.json` exists in the project folder, Omnisharp crashes and exits. This is because the base path is set to the `ConfigurationBuilder`, which points to the `ApplicaitonBase` instead of the root folder of the project .