### PR TITLE
Fix OmniSharp --encoding switch to apply to both stdin and stdout

### DIFF
--- a/src/OmniSharp.Host/Program.cs
+++ b/src/OmniSharp.Host/Program.cs
@@ -91,6 +91,15 @@ namespace OmniSharp
             var config = new ConfigurationBuilder()
                 .AddCommandLine(new[] { "--server.urls", $"http://{serverInterface}:{serverPort}" });
 
+            // If the --encoding switch was specified, we need to set the InputEncoding and OutputEncoding before
+            // constructing the SharedConsoleWriter. Otherwise, it might be created with the wrong encoding since
+            // it wraps around Console.Out, which gets recreated when OutputEncoding is set.
+            if (transportType == TransportType.Stdio && encoding != null)
+            {
+                Console.InputEncoding = encoding;
+                Console.OutputEncoding = encoding;
+            }
+
             var writer = new SharedConsoleWriter();
 
             var builder = new WebHostBuilder()
@@ -107,11 +116,6 @@ namespace OmniSharp
 
             if (transportType == TransportType.Stdio)
             {
-                if (encoding != null)
-                {
-                    Console.InputEncoding = encoding;
-                    Console.OutputEncoding = encoding;
-                }
                 builder.UseServer(new StdioServer(Console.In, writer));
             }
             else


### PR DESCRIPTION
When the --encoding switch was specified, it unintentionally only applied to stdin, but not stdout. This was due to the fact that the `SharedConsoleWriter` was instantiated before `Console.OutputEncoding` was set. Because `SharedConsoleWriter` initializes itself with the current value of `Console.Out`, it had the default encoding rather than the intended encoding.

A bit subtle.

cc @david-driscoll and @nabychan