### PR TITLE
Add required quotes to paths

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -134,7 +134,7 @@ Task("BuildEnvironment")
     }
     if (!IsRunningOnWindows())
     {
-        Run("chmod", $"+x {scriptPath}");
+        Run("chmod", $"+x '{scriptPath}'");
     }
     var installArgs = $"-Channel {buildPlan.DotNetChannel}";
     if (!String.IsNullOrEmpty(buildPlan.DotNetVersion))

--- a/scripts/cake-bootstrap.sh
+++ b/scripts/cake-bootstrap.sh
@@ -48,7 +48,7 @@ fi
 
 # Restore tools from NuGet.
 pushd "$TOOLS_DIR" >/dev/null
-mono "$NUGET_EXE" install $PACKAGES_CONFIG -ExcludeVersion -OutputDirectory "$TOOLS_DIR"
+mono "$NUGET_EXE" install "$PACKAGES_CONFIG" -ExcludeVersion -OutputDirectory "$TOOLS_DIR"
 if [ $? -ne 0 ]; then
     echo "Could not restore NuGet packages."
     exit 1


### PR DESCRIPTION
This adds quotes to two paths used during the execution of `./build.sh`, to prevent failing the build if `pwd` contains spaces.

Fixes #599.