### PR TITLE
Parameterize listening interface

### DIFF
--- a/src/OmniSharp.Host/Program.cs
+++ b/src/OmniSharp.Host/Program.cs
@@ -29,6 +29,7 @@ namespace OmniSharp
             var transportType = TransportType.Http;
             var otherArgs = new List<string>();
             var plugins = new List<string>();
+            var serverInterface = "localhost";
 
             var enumerator = args.GetEnumerator();
 
@@ -67,6 +68,11 @@ namespace OmniSharp
                 {
                     Configuration.ZeroBasedIndices = true;
                 }
+                else if (arg == "--interface")
+                {
+                    enumerator.MoveNext();
+                    serverInterface = (string)enumerator.Current;
+                }
                 else
                 {
                     otherArgs.Add((string)enumerator.Current);
@@ -76,7 +82,7 @@ namespace OmniSharp
             Environment = new OmnisharpEnvironment(applicationRoot, serverPort, hostPID, logLevel, transportType, otherArgs.ToArray());
 
             var config = new ConfigurationBuilder()
-                .AddCommandLine(new[] { "--server.urls", "http://localhost:" + serverPort });
+                .AddCommandLine(new[] { "--server.urls", $"http://{serverInterface}:{serverPort}" });
 
             var writer = new SharedConsoleWriter();
 


### PR DESCRIPTION
Sometimes the server is not on the same machine as the client. In order to reach it we need the ability to specify the listening interface.

For more details see https://github.com/OmniSharp/omnisharp-emacs/pull/223.