### PR TITLE
Set event's delegate type as return type

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Workers/Intellisense/ReturnTypeFormatter.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Intellisense/ReturnTypeFormatter.cs
@@ -45,6 +45,12 @@ namespace OmniSharp
                 return fieldSymbol.Type;
             }
 
+            var eventSymbol = symbol as IEventSymbol;
+            if (eventSymbol != null)
+            {
+                return eventSymbol.Type;
+            }
+
             return null;
         }
     }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SnippetFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SnippetFacts.cs
@@ -313,7 +313,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
             var completions = await FindCompletionsAsync(source);
             Assert.Equal(1, completions.Count());
-            ContainsSnippet("TickChanged$0", completions);
+            ContainsSnippet("TickChanged$0 : TickHandler", completions);
         }
 
         [Fact]


### PR DESCRIPTION
In [PR](https://github.com/OmniSharp/omnisharp-vscode/pull/164) I have added return type information into `completionItemProvider`. But the `ReturnType` of an `event` was returned `null` from omnisharp server.

I have changed to return `event`'s `delegate` type for `ReturnType` like it is implemented in Visual Studio's intellisense.

![image](https://cloud.githubusercontent.com/assets/4062518/15482662/e9c103e8-2141-11e6-8885-54cba9d525c3.png)

P.S. Waiting for [new icon](https://github.com/Microsoft/vscode/issues/5407) in VS Code to change event's icon.