### PR TITLE
Pass -NoProfile when executing powershell scripts

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -23,7 +23,7 @@ var workingDirectory = System.IO.Directory.GetCurrentDirectory();
 
 // System specific shell configuration
 var shell = IsRunningOnWindows() ? "powershell" : "bash";
-var shellArgument = IsRunningOnWindows() ? "/Command" : "-C";
+var shellArgument = IsRunningOnWindows() ? "-NoProfile /Command" : "-C";
 var shellExtension = IsRunningOnWindows() ? "ps1" : "sh";
 
 /// <summary>


### PR DESCRIPTION
This avoids loading the default powershell profile when executing powershell scripts during Windows builds, since the user can define a default powershell profile that might do things like change the CWD.