### PR TITLE
Fix IProjectSystem.GetProjectModel(...) API

### DIFF
--- a/src/OmniSharp.Abstractions/Services/IProjectSystem.cs
+++ b/src/OmniSharp.Abstractions/Services/IProjectSystem.cs
@@ -11,7 +11,17 @@ namespace OmniSharp.Services
         string Language { get; }
         IEnumerable<string> Extensions { get; }
         void Initalize(IConfiguration configuration);
-        Task<object> GetInformationModel(WorkspaceInformationRequest request);
-        Task<object> GetProjectModel(string path);
+
+        /// <summary>
+        /// Get a model of the entire workspace loaded in this project system.
+        /// </summary>
+        Task<object> GetWorkspaceModelAsync(WorkspaceInformationRequest request);
+
+        /// <summary>
+        /// Get a model of a specific project in this project system.
+        /// </summary>
+        /// <param name="filePath">The file path to the project to retrieve. Alternatively,
+        /// a file path to a document within a proejct may be specified.</param>
+        Task<object> GetProjectModelAsync(string filePath);
     }
 }

--- a/src/OmniSharp.DotNet/Cache/ProjectStatesCache.cs
+++ b/src/OmniSharp.DotNet/Cache/ProjectStatesCache.cs
@@ -129,39 +129,43 @@ namespace OmniSharp.DotNet.Cache
             }
         }
 
-        internal ProjectEntry GetOrAddEntry(string projectDirectory)
+        internal ProjectEntry GetEntry(string filePath)
         {
             ProjectEntry result;
-            if (_projects.TryGetValue(projectDirectory, out result))
+            if (_projects.TryGetValue(filePath, out result))
             {
                 return result;
             }
-            else
-            {
-                result = new ProjectEntry(projectDirectory);
-                _projects[projectDirectory] = result;
 
-                return result;
-            }
+            return null;
         }
 
-        private ProjectEntry GetOrAddEntry(string projectDirectory, out bool added)
+        internal ProjectEntry GetOrAddEntry(string filePath)
+        {
+            var result = GetEntry(filePath);
+
+            if (result == null)
+            {
+                result = new ProjectEntry(filePath);
+                _projects[filePath] = result;
+            }
+
+            return result;
+        }
+
+        private ProjectEntry GetOrAddEntry(string filePath, out bool added)
         {
             added = false;
-            ProjectEntry result;
-            if (_projects.TryGetValue(projectDirectory, out result))
-            {
+            var result = GetEntry(filePath);
 
-                return result;
-            }
-            else
+            if (result == null)
             {
-                result = new ProjectEntry(projectDirectory);
-                _projects[projectDirectory] = result;
+                result = new ProjectEntry(filePath);
+                _projects[filePath] = result;
                 added = true;
-
-                return result;
             }
+
+            return result;
         }
 
         private void EmitProject(string eventType, DotNetProjectInformation information)

--- a/src/OmniSharp.Plugins/Plugin.cs
+++ b/src/OmniSharp.Plugins/Plugin.cs
@@ -113,16 +113,16 @@ namespace OmniSharp.Plugins
             Task.Run(() => Run());
         }
 
-        public Task<object> GetInformationModel(WorkspaceInformationRequest request)
+        public Task<object> GetWorkspaceModelAsync(WorkspaceInformationRequest request)
         {
             // TODO: Call out to process
-            return null;
+            return Task.FromResult<object>(null);
         }
 
-        public Task<object> GetProjectModel(string path)
+        public Task<object> GetProjectModelAsync(string filePath)
         {
             // TODO: Call out to process
-            return null;
+            return Task.FromResult<object>(null);
         }
     }
 }

--- a/src/OmniSharp.Roslyn/ProjectEventForwarder.cs
+++ b/src/OmniSharp.Roslyn/ProjectEventForwarder.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Composition;
-using System.Composition.Hosting;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using OmniSharp.Models;
@@ -59,7 +58,7 @@ namespace OmniSharp.Roslyn
                             object payload = null;
                             if (e.EventType != EventTypes.ProjectRemoved)
                             {
-                                payload = await GetProjectInformation(e.FileName);
+                                payload = await GetProjectInformationAsync(e.FileName);
                             }
 
                             lock (_lock)
@@ -73,13 +72,13 @@ namespace OmniSharp.Roslyn
             }
         }
 
-        private async Task<ProjectInformationResponse> GetProjectInformation(string fileName)
+        private async Task<ProjectInformationResponse> GetProjectInformationAsync(string fileName)
         {
             var response = new ProjectInformationResponse();
 
             foreach (var projectSystem in _projectSystems)
             {
-                var project = await projectSystem.GetProjectModel(fileName);
+                var project = await projectSystem.GetProjectModelAsync(fileName);
                 if (project != null)
                 {
                     response.Add($"{projectSystem.Key}Project", project);

--- a/src/OmniSharp.Roslyn/ProjectInformationService.cs
+++ b/src/OmniSharp.Roslyn/ProjectInformationService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Threading.Tasks;
@@ -26,7 +25,7 @@ namespace OmniSharp
 
             foreach (var projectSystem in _projectSystems)
             {
-                var project = await projectSystem.GetProjectModel(request.FileName);
+                var project = await projectSystem.GetProjectModelAsync(request.FileName);
                 response.Add($"{projectSystem.Key}Project", project);
             }
 

--- a/src/OmniSharp.Roslyn/WorkspaceInformationService.cs
+++ b/src/OmniSharp.Roslyn/WorkspaceInformationService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Threading.Tasks;
@@ -26,8 +25,8 @@ namespace OmniSharp
 
             foreach (var projectSystem in _projectSystems)
             {
-                var informationModel = await projectSystem.GetInformationModel(request);
-                response.Add(projectSystem.Key, informationModel);
+                var workspaceModel = await projectSystem.GetWorkspaceModelAsync(request);
+                response.Add(projectSystem.Key, workspaceModel);
             }
 
             return response;

--- a/src/OmniSharp.ScriptCs/ScriptCsProjectSystem.cs
+++ b/src/OmniSharp.ScriptCs/ScriptCsProjectSystem.cs
@@ -210,12 +210,12 @@ namespace OmniSharp.ScriptCs
             }
         }
 
-        Task<object> IProjectSystem.GetProjectModel(string path)
+        Task<object> IProjectSystem.GetProjectModelAsync(string filePath)
         {
             return Task.FromResult<object>(null);
         }
 
-        Task<object> IProjectSystem.GetInformationModel(WorkspaceInformationRequest request)
+        Task<object> IProjectSystem.GetWorkspaceModelAsync(WorkspaceInformationRequest request)
         {
             return Task.FromResult<object>(new ScriptCsContextModel(Context));
         }

--- a/tests/OmniSharp.Tests/EndpointMiddlewareFacts.cs
+++ b/tests/OmniSharp.Tests/EndpointMiddlewareFacts.cs
@@ -66,12 +66,12 @@ namespace OmniSharp.Tests
             public string Language { get { return LanguageNames.CSharp; } }
             public IEnumerable<string> Extensions { get; } = new[] { ".cs" };
 
-            public Task<object> GetInformationModel(WorkspaceInformationRequest request)
+            public Task<object> GetWorkspaceModelAsync(WorkspaceInformationRequest request)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<object> GetProjectModel(string path)
+            public Task<object> GetProjectModelAsync(string path)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
This method almost always returns null because all implementations assume that the path passed in is a document path. However, every caller within OmniSharp always pass a project file path. Now, if a document isn't found, each implementation attempts the path as a project path. This fixes the '/projects' endpoint when a file path is specified and the Roslyn workspace events emitted from the OmniSharp server, such as 'ProjectChanged'.

cc @david-driscoll 