### PR TITLE
Refactored version information for CodeAnalysis Assemblies.

### DIFF
--- a/src/OmniSharp.Abstractions/Configuration.cs
+++ b/src/OmniSharp.Abstractions/Configuration.cs
@@ -3,5 +3,7 @@ namespace OmniSharp
     public static class Configuration
     {
         public static bool ZeroBasedIndices = false;
+        public const string CodeAnalysisVersion = "1.3.0.0";
+        public const string CodeAnalysisPublicKeyToken = "31bf3856ad364e35";
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/CodeActions/RoslynCodeActionProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/CodeActions/RoslynCodeActionProvider.cs
@@ -10,8 +10,14 @@ namespace OmniSharp.Roslyn.CSharp.Services.CodeActions
         [ImportingConstructor]
         public RoslynCodeActionProvider(IOmnisharpAssemblyLoader loader)
             : base("Roslyn", loader,
-                  "Microsoft.CodeAnalysis.CSharp.Features, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
-                  "Microsoft.CodeAnalysis.Features, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35")
+                  "Microsoft.CodeAnalysis.CSharp.Features" +
+                    $", Version={OmniSharp.Configuration.CodeAnalysisVersion}" +
+                    ", Culture=neutral" +
+                    $", PublicKeyToken={OmniSharp.Configuration.CodeAnalysisPublicKeyToken}",
+                  "Microsoft.CodeAnalysis.Features" +
+                    $", Version={OmniSharp.Configuration.CodeAnalysisVersion}" +
+                    ", Culture=neutral" +
+                    $", PublicKeyToken={OmniSharp.Configuration.CodeAnalysisPublicKeyToken}")
         { }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Intellisense/CSharpSyntaxContext.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Intellisense/CSharpSyntaxContext.cs
@@ -12,10 +12,13 @@ namespace OmniSharp
 {
     class ReflectionNamespaces
     {
-        internal const string WorkspacesAsmName = ", Microsoft.CodeAnalysis.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
-        internal const string CSWorkspacesAsmName = ", Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
-        internal const string CAAsmName = ", Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
-        internal const string CACSharpAsmName = ", Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
+        internal const string CodeAnalysisAsmSuffix =   ", Version=" + OmniSharp.Configuration.CodeAnalysisVersion +
+                                                        ", Culture=neutral" +
+                                                        ", PublicKeyToken=" + OmniSharp.Configuration.CodeAnalysisPublicKeyToken;
+        internal const string WorkspacesAsmName = ", Microsoft.CodeAnalysis.Workspaces" + CodeAnalysisAsmSuffix;
+        internal const string CSWorkspacesAsmName = ", Microsoft.CodeAnalysis.CSharp.Workspaces" + CodeAnalysisAsmSuffix;
+        internal const string CAAsmName = ", Microsoft.CodeAnalysis" + CodeAnalysisAsmSuffix;
+        internal const string CACSharpAsmName = ", Microsoft.CodeAnalysis.CSharp" + CodeAnalysisAsmSuffix;
     }
 
 

--- a/src/OmniSharp.Roslyn/MetadataHelper.cs
+++ b/src/OmniSharp.Roslyn/MetadataHelper.cs
@@ -24,9 +24,12 @@ namespace OmniSharp.Roslyn
         public MetadataHelper(IOmnisharpAssemblyLoader loader)
         {
             _loader = loader;
-            _featureAssembly = _loader.LazyLoad("Microsoft.CodeAnalysis.Features, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35");
-            _csharpFeatureAssembly = _loader.LazyLoad("Microsoft.CodeAnalysis.CSharp.Features, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35");
-            _workspaceAssembly = _loader.LazyLoad("Microsoft.CodeAnalysis.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35");
+            var codeAnalysisAsmSuffix = $", Version={OmniSharp.Configuration.CodeAnalysisVersion}" +
+                                        ", Culture=neutral" +
+                                        $", PublicKeyToken={OmniSharp.Configuration.CodeAnalysisPublicKeyToken}";
+            _featureAssembly = _loader.LazyLoad($"Microsoft.CodeAnalysis.Features{codeAnalysisAsmSuffix}");
+            _csharpFeatureAssembly = _loader.LazyLoad($"Microsoft.CodeAnalysis.CSharp.Features{codeAnalysisAsmSuffix}");
+            _workspaceAssembly = _loader.LazyLoad($"Microsoft.CodeAnalysis.Workspaces{codeAnalysisAsmSuffix}");
 
             _csharpMetadataAsSourceServices = new Lazy<Type>(() =>
             {


### PR DESCRIPTION
Fixes #554, while keeping the ability to hard-code version number and make it easy to manage long-term.