### PR TITLE
Support 32-bit Windows

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -96,9 +96,14 @@ Task("PopulateRuntimes")
     .IsDependentOn("BuildEnvironment")
     .Does(() =>
 {
-    if (IsRunningOnWindows())
+    if (IsRunningOnWindows() && string.Equals(Environment.GetEnvironmentVariable("APPVEYOR"), "True"))
     {
-        buildPlan.Rids = new string[] {"default"};
+        buildPlan.Rids = new string[]
+            {
+                "default", // To allow testing the published artifact
+                "win7-x86",
+                "win7-x64"
+            };
     }
     else if (string.Equals(Environment.GetEnvironmentVariable("TRAVIS_OS_NAME"), "linux"))
     {
@@ -116,6 +121,7 @@ Task("PopulateRuntimes")
     }
     else
     {
+        // In this case, the build is not happening in CI, so just use the default RID.
         buildPlan.Rids = new string[] {"default"};
     }
 });

--- a/src/OmniSharp/project.json
+++ b/src/OmniSharp/project.json
@@ -1,6 +1,7 @@
 {
   "version": "1.0.0-*",
   "buildOptions": {
+    "platform": "anycpu",
     "warningsAsErrors": true,
     "preserveCompilationContext": true,
     "emitEntryPoint": true


### PR DESCRIPTION
Fixes #603

The build scripts may not be right yet, so this is still a work in progress. However, targeting AnyCPU definitely allows OmniSharp.exe to run on 32-bit Windows.