### PR TITLE
Clean up!

### DIFF
--- a/OmniSharp.sln
+++ b/OmniSharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2C348365-A9D8-459E-9276-56FC46AAEE31}"
 EndProject
@@ -57,6 +57,8 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OmniSharp.DotNetTest", "src\OmniSharp.DotNetTest\OmniSharp.DotNetTest.xproj", "{33A68F57-B234-4481-AEDE-03D51756B35A}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OmniSharp.DotNetTest.Tests", "tests\OmniSharp.DotNetTest.Tests\OmniSharp.DotNetTest.Tests.xproj", "{F6195E7B-8002-42AE-BF86-E78DBC769A47}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OmniSharp.DotNet.Tests", "tests\OmniSharp.DotNet.Tests\OmniSharp.DotNet.Tests.xproj", "{A645D475-3448-4473-88CA-E3C3B31E33CA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -140,6 +142,10 @@ Global
 		{F6195E7B-8002-42AE-BF86-E78DBC769A47}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F6195E7B-8002-42AE-BF86-E78DBC769A47}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F6195E7B-8002-42AE-BF86-E78DBC769A47}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A645D475-3448-4473-88CA-E3C3B31E33CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A645D475-3448-4473-88CA-E3C3B31E33CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A645D475-3448-4473-88CA-E3C3B31E33CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A645D475-3448-4473-88CA-E3C3B31E33CA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -164,5 +170,6 @@ Global
 		{55C2439D-826F-4CDB-A6F7-B4A2818A6A3B} = {35E025BF-BBB2-4FAC-9F4B-37CBA083EE47}
 		{33A68F57-B234-4481-AEDE-03D51756B35A} = {2C348365-A9D8-459E-9276-56FC46AAEE31}
 		{F6195E7B-8002-42AE-BF86-E78DBC769A47} = {35E025BF-BBB2-4FAC-9F4B-37CBA083EE47}
+		{A645D475-3448-4473-88CA-E3C3B31E33CA} = {35E025BF-BBB2-4FAC-9F4B-37CBA083EE47}
 	EndGlobalSection
 EndGlobal

--- a/build.json
+++ b/build.json
@@ -22,6 +22,9 @@
     ],
     "OmniSharp.DotNetTest.Tests": [
       "netcoreapp1.0"
+    ],
+    "OmniSharp.Tests": [
+      "netcoreapp1.0"
     ]
   },
   "Frameworks": [

--- a/src/OmniSharp.Abstractions/project.json
+++ b/src/OmniSharp.Abstractions/project.json
@@ -4,7 +4,7 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "Newtonsoft.Json": "8.0.3",
+    "Newtonsoft.Json": "9.0.1",
     "Microsoft.CodeAnalysis": "2.0.0-beta3",
     "Microsoft.Composition": "1.0.30",
     "Microsoft.Extensions.Caching.Memory": "1.0.0",
@@ -34,7 +34,6 @@
     "netstandard1.6": {
       "imports": [
         "dotnet5.4",
-        "dnxcore50",
         "portable-net45+win8"
       ],
       "dependencies": {

--- a/src/OmniSharp.DotNet/DotNetProjectSystem.cs
+++ b/src/OmniSharp.DotNet/DotNetProjectSystem.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Collections.Immutable;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.IO;
 using System.Linq;

--- a/src/OmniSharp.DotNet/Models/DotNetWorkspaceInformation.cs
+++ b/src/OmniSharp.DotNet/Models/DotNetWorkspaceInformation.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.DotNet.ProjectModel;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using OmniSharp.DotNet.Cache;
 
 namespace OmniSharp.DotNet.Models

--- a/src/OmniSharp.DotNet/project.json
+++ b/src/OmniSharp.DotNet/project.json
@@ -18,7 +18,6 @@
     "netstandard1.6": {
       "imports": [
         "dotnet5.6",
-        "dnxcore50",
         "portable-net45+win8"
       ],
       "dependencies": {

--- a/src/OmniSharp.DotNetTest/Helpers/TestFeaturesDiscover.cs
+++ b/src/OmniSharp.DotNetTest/Helpers/TestFeaturesDiscover.cs
@@ -3,8 +3,8 @@ using System.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using OmniSharp.Models;
 using OmniSharp.Abstractions.Services;
+using OmniSharp.Models;
 
 namespace OmniSharp.DotNetTest.Helpers
 {

--- a/src/OmniSharp.DotNetTest/project.json
+++ b/src/OmniSharp.DotNetTest/project.json
@@ -14,7 +14,6 @@
     "netstandard1.6": {
       "imports": [
         "dotnet5.6",
-        "dnxcore50",
         "portable-net45+win8"
       ],
       "dependencies": {

--- a/src/OmniSharp.Host/project.json
+++ b/src/OmniSharp.Host/project.json
@@ -33,7 +33,6 @@
     "netstandard1.6": {
       "imports": [
         "dotnet5.6",
-        "dnxcore50",
         "portable-net45+win8"
       ],
       "dependencies": {

--- a/src/OmniSharp.Plugins/project.json
+++ b/src/OmniSharp.Plugins/project.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "OmniSharp.Abstractions": "1.0.0",
-    "Newtonsoft.Json": "8.0.3"
+    "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {
     "net451": {
@@ -16,7 +16,6 @@
     "netstandard1.6": {
       "imports": [
         "dotnet5.4",
-        "dnxcore50",
         "portable-net45+win8"
       ],
       "dependencies": {

--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/CodeActionHelper.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/CodeActionHelper.cs
@@ -16,6 +16,8 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
 {
     public static class CodeActionHelper
     {
+        private const string RemoveUnnecessaryUsingsProviderName = "Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnusedUsings.RemoveUnnecessaryUsingsCodeFixProvider";
+
         public static async Task<IEnumerable<CodeAction>> GetActions(OmnisharpWorkspace workspace, IEnumerable<ICodeActionProvider> codeActionProviders, ILogger logger, ICodeActionRequest request)
         {
             var actions = new List<CodeAction>();
@@ -26,10 +28,19 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
             }
 
             var refactoringContext = await GetRefactoringContext(originalDocument, request, actions);
+            if (refactoringContext != null)
+            {
+                await CollectRefactoringActions(codeActionProviders, logger, refactoringContext.Value);
+            }
+
             var codeFixContext = await GetCodeFixContext(originalDocument, request, actions);
-            await CollectRefactoringActions(codeActionProviders, logger, refactoringContext);
-            await CollectCodeFixActions(codeActionProviders, logger, codeFixContext);
+            if (codeFixContext != null)
+            {
+                await CollectCodeFixActions(codeActionProviders, logger, codeFixContext.Value);
+            }
+
             actions.Reverse();
+
             return actions;
         }
 
@@ -235,10 +246,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
             "ICSharpCode.NRefactory6.CSharp.Refactoring.ConditionIsAlwaysTrueOrFalseFixProvider"
         };
 
-        private static async Task CollectCodeFixActions(IEnumerable<ICodeActionProvider> codeActionProviders, ILogger logger, CodeFixContext? fixContext)
+        private static async Task CollectCodeFixActions(IEnumerable<ICodeActionProvider> codeActionProviders, ILogger logger, CodeFixContext context)
         {
-            if (!fixContext.HasValue)
-                return;
+            var diagnosticIds = context.Diagnostics.Select(d => d.Id).ToArray();
 
             foreach (var provider in codeActionProviders)
             {
@@ -249,9 +259,20 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
                         continue;
                     }
 
+                    // TODO: This is a horrible hack! However, remove unnecessary usings only
+                    // responds for diagnostics that are produced by its diagnostic analyzer.
+                    // We need to provide a *real* diagnostic engine to address this.
+                    if (codeFix.ToString() != RemoveUnnecessaryUsingsProviderName)
+                    {
+                        if (!diagnosticIds.Any(id => codeFix.FixableDiagnosticIds.Contains(id)))
+                        {
+                            continue;
+                        }
+                    }
+
                     try
                     {
-                        await codeFix.RegisterCodeFixesAsync(fixContext.Value);
+                        await codeFix.RegisterCodeFixesAsync(context);
                     }
                     catch
                     {
@@ -261,11 +282,8 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
             }
         }
 
-        private static async Task CollectRefactoringActions(IEnumerable<ICodeActionProvider> codeActionProviders, ILogger logger, CodeRefactoringContext? refactoringContext)
+        private static async Task CollectRefactoringActions(IEnumerable<ICodeActionProvider> codeActionProviders, ILogger logger, CodeRefactoringContext context)
         {
-            if (!refactoringContext.HasValue)
-                return;
-
             foreach (var provider in codeActionProviders)
             {
                 foreach (var refactoring in provider.Refactorings)
@@ -277,7 +295,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
 
                     try
                     {
-                        await refactoring.ComputeRefactoringsAsync(refactoringContext.Value);
+                        await refactoring.ComputeRefactoringsAsync(context);
                     }
                     catch
                     {

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticService.cs
@@ -1,12 +1,12 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using OmniSharp.Services;
-using OmniSharp.Models;
-using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
+using OmniSharp.Models;
+using OmniSharp.Services;
 
 namespace OmniSharp.Workers.Diagnostics
 {

--- a/src/OmniSharp.ScriptCs/Extensions/ScriptcsExtensions.cs
+++ b/src/OmniSharp.ScriptCs/Extensions/ScriptcsExtensions.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using ScriptCs;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using ScriptCs;
 
 namespace OmniSharp.ScriptCs.Extensions
 {

--- a/src/OmniSharp.ScriptCs/ScriptCsContext.cs
+++ b/src/OmniSharp.ScriptCs/ScriptCsContext.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
 using System.Composition;
+using Microsoft.CodeAnalysis;
 
 namespace OmniSharp.ScriptCs
 {

--- a/src/OmniSharp.ScriptCs/ScriptCsContextModel.cs
+++ b/src/OmniSharp.ScriptCs/ScriptCsContextModel.cs
@@ -1,6 +1,4 @@
-using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
-using System.Composition;
 using System.Linq;
 using OmniSharp.Roslyn.Models;
 

--- a/src/OmniSharp.ScriptCs/ScriptCsProjectSystem.cs
+++ b/src/OmniSharp.ScriptCs/ScriptCsProjectSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.IO;
 using System.Linq;
@@ -12,13 +13,12 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Models.v1;
+using OmniSharp.ScriptCs.Extensions;
 using OmniSharp.Services;
 using ScriptCs;
 using ScriptCs.Contracts;
-using LogLevel = ScriptCs.Contracts.LogLevel;
 using ScriptCs.Hosting;
-using OmniSharp.ScriptCs.Extensions;
-using System.Collections.Immutable;
+using LogLevel = ScriptCs.Contracts.LogLevel;
 
 namespace OmniSharp.ScriptCs
 {

--- a/src/OmniSharp.Stdio/project.json
+++ b/src/OmniSharp.Stdio/project.json
@@ -8,14 +8,13 @@
     "OmniSharp.Abstractions": "1.0.0",
     "Microsoft.AspNetCore.Hosting": "1.0.0",
     "Microsoft.AspNetCore.Http.Features": "1.0.0",
-    "Newtonsoft.Json": "8.0.3"
+    "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {
     "net451": {},
     "netstandard1.6": {
       "imports": [
         "dotnet5.4",
-        "dnxcore50",
         "portable-net45+win8"
       ],
       "dependencies": {

--- a/src/OmniSharp/project.json
+++ b/src/OmniSharp/project.json
@@ -26,7 +26,7 @@
     },
     "netcoreapp1.0": {
       "imports": [
-        "dnxcore50",
+        "dotnet5.4",
         "portable-net45+win8"
       ],
       "dependencies": {

--- a/tests/OmniSharp.DotNet.Tests/OmniSharp.DotNet.Tests.xproj
+++ b/tests/OmniSharp.DotNet.Tests/OmniSharp.DotNet.Tests.xproj
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0.25123" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25123</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>f6195e7b-8002-42ae-bf86-e78dbc769a47</ProjectGuid>
-    <RootNamespace>OmniSharp.DotNetTest.Tests</RootNamespace>
+    <ProjectGuid>a645d475-3448-4473-88ca-e3c3b31e33ca</ProjectGuid>
+    <RootNamespace>OmniSharp.DotNet.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>

--- a/tests/OmniSharp.DotNet.Tests/project.json
+++ b/tests/OmniSharp.DotNet.Tests/project.json
@@ -10,18 +10,17 @@
   },
   "frameworks": {
     "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.4",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "Microsoft.NETCore.App": {
           "version": "1.0.0",
           "type": "platform"
-        }
-      },
-      "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
-      ]
+        },
+        "dotnet-test-xunit": "2.2.0-preview2-build1029"
+      }
     }
   },
   "testRunner": "xunit"

--- a/tests/OmniSharp.DotNetTest.Tests/project.json
+++ b/tests/OmniSharp.DotNetTest.Tests/project.json
@@ -5,26 +5,23 @@
   },
   "dependencies": {
     "OmniSharp.DotNetTest": "1.0.0",
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
-    "Microsoft.Extensions.Logging.Console": "1.0.0",
     "TestCommon": "1.0.0",
     "TestUtility": "1.0.0",
     "xunit": "2.1.0"
   },
   "frameworks": {
     "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.4",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "Microsoft.NETCore.App": {
           "version": "1.0.0",
           "type": "platform"
-        }
-      },
-      "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
-      ]
+        },
+        "dotnet-test-xunit": "2.2.0-preview2-build1029"
+      }
     }
   },
   "testRunner": "xunit"

--- a/tests/OmniSharp.MSBuild.Tests/project.json
+++ b/tests/OmniSharp.MSBuild.Tests/project.json
@@ -4,7 +4,6 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "OmniSharp.Tests": "1.0.0",
     "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta3",
     "xunit": "2.1.0",
     "TestCommon": "1.0.0",

--- a/tests/OmniSharp.MSBuild.Tests/project.json
+++ b/tests/OmniSharp.MSBuild.Tests/project.json
@@ -4,26 +4,24 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta3",
-    "xunit": "2.1.0",
+    "OmniSharp.MSBuild": "1.0.0",
     "TestCommon": "1.0.0",
-    "TestUtility": "1.0.0"
+    "TestUtility": "1.0.0",
+    "xunit": "2.1.0"
   },
   "frameworks": {
     "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.4",
+        "portable-net45+win8"
+      ],
       "dependencies": {
-        "OmniSharp.MSBuild": "1.0.0",
-        "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "Microsoft.NETCore.App": {
           "version": "1.0.0",
           "type": "platform"
-        }
-      },
-      "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
-      ]
+        },
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+      }
     }
   },
   "testRunner": "xunit"

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/BufferManagerFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/BufferManagerFacts.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Services;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CodeActionsV2Facts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CodeActionsV2Facts.cs
@@ -9,7 +9,7 @@ using OmniSharp.Roslyn.CSharp.Services;
 using OmniSharp.Roslyn.CSharp.Services.CodeActions;
 using OmniSharp.Roslyn.CSharp.Services.Refactoring.V2;
 using OmniSharp.Services;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsFacts.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Diagnostics;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsV2Facts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsV2Facts.cs
@@ -1,11 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Diagnostics;
 using OmniSharp.Services;
-using OmniSharp.Tests;
 using OmniSharp.Workers.Diagnostics;
+using TestUtility;
 using TestUtility.Fake;
 using Xunit;
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Navigation;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindReferencesFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindReferencesFacts.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Navigation;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindSymbolsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindSymbolsFacts.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Navigation;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FixUsingsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FixUsingsFacts.cs
@@ -7,7 +7,7 @@ using OmniSharp.Models;
 using OmniSharp.Options;
 using OmniSharp.Roslyn.CSharp.Services.Refactoring;
 using OmniSharp.Services;
-using OmniSharp.Tests;
+using TestUtility;
 using TestUtility.Annotate;
 using TestUtility.Fake;
 using Xunit;

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
@@ -7,7 +7,7 @@ using OmniSharp.Models;
 using OmniSharp.Options;
 using OmniSharp.Roslyn.CSharp.Services.Formatting;
 using OmniSharp.Roslyn.CSharp.Workers.Formatting;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Navigation;
 using OmniSharp.Services;
-using OmniSharp.Tests;
+using TestUtility;
 using TestUtility.Annotate;
 using Xunit;
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToFileFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToFileFacts.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Navigation;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToRegionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToRegionFacts.cs
@@ -1,10 +1,9 @@
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Navigation;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/HighlightFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/HighlightFacts.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Highlighting;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Options;
 using OmniSharp.Roslyn.CSharp.Services.Intellisense;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/MetadataFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/MetadataFacts.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Navigation;
 using OmniSharp.Services;
-using OmniSharp.Tests;
+using TestUtility;
 using TestUtility.Annotate;
 using Xunit;
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/NavigateUpDownFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/NavigateUpDownFacts.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Navigation;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/OpenCloseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/OpenCloseFacts.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Files;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/RenameFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/RenameFacts.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Refactoring;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Signatures;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SnippetFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SnippetFacts.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Options;
 using OmniSharp.Roslyn.CSharp.Services.Intellisense;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/StructureFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/StructureFacts.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/TypeLookupFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/TypeLookupFacts.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Options;
 using OmniSharp.Roslyn.CSharp.Services.Types;
-using OmniSharp.Tests;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/project.json
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/project.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "TestUtility": "1.0.0",
     "TestCommon": "1.0.0",
-    "OmniSharp.Tests": "1.0.0",
     "OmniSharp.Roslyn.CSharp": "1.0.0",
     "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta3",
     "xunit": "2.1.0"

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/project.json
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/project.json
@@ -4,17 +4,15 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "TestUtility": "1.0.0",
-    "TestCommon": "1.0.0",
     "OmniSharp.Roslyn.CSharp": "1.0.0",
-    "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta3",
+    "TestCommon": "1.0.0",
+    "TestUtility": "1.0.0",
     "xunit": "2.1.0"
   },
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
+        "dotnet5.4",
         "portable-net45+win8"
       ],
       "dependencies": {
@@ -22,9 +20,6 @@
           "version": "1.0.0",
           "type": "platform"
         },
-        "System.Linq.Parallel": "4.0.1",
-        "System.Runtime.Serialization.Primitives": "4.1.1",
-        "System.Threading.Tasks.Parallel": "4.0.1",
         "dotnet-test-xunit": "2.2.0-preview2-build1029"
       }
     },

--- a/tests/OmniSharp.Stdio.Tests/project.json
+++ b/tests/OmniSharp.Stdio.Tests/project.json
@@ -10,8 +10,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
+        "dotnet5.4",
         "portable-net45+win8"
       ],
       "dependencies": {
@@ -20,11 +19,6 @@
           "type": "platform"
         },
         "NuGet.Packaging": "3.5.0-beta2-1484",
-        "System.IO.Compression": "4.1.0",
-        "System.Runtime.Loader": "4.0.0",
-        "System.Runtime.Serialization.Primitives": "4.1.1",
-        "System.Threading.ThreadPool": "4.0.10",
-        "System.Xml.XDocument": "4.0.11",
         "dotnet-test-xunit": "2.2.0-preview2-build1029"
       }
     },

--- a/tests/OmniSharp.Stdio.Tests/project.json
+++ b/tests/OmniSharp.Stdio.Tests/project.json
@@ -18,7 +18,6 @@
           "version": "1.0.0",
           "type": "platform"
         },
-        "NuGet.Packaging": "3.5.0-beta2-1484",
         "dotnet-test-xunit": "2.2.0-preview2-build1029"
       }
     },

--- a/tests/OmniSharp.Tests/AssemblyInfo.cs
+++ b/tests/OmniSharp.Tests/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+﻿[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/OmniSharp.Tests/CodingGuidelinesFacts.cs
+++ b/tests/OmniSharp.Tests/CodingGuidelinesFacts.cs
@@ -19,11 +19,8 @@ namespace OmniSharp.Tests
             {
                 var source = File.ReadAllText(sourcePath);
                 var syntaxTree = CSharpSyntaxTree.ParseText(source);
-                var usings = ((CompilationUnitSyntax)syntaxTree.GetRoot()).Usings
-                    .Select(u => u.Name.ToString());
-
-                var sorted = usings.OrderByDescending(u => u.StartsWith("System"))
-                                   .ThenBy(u => u);
+                var usings = ((CompilationUnitSyntax)syntaxTree.GetRoot()).Usings;
+                var sorted = usings.OrderBy(u => u, UsingComparer.Instance);
 
                 if (!usings.SequenceEqual(sorted))
                 {

--- a/tests/OmniSharp.Tests/EndpointMiddlewareFacts.cs
+++ b/tests/OmniSharp.Tests/EndpointMiddlewareFacts.cs
@@ -122,8 +122,6 @@ namespace OmniSharp.Tests
             var context = new DefaultHttpContext();
             context.Request.Path = PathString.FromUriComponent("/gotodefinition");
 
-            var memoryStream = new MemoryStream();
-
             context.Request.Body = new MemoryStream(
                 Encoding.UTF8.GetBytes(
                     JsonConvert.SerializeObject(new GotoDefinitionRequest
@@ -151,8 +149,6 @@ namespace OmniSharp.Tests
 
             var context = new DefaultHttpContext();
             context.Request.Path = PathString.FromUriComponent("/gotodefinition");
-
-            var memoryStream = new MemoryStream();
 
             context.Request.Body = new MemoryStream(
                 Encoding.UTF8.GetBytes(
@@ -182,8 +178,6 @@ namespace OmniSharp.Tests
             var context = new DefaultHttpContext();
             context.Request.Path = PathString.FromUriComponent("/findsymbols");
 
-            var memoryStream = new MemoryStream();
-
             context.Request.Body = new MemoryStream(
                 Encoding.UTF8.GetBytes(
                     JsonConvert.SerializeObject(new FindSymbolsRequest
@@ -208,8 +202,6 @@ namespace OmniSharp.Tests
 
             var context = new DefaultHttpContext();
             context.Request.Path = PathString.FromUriComponent("/findsymbols");
-
-            var memoryStream = new MemoryStream();
 
             context.Request.Body = new MemoryStream(
                 Encoding.UTF8.GetBytes(
@@ -244,8 +236,6 @@ namespace OmniSharp.Tests
 
             var context = new DefaultHttpContext();
             context.Request.Path = PathString.FromUriComponent("/throw");
-
-            var memoryStream = new MemoryStream();
 
             context.Request.Body = new MemoryStream(
                 Encoding.UTF8.GetBytes(

--- a/tests/OmniSharp.Tests/EndpointMiddlewareFacts.cs
+++ b/tests/OmniSharp.Tests/EndpointMiddlewareFacts.cs
@@ -15,6 +15,7 @@ using OmniSharp.Middleware;
 using OmniSharp.Models;
 using OmniSharp.Models.v1;
 using OmniSharp.Services;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Tests

--- a/tests/OmniSharp.Tests/LinePositionSpanTextChangeFacts.cs
+++ b/tests/OmniSharp.Tests/LinePositionSpanTextChangeFacts.cs
@@ -9,7 +9,7 @@ namespace OmniSharp.Tests
 {
     public class LinePositionSpanTextChangeFacts
     {
-        [Fact]
+        [Fact(Skip="Need to fix")]
         public async Task ExtendsTextChangeAtStart()
         {
             var workspace = await TestHelpers.CreateSimpleWorkspace("class {\r\n }");
@@ -26,7 +26,7 @@ namespace OmniSharp.Tests
             Assert.Equal(3, lineChanges.ElementAt(0).EndColumn);
         }
 
-        [Fact]
+        [Fact(Skip="Need to fix")]
         public async Task ExtendsTextChangeAtEnd()
         {
             var workspace = await TestHelpers.CreateSimpleWorkspace("class {\n}");

--- a/tests/OmniSharp.Tests/LinePositionSpanTextChangeFacts.cs
+++ b/tests/OmniSharp.Tests/LinePositionSpanTextChangeFacts.cs
@@ -9,38 +9,38 @@ namespace OmniSharp.Tests
 {
     public class LinePositionSpanTextChangeFacts
     {
-        [Fact(Skip="Need to fix")]
+        [Fact]
         public async Task ExtendsTextChangeAtStart()
         {
             var workspace = await TestHelpers.CreateSimpleWorkspace("class {\r\n }");
             var document = workspace.GetDocument("dummy.cs");
 
-            var lineChanges = await LinePositionSpanTextChange.Convert(document, new TextChange[] {
-                new TextChange(TextSpan.FromBounds(8, 11), "\n}")
-            });
+            var textChange = new TextChange(TextSpan.FromBounds(8, 11), "\n}");
+            var adjustedTextChanges = await LinePositionSpanTextChange.Convert(document, new[] { textChange });
 
-            Assert.Equal("\r\n}", lineChanges.ElementAt(0).NewText);
-            Assert.Equal(1, lineChanges.ElementAt(0).StartLine);
-            Assert.Equal(8, lineChanges.ElementAt(0).StartColumn);
-            Assert.Equal(2, lineChanges.ElementAt(0).EndLine);
-            Assert.Equal(3, lineChanges.ElementAt(0).EndColumn);
+            var adjustedTextChange = adjustedTextChanges.First();
+            Assert.Equal("\r\n}", adjustedTextChange.NewText);
+            Assert.Equal(0, adjustedTextChange.StartLine);
+            Assert.Equal(7, adjustedTextChange.StartColumn);
+            Assert.Equal(1, adjustedTextChange.EndLine);
+            Assert.Equal(2, adjustedTextChange.EndColumn);
         }
 
-        [Fact(Skip="Need to fix")]
+        [Fact]
         public async Task ExtendsTextChangeAtEnd()
         {
             var workspace = await TestHelpers.CreateSimpleWorkspace("class {\n}");
             var document = workspace.GetDocument("dummy.cs");
 
-            var lineChanges = await LinePositionSpanTextChange.Convert(document, new TextChange[] {
-                new TextChange(TextSpan.FromBounds(5, 7), "\r\n {\r")
-            });
+            var textChange = new TextChange(TextSpan.FromBounds(5, 7), "\r\n {\r");
+            var adjustedTextChanges = await LinePositionSpanTextChange.Convert(document, new[] { textChange });
 
-            Assert.Equal("\r\n {\r\n", lineChanges.ElementAt(0).NewText);
-            Assert.Equal(1, lineChanges.ElementAt(0).StartLine);
-            Assert.Equal(6, lineChanges.ElementAt(0).StartColumn);
-            Assert.Equal(2, lineChanges.ElementAt(0).EndLine);
-            Assert.Equal(1, lineChanges.ElementAt(0).EndColumn);
+            var adjustedTextChange = adjustedTextChanges.First();
+            Assert.Equal("\r\n {\r\n", adjustedTextChange.NewText);
+            Assert.Equal(0, adjustedTextChange.StartLine);
+            Assert.Equal(5, adjustedTextChange.StartColumn);
+            Assert.Equal(1, adjustedTextChange.EndLine);
+            Assert.Equal(0, adjustedTextChange.EndColumn);
         }
     }
 }

--- a/tests/OmniSharp.Tests/LinePositionSpanTextChangeFacts.cs
+++ b/tests/OmniSharp.Tests/LinePositionSpanTextChangeFacts.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Models;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Tests

--- a/tests/OmniSharp.Tests/OmniSharp.Tests.xproj
+++ b/tests/OmniSharp.Tests/OmniSharp.Tests.xproj
@@ -10,21 +10,12 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AssemblyName>OmniSharp.Tests</AssemblyName>
-  </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
-    <DevelopmentServerPort>3319</DevelopmentServerPort>
   </PropertyGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ProjectExtensions>
-    <VisualStudio>
-      <UserProperties project_1json__JSONSchema="http://www.asp.net/media/4878834/project.json" />
-    </VisualStudio>
-  </ProjectExtensions>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" />
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" />
 </Project>

--- a/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
+++ b/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
@@ -13,32 +12,29 @@ namespace OmniSharp.Tests
         [Fact]
         public async Task UpdateBuffer_HandlesVoidRequest()
         {
-            var workspace = await TestHelpers.CreateSimpleWorkspace(new Dictionary<string, string>
-            {
-                { "test.cs", "class C {}" }
-            });
+            var workspace = await TestHelpers.CreateSimpleWorkspace("class C {}", "test.cs");
 
             var docId = workspace.CurrentSolution.GetDocumentIdsWithFilePath("test.cs").First();
 
             // ignore void buffers
-            await workspace.BufferManager.UpdateBuffer(new OmniSharp.Models.Request() { });
+            await workspace.BufferManager.UpdateBuffer(new Models.Request() { });
             var sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
             Assert.Equal("class C {}", sourceText.ToString());
 
-            await workspace.BufferManager.UpdateBuffer(new OmniSharp.Models.Request() { FileName = "test.cs" });
+            await workspace.BufferManager.UpdateBuffer(new Models.Request() { FileName = "test.cs" });
             sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
             Assert.Equal("class C {}", sourceText.ToString());
 
-            await workspace.BufferManager.UpdateBuffer(new OmniSharp.Models.Request() { Buffer = "// c", FileName = "some_other_file.cs" });
+            await workspace.BufferManager.UpdateBuffer(new Models.Request() { Buffer = "// c", FileName = "some_other_file.cs" });
             sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
             Assert.Equal("class C {}", sourceText.ToString());
 
             // valid updates
-            await workspace.BufferManager.UpdateBuffer(new OmniSharp.Models.Request() { FileName = "test.cs", Buffer = "interface I {}" });
+            await workspace.BufferManager.UpdateBuffer(new Models.Request() { FileName = "test.cs", Buffer = "interface I {}" });
             sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
             Assert.Equal("interface I {}", sourceText.ToString());
 
-            await workspace.BufferManager.UpdateBuffer(new OmniSharp.Models.Request() { FileName = "test.cs", Buffer = "" });
+            await workspace.BufferManager.UpdateBuffer(new Models.Request() { FileName = "test.cs", Buffer = "" });
             sourceText = await workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
             Assert.Equal("", sourceText.ToString());
         }
@@ -46,12 +42,9 @@ namespace OmniSharp.Tests
         [Fact]
         public async Task UpdateBuffer_AddsNewDocumentsIfNeeded()
         {
-            var workspace = await TestHelpers.CreateSimpleWorkspace(new Dictionary<string, string>
-            {
-                { "test.cs", "class C {}" }
-            });
+            var workspace = await TestHelpers.CreateSimpleWorkspace("class C {}", "test.cs");
 
-            await workspace.BufferManager.UpdateBuffer(new OmniSharp.Models.Request() { FileName = "test2.cs", Buffer = "interface I {}" });
+            await workspace.BufferManager.UpdateBuffer(new Models.Request() { FileName = "test2.cs", Buffer = "interface I {}" });
 
             Assert.Equal(2, workspace.CurrentSolution.GetDocumentIdsWithFilePath("test2.cs").Length);
             var docId = workspace.CurrentSolution.GetDocumentIdsWithFilePath("test2.cs").FirstOrDefault();
@@ -68,12 +61,9 @@ namespace OmniSharp.Tests
         [Fact]
         public async Task UpdateBuffer_TransientDocumentsDisappearWhenProjectAddsThem()
         {
-            var workspace = await TestHelpers.CreateSimpleWorkspace(new Dictionary<string, string>
-            {
-                { "test.cs", "class C {}" }
-            });
+            var workspace = await TestHelpers.CreateSimpleWorkspace("class C {}", "test.cs");
 
-            await workspace.BufferManager.UpdateBuffer(new OmniSharp.Models.Request() { FileName = "transient.cs", Buffer = "interface I {}" });
+            await workspace.BufferManager.UpdateBuffer(new Models.Request() { FileName = "transient.cs", Buffer = "interface I {}" });
 
             var docIds = workspace.CurrentSolution.GetDocumentIdsWithFilePath("transient.cs");
             Assert.Equal(2, docIds.Length);
@@ -88,7 +78,7 @@ namespace OmniSharp.Tests
             docIds = workspace.CurrentSolution.GetDocumentIdsWithFilePath("transient.cs");
             Assert.Equal(2, docIds.Length);
 
-            await workspace.BufferManager.UpdateBuffer(new OmniSharp.Models.Request() { FileName = "transient.cs", Buffer = "enum E {}" });
+            await workspace.BufferManager.UpdateBuffer(new Models.Request() { FileName = "transient.cs", Buffer = "enum E {}" });
             var sourceText = await workspace.CurrentSolution.GetDocument(docIds.First()).GetTextAsync();
             Assert.Equal("enum E {}", sourceText.ToString());
             sourceText = await workspace.CurrentSolution.GetDocument(docIds.Last()).GetTextAsync();

--- a/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
+++ b/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Tests

--- a/tests/OmniSharp.Tests/UsingComparer.cs
+++ b/tests/OmniSharp.Tests/UsingComparer.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace OmniSharp.Tests
+{
+    internal class UsingComparer : IComparer<UsingDirectiveSyntax>
+    {
+        public static UsingComparer Instance { get; } = new UsingComparer();
+
+        public int Compare(UsingDirectiveSyntax using1, UsingDirectiveSyntax using2)
+        {
+            if (using1 == using2)
+            {
+                return 0;
+            }
+
+            var usingNamespace1 = using1 != null && using1.Alias == null && !using1.StaticKeyword.IsKind(SyntaxKind.StaticKeyword);
+            var usingNamespace2 = using2 != null && using2.Alias == null && !using2.StaticKeyword.IsKind(SyntaxKind.StaticKeyword);
+
+            var usingStatic1 = using1 != null && using1.StaticKeyword.IsKind(SyntaxKind.StaticKeyword);
+            var usingStatic2 = using2 != null && using2.StaticKeyword.IsKind(SyntaxKind.StaticKeyword);
+
+            var usingAlias1 = using1 != null && using1.Alias != null;
+            var usingAlias2 = using2 != null && using2.Alias != null;
+
+            if (usingNamespace1 && !usingNamespace2)
+            {
+                return -1;
+            }
+            else if (usingNamespace2 && !usingNamespace1)
+            {
+                return 1;
+            }
+            else if (usingStatic1 && !usingStatic2)
+            {
+                return -1;
+            }
+            else if (usingStatic2 && !usingStatic1)
+            {
+                return 1;
+            }
+            else if (usingAlias1 && !usingAlias2)
+            {
+                return -1;
+            }
+            else if (usingAlias2 && !usingAlias1)
+            {
+                return -1;
+            }
+
+            if (usingAlias1)
+            {
+                var aliasComparisonResult = StringComparer.CurrentCulture.Compare(using1.Alias.ToString(), using2.Alias.ToString());
+
+                if (aliasComparisonResult != 0)
+                {
+                    return aliasComparisonResult;
+                }
+            }
+
+            return CompareNames(using1.Name, using2.Name);
+        }
+
+        private static int CompareNames(NameSyntax name1, NameSyntax name2)
+        {
+            var nameText1 = name1.ToString();
+            var nameText2 = name2.ToString();
+
+            var systemNameText1 = nameText1.StartsWith("System");
+            var systemNameText2 = nameText2.StartsWith("System");
+
+            if (systemNameText1 && !systemNameText2)
+            {
+                return -1;
+            }
+            else if (systemNameText2 && !systemNameText1)
+            {
+                return 1;
+            }
+
+            return StringComparer.CurrentCulture.Compare(nameText1, nameText2);
+        }
+    }
+}

--- a/tests/OmniSharp.Tests/project.json
+++ b/tests/OmniSharp.Tests/project.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "OmniSharp.Host": "1.0.0",
     "OmniSharp.Roslyn.CSharp": "1.0.0",
+    "TestCommon": "1.0.0",
     "TestUtility": "1.0.0",
     "xunit": "2.1.0"
   },

--- a/tests/OmniSharp.Tests/project.json
+++ b/tests/OmniSharp.Tests/project.json
@@ -4,18 +4,15 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "TestUtility": "1.0.0",
     "OmniSharp.Host": "1.0.0",
     "OmniSharp.Roslyn.CSharp": "1.0.0",
-    "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta3",
-    "Microsoft.DotNet.InternalAbstractions": "1.0.0",
+    "TestUtility": "1.0.0",
     "xunit": "2.1.0"
   },
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
+        "dotnet5.4",
         "portable-net45+win8"
       ],
       "dependencies": {
@@ -23,8 +20,6 @@
           "version": "1.0.0",
           "type": "platform"
         },
-        "System.Runtime.Serialization.Primitives": "4.1.1",
-        "System.IO.Compression": "4.1.0",
         "dotnet-test-xunit": "2.2.0-preview2-build1029"
       }
     },

--- a/tests/TestCommon/project.json
+++ b/tests/TestCommon/project.json
@@ -1,7 +1,10 @@
 {
   "version": "1.0.0-*",
+  "buildOptions": {
+    "warningsAsErrors": true
+  },
   "dependencies": {
-  	"NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.0"
   },
   "frameworks": {
     "netstandard1.6": {},

--- a/tests/TestUtility/Fake/FakeOmniSharpEnvironment.cs
+++ b/tests/TestUtility/Fake/FakeOmniSharpEnvironment.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
 using OmniSharp.Services;
 
-namespace OmniSharp.Tests
+namespace TestUtility.Fake
 {
     public class FakeEnvironment : IOmnisharpEnvironment
     {

--- a/tests/TestUtility/Fake/FakeOmniSharpOptions.cs
+++ b/tests/TestUtility/Fake/FakeOmniSharpOptions.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Options;
 using OmniSharp.Options;
 
-namespace OmniSharp.Tests
+namespace TestUtility.Fake
 {
     public class FakeOmniSharpOptions : IOptions<OmniSharpOptions>
     {

--- a/tests/TestUtility/Fake/FakeServiceProvider.cs
+++ b/tests/TestUtility/Fake/FakeServiceProvider.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 using OmniSharp.Services;
 using TestUtility.Annotate;
 
-namespace OmniSharp.Tests
+namespace TestUtility.Fake
 {
     internal class TestServiceProvider : IServiceProvider
     {

--- a/tests/TestUtility/TestAssistant.cs
+++ b/tests/TestUtility/TestAssistant.cs
@@ -7,9 +7,11 @@ using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
+using OmniSharp;
 using OmniSharp.Roslyn.CSharp.Services.Diagnostics;
+using TestUtility.Fake;
 
-namespace OmniSharp.Tests
+namespace TestUtility
 {
     public class TestAssistant
     {

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -8,12 +8,13 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Text;
+using OmniSharp;
 using OmniSharp.Models;
 using OmniSharp.Roslyn.CSharp.Services.Diagnostics;
 using OmniSharp.Services;
 using TestUtility.Fake;
 
-namespace OmniSharp.Tests
+namespace TestUtility
 {
     public static class TestHelpers
     {

--- a/tests/TestUtility/project.json
+++ b/tests/TestUtility/project.json
@@ -13,16 +13,13 @@
   "frameworks": {
     "netstandard1.6": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
+        "dotnet5.4",
         "portable-net45+win8"
       ],
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       }
     },
-    "net451": {
-      "dependencies": {}
-    }
+    "net451": {}
   }
 }


### PR DESCRIPTION
This PR addresses several problems:

1. Factors test helper code out of OmniSharp.Tests and into TestUtility
2. Adds OmniSharp.Tests to build.json so that it runs on builds
3. Fixes the "coding guidelines" tests
4. Cleans up all project.json files
5. Tweaks to only ask for code fixes when the provider supports one of the diagnostics under the caret. (Note: except for a special hacky case with Remove Unnecessary Usings.) This should improve the performance of the GetCodeActions end point.

cc @david-driscoll 