### PR TITLE
PowerShell doesn't support double slash parameters, it would have bee…

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,3 @@
 $Env:OMNISHARP_PACKAGE_OSNAME = "win-x64"
-.\scripts\cake-bootstrap.ps1 --experimental @args
+.\scripts\cake-bootstrap.ps1 -experimental @args
 exit $LASTEXITCODE


### PR DESCRIPTION
…n failed when you have [CmdletBinding()] in cake-bootstrap.ps1, but since you have "ValueFromRemainingArguments" set to true for the "$ScriptArgs", the "--Experimental" will be captured by it instead.