### PR TITLE
Update to Roslyn 2.0.0-beta5

### DIFF
--- a/src/OmniSharp.Abstractions/project.json
+++ b/src/OmniSharp.Abstractions/project.json
@@ -5,15 +5,15 @@
   },
   "dependencies": {
     "Newtonsoft.Json": "9.0.1",
-    "Microsoft.CodeAnalysis": "2.0.0-beta3",
+    "Microsoft.CodeAnalysis.Common": "2.0.0-beta5",
+    "Microsoft.CodeAnalysis.Workspaces.Common": "2.0.0-beta5",
     "Microsoft.Composition": "1.0.30",
     "Microsoft.Extensions.Caching.Memory": "1.0.0",
     "Microsoft.Extensions.Configuration": "1.0.0",
     "Microsoft.Extensions.Configuration.Binder": "1.0.0",
     "Microsoft.Extensions.FileSystemGlobbing": "1.0.0",
     "Microsoft.Extensions.Logging.Console": "1.0.0",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0",
-    "System.Reflection.Metadata": "1.3.0"
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0"
   },
   "frameworks": {
     "net46": {

--- a/src/OmniSharp.DotNet/project.json
+++ b/src/OmniSharp.DotNet/project.json
@@ -3,8 +3,7 @@
   "dependencies": {
     "OmniSharp.Abstractions": "1.0.0",
     "OmniSharp.Roslyn": "1.0.0",
-    "Microsoft.CodeAnalysis": "2.0.0-beta3",
-    "Microsoft.CodeAnalysis.Common": "2.0.0-beta3",
+    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta5",
     "Microsoft.DotNet.ProjectModel": "1.0.0-rc3-003121",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0"
   },

--- a/src/OmniSharp.DotNetTest/project.json
+++ b/src/OmniSharp.DotNetTest/project.json
@@ -2,6 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "OmniSharp.Abstractions": "1.0.0",
+    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta5",
     "Microsoft.Extensions.Testing.Abstractions": "1.0.0-preview2-003121"
   },
   "frameworks": {

--- a/src/OmniSharp.MSBuild/project.json
+++ b/src/OmniSharp.MSBuild/project.json
@@ -27,7 +27,7 @@
         "Microsoft.Build.Targets": "0.1.0-preview-00038-160914",
         "Microsoft.Build.Tasks.Core": "0.1.0-preview-00038-160914",
         "Microsoft.Build.Utilities.Core": "0.1.0-preview-00038-160914",
-        "Microsoft.Net.Compilers": "1.3.0"
+        "Microsoft.Net.Compilers": "2.0.0-beta5"
       }
     }
   }

--- a/src/OmniSharp.Roslyn.CSharp/project.json
+++ b/src/OmniSharp.Roslyn.CSharp/project.json
@@ -6,9 +6,9 @@
   "dependencies": {
     "OmniSharp.Abstractions": "1.0.0",
     "OmniSharp.Roslyn": "1.0.0",
-    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta3",
-    "Microsoft.CodeAnalysis.CSharp.Features": "2.0.0-beta3",
-    "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta3"
+    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta5",
+    "Microsoft.CodeAnalysis.CSharp.Features": "2.0.0-beta5",
+    "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta5"
   },
   "frameworks": {
     "net46": {

--- a/src/OmniSharp.Roslyn/MetadataHelper.cs
+++ b/src/OmniSharp.Roslyn/MetadataHelper.cs
@@ -80,7 +80,7 @@ namespace OmniSharp.Roslyn
 
         public async Task<Location> GetSymbolLocationFromMetadata(ISymbol symbol, Document metadataDocument, CancellationToken cancellationToken = new CancellationToken())
         {
-            var symbolKeyCreateMethod = _symbolKey.Value.GetMethod("Create", BindingFlags.Static | BindingFlags.NonPublic);
+            var symbolKeyCreateMethod = _symbolKey.Value.GetMethod("Create", BindingFlags.Static | BindingFlags.Public);
             var symboldId = symbolKeyCreateMethod.Invoke(null, new object[] { symbol, cancellationToken });
 
             return await (Task<Location>)_getLocationInGeneratedSourceAsync.Value.Invoke(null, new object[] { symboldId, metadataDocument, cancellationToken });

--- a/src/OmniSharp.Roslyn/project.json
+++ b/src/OmniSharp.Roslyn/project.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "OmniSharp.Abstractions": "1.0.0",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0",
-    "Microsoft.CodeAnalysis": "2.0.0-beta3"
+    "Microsoft.CodeAnalysis.Common": "2.0.0-beta5",
+    "Microsoft.CodeAnalysis.Workspaces.Common": "2.0.0-beta5"
   },
   "frameworks": {
     "net46": {

--- a/tests/OmniSharp.DotNet.Tests/project.json
+++ b/tests/OmniSharp.DotNet.Tests/project.json
@@ -19,6 +19,7 @@
           "version": "1.0.1",
           "type": "platform"
         },
+        "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta5",
         "dotnet-test-xunit": "2.2.0-preview2-build1029"
       }
     }

--- a/tests/OmniSharp.Stdio.Tests/project.json
+++ b/tests/OmniSharp.Stdio.Tests/project.json
@@ -18,6 +18,7 @@
           "version": "1.0.1",
           "type": "platform"
         },
+        "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta5",
         "dotnet-test-xunit": "2.2.0-preview2-build1029"
       }
     },

--- a/tests/TestUtility/project.json
+++ b/tests/TestUtility/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "OmniSharp.Host": "1.0.0",
     "OmniSharp.Roslyn.CSharp": "1.0.0",
-    "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta3",
+    "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta5",
     "Microsoft.DotNet.ProjectModel": "1.0.0-rc3-003121",
     "Microsoft.DotNet.ProjectModel.Workspaces": "1.0.0-preview2-003121"
   },


### PR DESCRIPTION
This change updates the Microsoft.CodeAnalysis packages to 2.0.0-beta5, which should match the versions shipped with Visual Studio "15" Preview 5 earlier this month. In addition, we now reference specific packages rather than just "Microsoft.CodeAnalysis", so it no longer pulls in Microsoft.CodeAnalysis.VisualBasic.Workspaces for netcoreapp1.0 builds or Microsoft.CodeAnalysis.VisualBasic for net46 builds.
