### PR TITLE
Add configuration to make OmniSharp easier to test with MSBuild-based .NET Core projects

### DIFF
--- a/src/OmniSharp.DotNet/DotNetProjectSystem.cs
+++ b/src/OmniSharp.DotNet/DotNetProjectSystem.cs
@@ -92,6 +92,18 @@ namespace OmniSharp.DotNet
 
         public void Initalize(IConfiguration configuration)
         {
+            bool enabled;
+            if (!bool.TryParse(configuration["enabled"], out enabled))
+            {
+                enabled = true;
+            }
+
+            if (!enabled)
+            {
+                _logger.LogInformation("DotNetProjectSystem is disabled");
+                return;
+            }
+
             _logger.LogInformation($"Initializing in {_environment.Path}");
 
             if (!bool.TryParse(configuration["enablePackageRestore"], out _enableRestorePackages))

--- a/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
+++ b/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
@@ -5,6 +5,7 @@ namespace OmniSharp.Options
         public string ToolsVersion { get; set; }
         public string VisualStudioVersion { get; set; }
         public bool WaitForDebugger { get; set; }
+        public string MSBuildExtensionsPath { get; set; }
 
         // TODO: Allow loose properties
         // public IConfiguration Properties { get; set; }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
@@ -13,6 +13,7 @@
             public const string DocumentationFile = nameof(DocumentationFile);
             public const string LangVersion = nameof(LangVersion);
             public const string OutputType = nameof(OutputType);
+            public const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);
             public const string ProjectGuid = nameof(ProjectGuid);
             public const string ProjectName = nameof(ProjectName);
             public const string _ResolveReferenceDependencies = nameof(_ResolveReferenceDependencies);

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -116,6 +116,11 @@ namespace OmniSharp.MSBuild.ProjectFile
                 { PropertyNames.SolutionDir, solutionDirectory + Path.DirectorySeparatorChar }
             };
 
+            if (!string.IsNullOrWhiteSpace(options.MSBuildExtensionsPath))
+            {
+                globalProperties.Add(PropertyNames.MSBuildExtensionsPath, options.MSBuildExtensionsPath);
+            }
+
             if (!string.IsNullOrWhiteSpace(options.VisualStudioVersion))
             {
                 globalProperties.Add(PropertyNames.VisualStudioVersion, options.VisualStudioVersion);


### PR DESCRIPTION
Two settings have been added:

* dotnet.enabled: If set to false, the DotNetProjectSystem will not attempt to initialize and load any projects.
* msbuild.msbuildextensionpath: If set, the value will be passed into MSBuild as the MSBuildExtensionPath property.