### PR TITLE
Do #load traversal recursively in scriptcs subsystem, #512

### DIFF
--- a/src/OmniSharp.ScriptCs/Extensions/EnumerableExtensions.cs
+++ b/src/OmniSharp.ScriptCs/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.CodeAnalysis;
+using ScriptCs;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace OmniSharp.ScriptCs.Extensions
+{
+    internal static class EnumerableExtensions
+    {
+        private static readonly string BaseAssemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
+
+        internal static IEnumerable<MetadataReference> ToMetadataReferences(this IEnumerable<string> referencesToImport, ScriptServices scriptServices)
+        {
+            var listOfReferences = new List<MetadataReference>();
+            foreach (var importedReference in referencesToImport.Where(x => !x.ToLowerInvariant().Contains("scriptcs.contracts")))
+            {
+                if (scriptServices.FileSystem.IsPathRooted(importedReference))
+                {
+                    if (scriptServices.FileSystem.FileExists(importedReference))
+                        listOfReferences.Add(MetadataReference.CreateFromFile(importedReference));
+                }
+                else
+                {
+                    listOfReferences.Add(MetadataReference.CreateFromFile(Path.Combine(BaseAssemblyPath, importedReference.ToLower().EndsWith(".dll") ? importedReference : importedReference + ".dll")));
+                }
+            }
+
+            return listOfReferences;
+        }
+    }
+}

--- a/src/OmniSharp.ScriptCs/Extensions/ScriptcsExtensions.cs
+++ b/src/OmniSharp.ScriptCs/Extensions/ScriptcsExtensions.cs
@@ -8,14 +8,14 @@ using System.Threading.Tasks;
 
 namespace OmniSharp.ScriptCs.Extensions
 {
-    internal static class EnumerableExtensions
+    internal static class ScriptcsExtensions
     {
         private static readonly string BaseAssemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
 
-        internal static IEnumerable<MetadataReference> ToMetadataReferences(this IEnumerable<string> referencesToImport, ScriptServices scriptServices)
+        internal static IEnumerable<MetadataReference> MakeMetadataReferences(this ScriptServices scriptServices, IEnumerable<string> referencesPaths)
         {
             var listOfReferences = new List<MetadataReference>();
-            foreach (var importedReference in referencesToImport.Where(x => !x.ToLowerInvariant().Contains("scriptcs.contracts")))
+            foreach (var importedReference in referencesPaths.Where(x => !x.ToLowerInvariant().Contains("scriptcs.contracts")))
             {
                 if (scriptServices.FileSystem.IsPathRooted(importedReference))
                 {

--- a/src/OmniSharp.ScriptCs/ScriptCsContext.cs
+++ b/src/OmniSharp.ScriptCs/ScriptCsContext.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
 using System.Composition;
 
@@ -6,11 +7,21 @@ namespace OmniSharp.ScriptCs
     [Export, Shared]
     public class ScriptCsContext
     {
-        public HashSet<string> CsxFiles { get; } = new HashSet<string>();
-        public HashSet<string> References { get; } = new HashSet<string>();
-        public HashSet<string> Usings { get; } = new HashSet<string>();
+        public HashSet<string> CsxFilesBeingProcessed { get; } = new HashSet<string>();
+
+        // All of the followings are keyed with the file path
+        // Each .csx file is wrapped into a project
+        public Dictionary<string, ProjectInfo> CsxFileProjects { get; } = new Dictionary<string, ProjectInfo>();
+        public Dictionary<string, List<MetadataReference>> CsxReferences { get; } = new Dictionary<string, List<MetadataReference>>();
+        public Dictionary<string, List<ProjectInfo>> CsxLoadReferences { get; } = new Dictionary<string, List<ProjectInfo>>();
+        public Dictionary<string, List<string>> CsxUsings { get; } = new Dictionary<string, List<string>>();
+
         public HashSet<string> ScriptPacks { get; } = new HashSet<string>();
 
-        public string Path { get; set; }
+        // Nuget and ScriptPack stuff
+        public HashSet<MetadataReference> CommonReferences { get; } = new HashSet<MetadataReference>();
+        public HashSet<string> CommonUsings { get; } = new HashSet<string>();
+
+        public string RootPath { get; set; }
     }
 }

--- a/src/OmniSharp.ScriptCs/project.json
+++ b/src/OmniSharp.ScriptCs/project.json
@@ -10,7 +10,7 @@
   "frameworks": {
     "net451": {
       "dependencies": {
-        "ScriptCs.Hosting": "0.14.1",
+        "ScriptCs.Hosting": "0.16.1",
         "Microsoft.Web.Xdt": "2.1.1",
         "NuGet.Core": "2.10.1"
       }


### PR DESCRIPTION
This is a refactoring and rewrite of the initialization logic in the ScriptCs subsytem.
The aims are the following:

1. Support .csx files in all subdirectories not just root
2. Do not crash on multiple `#load# references in scripts
3. Follow `#load` references recursively and map them to proper project references
4. Do not break anything that worked before.