### PR TITLE
Move OmniSharp to net46

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   global:
     secure: m2PtYwYOhaK0uFMZ19ZxApZwWZeAIq1dS//jx/5I3txpIWD+TfycQMAWYxycFJ/GJkeVF29P4Zz1uyS2XKKjPJpp2Pds98FNQyDv3OftpLAVa0drsjfhurVlBmSdrV7GH6ncKfvhd+h7KVK5vbZc+NeR4dH7eNvN/jraS//AMJg=
 mono:
-  - 4.2.3
+  - 4.6.0
 os:
   - linux
   - osx

--- a/build.json
+++ b/build.json
@@ -15,7 +15,7 @@
     ],
     "OmniSharp.Stdio.Tests": [
       "netcoreapp1.0",
-      "net451"
+      "net46"
     ],
     "OmniSharp.DotNet.Tests": [
       "netcoreapp1.0"
@@ -28,7 +28,7 @@
     ]
   },
   "Frameworks": [
-    "net451",
+    "net46",
     "netcoreapp1.0"
   ],
   "MainProject": "OmniSharp"

--- a/scripts/archiving.cake
+++ b/scripts/archiving.cake
@@ -38,18 +38,18 @@ string GetBuildIdentifier(string runtime, string framework)
 
     // Rename/restrict some archive names on CI
     var travisOSName = Environment.GetEnvironmentVariable("TRAVIS_OS_NAME");
-    // Travis/Linux + default + net451 is renamed to Mono
-    if (string.Equals(travisOSName, "linux") && runtime.Equals("default") && framework.Equals("net451"))
+    // Travis/Linux + default + net46 is renamed to Mono
+    if (string.Equals(travisOSName, "linux") && runtime.Equals("default") && framework.Equals("net46"))
     {
         return "mono";
     }
-    // No need to archive other Travis + net451 combinations
-    else if (travisOSName != null && framework.Equals("net451"))
+    // No need to archive other Travis + net46 combinations
+    else if (travisOSName != null && framework.Equals("net46"))
     {
         return null;
     }
-    // No need to archive Travis/Linux + default + not(net451) (expect all runtimes to be explicitely named)
-    else if (string.Equals(travisOSName, "linux") && runtime.Equals("default") && !framework.Equals("net451"))
+    // No need to archive Travis/Linux + default + not(net46) (expect all runtimes to be explicitely named)
+    else if (string.Equals(travisOSName, "linux") && runtime.Equals("default") && !framework.Equals("net46"))
     {
         return null;
     }

--- a/scripts/artifacts.cake
+++ b/scripts/artifacts.cake
@@ -20,7 +20,7 @@ void CreateRunScript(string outputRoot, string scriptFolder)
         {
             System.IO.File.Delete(desktopScript);
         }
-        content[2] = String.Format(content[2], "net451");
+        content[2] = String.Format(content[2], "net46");
         System.IO.File.WriteAllLines(desktopScript, content);
         if (System.IO.File.Exists(coreScript))
         {
@@ -43,7 +43,7 @@ void CreateRunScript(string outputRoot, string scriptFolder)
         {
             System.IO.File.Delete(desktopScript);
         }
-        content[2] = String.Format(content[2], "mono", "net451", ".exe");
+        content[2] = String.Format(content[2], "mono", "net46", ".exe");
         System.IO.File.WriteAllLines(desktopScript, content);
         Run("chmod", $"+x \"{desktopScript}\"");
         if (System.IO.File.Exists(coreScript))

--- a/src/OmniSharp.Abstractions/project.json
+++ b/src/OmniSharp.Abstractions/project.json
@@ -16,7 +16,7 @@
     "System.Reflection.Metadata": "1.3.0"
   },
   "frameworks": {
-    "net451": {
+    "net46": {
       "frameworkAssemblies": {
         "System.Runtime": "",
         "System.Threading": "",

--- a/src/OmniSharp.DotNet/project.json
+++ b/src/OmniSharp.DotNet/project.json
@@ -9,7 +9,7 @@
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0"
   },
   "frameworks": {
-    "net451": {
+    "net46": {
       "frameworkAssemblies": {
         "System.IO": "",
         "System.Collections": ""

--- a/src/OmniSharp.DotNetTest/project.json
+++ b/src/OmniSharp.DotNetTest/project.json
@@ -5,7 +5,7 @@
     "Microsoft.Extensions.Testing.Abstractions": "1.0.0-preview2-003121"
   },
   "frameworks": {
-    "net451": {
+    "net46": {
       "frameworkAssemblies": {
         "System.IO": "",
         "System.Collections": ""

--- a/src/OmniSharp.Host/project.json
+++ b/src/OmniSharp.Host/project.json
@@ -24,7 +24,7 @@
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0"
   },
   "frameworks": {
-    "net451": {
+    "net46": {
       "frameworkAssemblies": {
         "System.ComponentModel.Composition": ""
       },

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -101,7 +101,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 return null;
             }
 
-#if NET451
+#if NET46
             if (PlatformHelper.IsMono)
             {
                 return CreateForMono(projectFilePath, solutionDirectory, options, logger, diagnostics);

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo_Mono.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo_Mono.cs
@@ -1,4 +1,4 @@
-﻿#if NET451
+﻿#if NET46
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/OmniSharp.MSBuild/project.json
+++ b/src/OmniSharp.MSBuild/project.json
@@ -9,7 +9,7 @@
     "Microsoft.Extensions.Options": "1.0.0"
   },
   "frameworks": {
-    "net451": {
+    "net46": {
       "frameworkAssemblies": {
         "Microsoft.Build": "",
         "Microsoft.Build.Engine": "",

--- a/src/OmniSharp.Nuget/OmniSharpSourceRepositoryProvider.cs
+++ b/src/OmniSharp.Nuget/OmniSharpSourceRepositoryProvider.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-#if NET451
+#if NET46
 using NuGet.Protocol.Core.Types;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.v2;
@@ -11,7 +11,7 @@ using NuGet.Protocol.Core.v3;
 
 namespace OmniSharp.NuGet
 {
-#if NET451
+#if NET46
     public class OmniSharpSourceRepositoryProvider : ISourceRepositoryProvider
     {
         private static PackageSource[] DefaultPrimarySources = {

--- a/src/OmniSharp.Nuget/Services/PackageSearchService.cs
+++ b/src/OmniSharp.Nuget/Services/PackageSearchService.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Recommendations;
 using Microsoft.CodeAnalysis.Text;
-#if NET451
+#if NET46
 using NuGet.Logging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -20,7 +20,7 @@ using OmniSharp.NuGet;
 
 namespace OmniSharp
 {
-#if NET451
+#if NET46
     [OmniSharpHandler(OmnisharpEndpoints.PackageSearch, "NuGet")]
     public class PackageSearchService : RequestHandler<PackageSearchRequest, PackageSearchResponse>
     {

--- a/src/OmniSharp.Nuget/Services/PackageSourceService.cs
+++ b/src/OmniSharp.Nuget/Services/PackageSourceService.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Recommendations;
 using Microsoft.CodeAnalysis.Text;
-#if NET451
+#if NET46
 using NuGet.Logging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -20,7 +20,7 @@ using OmniSharp.NuGet;
 
 namespace OmniSharp
 {
-#if NET451
+#if NET46
     [OmniSharpHandler(OmnisharpEndpoints.PackageSource, "NuGet")]
     public class PackageSourceService : RequestHandler<PackageSourceRequest, PackageSourceResponse>
     {

--- a/src/OmniSharp.Nuget/Services/PackageVersionService.cs
+++ b/src/OmniSharp.Nuget/Services/PackageVersionService.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Recommendations;
 using Microsoft.CodeAnalysis.Text;
-#if NET451
+#if NET46
 using NuGet.Logging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -20,7 +20,7 @@ using OmniSharp.NuGet;
 
 namespace OmniSharp
 {
-#if NET451
+#if NET46
     [OmniSharpHandler(OmnisharpEndpoints.PackageVersion, "NuGet")]
     public class PackageVersionService : RequestHandler<PackageVersionRequest, PackageVersionResponse>
     {

--- a/src/OmniSharp.Nuget/project.json
+++ b/src/OmniSharp.Nuget/project.json
@@ -8,7 +8,7 @@
     "OmniSharp.Roslyn": "1.0.0"
   },
   "frameworks": {
-    "net451": {
+    "net46": {
       "dependencies": {
         "NuGet.Configuration": "3.5.0-beta2-1484",
         "NuGet.Protocol.Core.v2": "3.3.0",

--- a/src/OmniSharp.Plugins/project.json
+++ b/src/OmniSharp.Plugins/project.json
@@ -8,7 +8,7 @@
     "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {
-    "net451": {
+    "net46": {
       "frameworkAssemblies": {
         "System.Collections.Concurrent": ""
       }

--- a/src/OmniSharp.Roslyn.CSharp/project.json
+++ b/src/OmniSharp.Roslyn.CSharp/project.json
@@ -11,7 +11,7 @@
     "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta3"
   },
   "frameworks": {
-    "net451": {
+    "net46": {
       "dependencies": {},
       "frameworkAssemblies": {
         "System.Runtime": "",

--- a/src/OmniSharp.Roslyn/project.json
+++ b/src/OmniSharp.Roslyn/project.json
@@ -9,7 +9,7 @@
     "Microsoft.CodeAnalysis": "2.0.0-beta3"
   },
   "frameworks": {
-    "net451": {
+    "net46": {
       "frameworkAssemblies": {
         "System.Runtime": "",
         "System.Threading": "",

--- a/src/OmniSharp.ScriptCs/project.json
+++ b/src/OmniSharp.ScriptCs/project.json
@@ -8,7 +8,7 @@
     "OmniSharp.Roslyn.CSharp": "1.0.0"
   },
   "frameworks": {
-    "net451": {
+    "net46": {
       "dependencies": {
         "ScriptCs.Hosting": "0.16.1",
         "Microsoft.Web.Xdt": "2.1.1",

--- a/src/OmniSharp.Stdio/project.json
+++ b/src/OmniSharp.Stdio/project.json
@@ -11,7 +11,7 @@
     "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {
-    "net451": {},
+    "net46": {},
     "netstandard1.6": {
       "imports": [
         "dotnet5.4",

--- a/src/OmniSharp/project.json
+++ b/src/OmniSharp/project.json
@@ -19,7 +19,7 @@
     "OmniSharp.MSBuild": "1.0.0"
   },
   "frameworks": {
-    "net451": {
+    "net46": {
       "dependencies": {
         "OmniSharp.ScriptCs": "1.0.0"
       }

--- a/tests/OmniSharp.MSBuild.Tests/project.json
+++ b/tests/OmniSharp.MSBuild.Tests/project.json
@@ -20,7 +20,7 @@
           "version": "1.0.1",
           "type": "platform"
         },
-        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+        "dotnet-test-xunit": "2.2.0-preview2-build1029"
       }
     }
   },

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/project.json
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/project.json
@@ -23,7 +23,7 @@
         "dotnet-test-xunit": "2.2.0-preview2-build1029"
       }
     },
-    "net451": {
+    "net46": {
       "dependencies": {
         "xunit.runner.console": "2.1.0"
       }

--- a/tests/OmniSharp.Stdio.Tests/project.json
+++ b/tests/OmniSharp.Stdio.Tests/project.json
@@ -21,7 +21,7 @@
         "dotnet-test-xunit": "2.2.0-preview2-build1029"
       }
     },
-    "net451": {
+    "net46": {
       "dependencies": {
         "xunit.runner.console": "2.1.0"
       }

--- a/tests/OmniSharp.Tests/project.json
+++ b/tests/OmniSharp.Tests/project.json
@@ -24,7 +24,7 @@
         "dotnet-test-xunit": "2.2.0-preview2-build1029"
       }
     },
-    "net451": {
+    "net46": {
       "dependencies": {
         "xunit.runner.console": "2.1.0"
       }

--- a/tests/TestCommon/project.json
+++ b/tests/TestCommon/project.json
@@ -8,6 +8,6 @@
   },
   "frameworks": {
     "netstandard1.6": {},
-    "net451": {}
+    "net46": {}
   }
 }

--- a/tests/TestUtility/project.json
+++ b/tests/TestUtility/project.json
@@ -20,6 +20,6 @@
         "NETStandard.Library": "1.6.0"
       }
     },
-    "net451": {}
+    "net46": {}
   }
 }


### PR DESCRIPTION
This is necessary to take advantage of newer MSBuild bits in the near future.