### PR TITLE
Allow OmniSharp to default to the latest C# language version

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
@@ -47,10 +47,10 @@ namespace OmniSharp.MSBuild.ProjectFile
             if (string.IsNullOrWhiteSpace(propertyValue) ||
                 propertyValue.Equals("Default", StringComparison.OrdinalIgnoreCase))
             {
-                return LanguageVersion.CSharp6;
+                return LanguageVersion.Default;
             }
 
-            // ISO-1, ISO-2, 3, 4, 5, 6 or Default
+            // ISO-1, ISO-2, 3, 4, 5, 6, 7 or Default
             switch (propertyValue.ToLower())
             {
                 case "iso-1": return LanguageVersion.CSharp1;
@@ -59,7 +59,8 @@ namespace OmniSharp.MSBuild.ProjectFile
                 case "4": return LanguageVersion.CSharp4;
                 case "5": return LanguageVersion.CSharp5;
                 case "6": return LanguageVersion.CSharp6;
-                default: return LanguageVersion.CSharp6;
+                case "7": return LanguageVersion.CSharp7;
+                default: return LanguageVersion.Default;
             }
         }
 


### PR DESCRIPTION
For MSBuild projects, C# 6 was hard-coded as the "default" language version. Now that OmniSharp is on Roslyn 2.0.0-beta5 it can use the `LanguageVersion.Default`, which defaults to the latest major version of the language. In this case, that'll be C# 7.

See https://github.com/dotnet/roslyn/commit/042823a3170bb2c2ca718cd39cc02762fb6f3770 for details on how `LanguageVersion.Default` works.