### PR TITLE
Disable package restore for this solution

### DIFF
--- a/omnisharp.json
+++ b/omnisharp.json
@@ -1,5 +1,6 @@
 {
     "dotnet": {
-        "projects": "src/*/project.json;tests/*/project.json"
+        "projects": "src/*/project.json;tests/*/project.json",
+        "enableRestorePackage": false
     }
 }


### PR DESCRIPTION
The restore `--infer-runtimes` is not in the auto package restore. The auto restore now run into endless issues for now