### PR TITLE
Handle strong-name key files from msbuild projects

### DIFF
--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -134,6 +134,13 @@ namespace OmniSharp.MSBuild
                     compilationOptions = compilationOptions.WithAllowUnsafe(true);
                 }
 
+                if (projectFileInfo.SignAssembly && !string.IsNullOrEmpty(projectFileInfo.AssemblyOriginatorKeyFile))
+                {
+                    var keyFile = Path.Combine(projectFileInfo.ProjectDirectory, projectFileInfo.AssemblyOriginatorKeyFile);
+                    compilationOptions = compilationOptions.WithStrongNameProvider(new DesktopStrongNameProvider())
+                                                           .WithCryptoKeyFile(keyFile);
+                }
+
                 var projectInfo = ProjectInfo.Create(ProjectId.CreateNewId(projectFileInfo.Name),
                                                      VersionStamp.Create(),
                                                      projectFileInfo.Name,

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -47,6 +47,10 @@ namespace OmniSharp.MSBuild.ProjectFile
 
         public OutputKind OutputKind { get; private set; }
 
+        public bool SignAssembly { get; private set; }
+
+        public string AssemblyOriginatorKeyFile { get; private set; }
+
         public static ProjectFileInfo Create(MSBuildOptions options, ILogger logger, string solutionDirectory, string projectFilePath, ICollection<MSBuildDiagnosticsMessage> diagnostics)
         {
             var projectFileInfo = new ProjectFileInfo();
@@ -133,6 +137,14 @@ namespace OmniSharp.MSBuild.ProjectFile
                 {
                     projectFileInfo.DefineConstants = defineConstants.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Distinct().ToList();
                 }
+
+                var signAssembly = projectInstance.GetPropertyValue("SignAssembly");
+                if (!string.IsNullOrWhiteSpace(signAssembly))
+                {
+                    projectFileInfo.SignAssembly = Convert.ToBoolean(signAssembly);
+                }
+
+                projectFileInfo.AssemblyOriginatorKeyFile = projectInstance.GetPropertyValue("AssemblyOriginatorKeyFile");
             }
             else
             {
@@ -211,6 +223,14 @@ namespace OmniSharp.MSBuild.ProjectFile
                 {
                     projectFileInfo.DefineConstants = defineConstants.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Distinct().ToList();
                 }
+
+                var signAssembly = properties["SignAssembly"].FinalValue;
+                if (!string.IsNullOrWhiteSpace(signAssembly))
+                {
+                    projectFileInfo.SignAssembly = Convert.ToBoolean(signAssembly);
+                }
+
+                projectFileInfo.AssemblyOriginatorKeyFile = properties["AssemblyOriginatorKeyFile"].FinalValue;
             }
             return projectFileInfo;
         }


### PR DESCRIPTION
This change adds support for the SignAssembly and AssemblyOriginatorKeyFile properties in MSBuild project.
It allows projects with InternalsVisibleTo attributes for strong named assemblies to have proper error reporting and intellisense.