### PR TITLE
Refinement of archive generation

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -423,25 +423,24 @@ Task("OnlyPublish")
             }
 
             var buildIdentifier = $"{runtimeShort}-{framework}";
+            // Rename/restrict some archive names on CI
             // Travis/Linux + default + net451 is renamed to Mono
             if (string.Equals(EnvironmentVariable("TRAVIS_OS_NAME"), "linux") && runtime.Equals("default") && framework.Equals("net451"))
             {
-                buildIdentifier ="linux-mono";
+                buildIdentifier ="mono";
             }
-            // No need to archive for other Travis + net451 combinations
+            // No need to archive other Travis + net451 combinations
             else if (EnvironmentVariable("TRAVIS_OS_NAME") != null && framework.Equals("net451"))
+            {
+                continue;
+            }
+            // No need to archive Travis/Linux + default + not(net451) (expect all runtimes to be explicitely named)
+            else if (string.Equals(EnvironmentVariable("TRAVIS_OS_NAME"), "linux") && runtime.Equals("default") && !framework.Equals("net451"))
             {
                 continue;
             }
 
             DoArchive(runtime, outputFolder, $"{packageFolder}/{buildPlan.MainProject.ToLower()}-{buildIdentifier}");
-
-            // Alias linux
-            if (runtimeShort.Contains("ubuntu-") && !framework.Equals("net451"))
-            {
-                buildIdentifier = $"linux-{framework}";
-                DoArchive(runtime, outputFolder, $"{packageFolder}/{buildPlan.MainProject.ToLower()}-{buildIdentifier}");
-            }
         }
     }
 });


### PR DESCRIPTION
Proposal for simpler archiving logic. I'm also including existing functionality to make the behavior clear and easy to discuss.

Windows: nothing changes, archives generated with the `win-x64-{framework}` and `win-x86-{framework}` (for non-Local builds) identifiers.

Linux/Users: nothing changes, archives generated with the `linux-64-{framework}` identifiers for the local runtime.

Linux/Travis:
  - archive generated with the `mono` identifier for the local runtime using .NET 4.5.1 as framework.
  - archives generated with the `{osshortname}-x64` identifier for all the runtimes explicitly mentioned in PopulateRuntimes (none for the local one, we expect it to be in the list) using .NET Core as framework.

OSX/User: nothing changes, archive generated with the `osx-x64-{framework}` identifier for the local runtime.

OSX/Travis: nothing changes, archive generated with the `osx-x64` identifier for the local runtime using .NET Core as framework.

The differences are:
  - `linux-mono` -> `mono` to clarify that it works on OSX.
  - No more double archiving for local runtime and explicit Ubuntu. Safeguard to ignore OS variant on Travis/Linux. Users still get archive if they desire, using generic `linux-x64-{framework}` name.
  - No more `linux` alias for .NET Core.

Suggestions? Opinions?

@DustinCampbell @david-driscoll @troydai 