### PR TITLE
Added tracking of XML comments via Roslyn (#542)

### DIFF
--- a/src/OmniSharp.DotNet/DotNetProjectSystem.cs
+++ b/src/OmniSharp.DotNet/DotNetProjectSystem.cs
@@ -340,6 +340,12 @@ namespace OmniSharp.DotNet
             var parseOptions = new CSharpParseOptions(languageVersion: ParseLanguageVersion(option.LanguageVersion),
                                                       preprocessorSymbols: option.Defines);
 
+            if (option.GenerateXmlDocumentation ?? false)
+            {
+                csharpOptions = csharpOptions.WithXmlReferenceResolver(XmlFileResolver.Default);
+                parseOptions = parseOptions.WithDocumentationMode(DocumentationMode.Diagnose);
+            }
+
             _omnisharpWorkspace.SetCompilationOptions(state.Id, csharpOptions);
             _omnisharpWorkspace.SetParseOptions(state.Id, parseOptions);
         }

--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -141,6 +141,11 @@ namespace OmniSharp.MSBuild
                                                            .WithCryptoKeyFile(keyFile);
                 }
 
+                if (projectFileInfo.GenerateXmlDocumentation)
+                {
+                    compilationOptions = compilationOptions.WithXmlReferenceResolver(XmlFileResolver.Default);
+                }
+
                 var projectInfo = ProjectInfo.Create(ProjectId.CreateNewId(projectFileInfo.Name),
                                                      VersionStamp.Create(),
                                                      projectFileInfo.Name,
@@ -271,6 +276,10 @@ namespace OmniSharp.MSBuild
                 if (projectFileInfo.DefineConstants != null && projectFileInfo.DefineConstants.Any())
                 {
                     parseOptions = parseOptions.WithPreprocessorSymbols(projectFileInfo.DefineConstants);
+                }
+                if (projectFileInfo.GenerateXmlDocumentation)
+                {
+                    parseOptions = parseOptions.WithDocumentationMode(DocumentationMode.Diagnose);
                 }
                 _workspace.SetParseOptions(project.Id, parseOptions);
             }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -51,6 +51,8 @@ namespace OmniSharp.MSBuild.ProjectFile
 
         public string AssemblyOriginatorKeyFile { get; private set; }
 
+        public bool GenerateXmlDocumentation { get; private set; }
+
         public static ProjectFileInfo Create(MSBuildOptions options, ILogger logger, string solutionDirectory, string projectFilePath, ICollection<MSBuildDiagnosticsMessage> diagnostics)
         {
             var projectFileInfo = new ProjectFileInfo();
@@ -145,6 +147,12 @@ namespace OmniSharp.MSBuild.ProjectFile
                 }
 
                 projectFileInfo.AssemblyOriginatorKeyFile = projectInstance.GetPropertyValue("AssemblyOriginatorKeyFile");
+                
+                var documentationFile = projectInstance.GetPropertyValue("DocumentationFile");
+                if (!string.IsNullOrWhiteSpace(documentationFile))
+                {
+                    projectFileInfo.GenerateXmlDocumentation = true;
+                }
             }
             else
             {
@@ -231,6 +239,12 @@ namespace OmniSharp.MSBuild.ProjectFile
                 }
 
                 projectFileInfo.AssemblyOriginatorKeyFile = properties["AssemblyOriginatorKeyFile"].FinalValue;
+                
+                var documentationFile = properties["DocumentationFile"].FinalValue;
+                if (!string.IsNullOrWhiteSpace(documentationFile))
+                {
+                    projectFileInfo.GenerateXmlDocumentation = true;
+                }
             }
             return projectFileInfo;
         }


### PR DESCRIPTION
Solves #542.

Only enabled when XML document generation is requested to avoid FxCop warnings. Should work for both `csproj` and `project.json` (tested locally on `project.json`).

Still needs unit-tests if you guys like the methodology.