### PR TITLE
use SymbolDisplayFormat in TypeLookup

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Types/TypeLookup.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Types/TypeLookup.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Composition;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -16,7 +17,10 @@ namespace OmniSharp.Roslyn.CSharp.Services.Types
     {
         private readonly FormattingOptions _formattingOptions;
         private readonly OmnisharpWorkspace _workspace;
-        private static readonly SymbolDisplayFormat DefaultFormat = SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted);
+        private static readonly SymbolDisplayFormat DefaultFormat = SymbolDisplayFormat.FullyQualifiedFormat.
+            WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted).
+            WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.None).
+            WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers);
 
         [ImportingConstructor]
         public TypeLookupService(OmnisharpWorkspace workspace, FormattingOptions formattingOptions)
@@ -37,22 +41,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Types
                 var symbol = await SymbolFinder.FindSymbolAtPositionAsync(semanticModel, position, _workspace);
                 if (symbol != null)
                 {
-                    //non regular C# code semantics (interactive, script) don't allow namespaces
-                    if (symbol.Kind == SymbolKind.NamedType)
-                    {
-                        if (document.SourceCodeKind == SourceCodeKind.Regular && !symbol.ContainingNamespace.IsGlobalNamespace)
-                        {
-                            response.Type = symbol.ToDisplayString(DefaultFormat);
-                        }
-                        else
-                        {
-                            response.Type = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-                        }
-                    }
-                    else
-                    {
-                        response.Type = symbol.ToMinimalDisplayString(semanticModel, position);
-                    }
+                    response.Type = symbol.Kind == SymbolKind.NamedType ? 
+                        symbol.ToDisplayString(DefaultFormat) : 
+                        symbol.ToMinimalDisplayString(semanticModel, position);
                 }
 
                 if (request.IncludeDocumentation)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Types/TypeLookup.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Types/TypeLookup.cs
@@ -15,6 +15,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Types
     {
         private readonly FormattingOptions _formattingOptions;
         private readonly OmnisharpWorkspace _workspace;
+        private static readonly SymbolDisplayFormat Format = SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted);
 
         [ImportingConstructor]
         public TypeLookupService(OmnisharpWorkspace workspace, FormattingOptions formattingOptions)
@@ -38,7 +39,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Types
                     //non regular C# code semantics (interactive, script) don't allow namespaces
                     if(document.SourceCodeKind == SourceCodeKind.Regular && symbol.Kind == SymbolKind.NamedType && !symbol.ContainingNamespace.IsGlobalNamespace)
                     {
-                        response.Type = $"{symbol.ContainingNamespace.ToDisplayString()}.{symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)}";
+                        response.Type = symbol.ToDisplayString(Format);
                     }
                     else
                     {

--- a/src/OmniSharp.Roslyn.CSharp/Services/Types/TypeLookup.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Types/TypeLookup.cs
@@ -15,7 +15,14 @@ namespace OmniSharp.Roslyn.CSharp.Services.Types
     {
         private readonly FormattingOptions _formattingOptions;
         private readonly OmnisharpWorkspace _workspace;
-        private static readonly SymbolDisplayFormat Format = SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted);
+        private static readonly SymbolDisplayFormat DefaultFormat = SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted);
+        private static readonly SymbolDisplayFormat SimpleFormat = new SymbolDisplayFormat(
+                globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,
+                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
+                genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+                miscellaneousOptions:
+                    SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers |
+                    SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
         [ImportingConstructor]
         public TypeLookupService(OmnisharpWorkspace workspace, FormattingOptions formattingOptions)
@@ -39,11 +46,11 @@ namespace OmniSharp.Roslyn.CSharp.Services.Types
                     //non regular C# code semantics (interactive, script) don't allow namespaces
                     if(document.SourceCodeKind == SourceCodeKind.Regular && symbol.Kind == SymbolKind.NamedType && !symbol.ContainingNamespace.IsGlobalNamespace)
                     {
-                        response.Type = symbol.ToDisplayString(Format);
+                        response.Type = symbol.ToDisplayString(DefaultFormat);
                     }
                     else
                     {
-                        response.Type = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                        response.Type = symbol.ToDisplayString(SimpleFormat);
                     }
 
                     if (request.IncludeDocumentation)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Types/TypeLookup.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Types/TypeLookup.cs
@@ -17,7 +17,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Types
         private readonly OmnisharpWorkspace _workspace;
         private static readonly SymbolDisplayFormat DefaultFormat = SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted);
         private static readonly SymbolDisplayFormat SimpleFormat = new SymbolDisplayFormat(
-                globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,
+                globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
                 typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
                 genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
                 miscellaneousOptions:

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/TypeLookupFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/TypeLookupFacts.cs
@@ -56,7 +56,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         }
 
         [Fact]
-        public async Task IncludesContainingTypeFoNestedTypes()
+        public async Task IncludesContainingTypeFoNestedTypesForRegularCSharpSyntax()
         {
             var source1 = @"namespace Bar {
             class Foo {
@@ -70,6 +70,21 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             var response = await controller.Handle(new TypeLookupRequest { FileName = "dummy.cs", Line = 2, Column = 27 });
 
             Assert.Equal("Bar.Foo.Xyz", response.Type);
+        }
+
+        [Fact]
+        public async Task IncludesContainingTypeFoNestedTypesForNonRegularCSharpSyntax()
+        {
+            var source1 = @"class Foo {
+                class Bar {}
+            }";
+
+            var workspace = TestHelpers.CreateCsxWorkspace(source1);
+
+            var controller = new TypeLookupService(workspace, new FormattingOptions());
+            var response = await controller.Handle(new TypeLookupRequest { FileName = "dummy.csx", Line = 1, Column = 23 });
+
+            Assert.Equal("Foo.Bar", response.Type);
         }
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/TypeLookupFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/TypeLookupFacts.cs
@@ -54,5 +54,22 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
             Assert.Equal("Bar.Foo", response.Type);
         }
+
+        [Fact]
+        public async Task IncludesContainingTypeFoNestedTypes()
+        {
+            var source1 = @"namespace Bar {
+            class Foo {
+                    class Xyz {}
+                }   
+            }";
+
+            var workspace = await TestHelpers.CreateSimpleWorkspace(source1);
+
+            var controller = new TypeLookupService(workspace, new FormattingOptions());
+            var response = await controller.Handle(new TypeLookupRequest { FileName = "dummy.cs", Line = 2, Column = 27 });
+
+            Assert.Equal("Bar.Foo.Xyz", response.Type);
+        }
     }
 }


### PR DESCRIPTION
Instead of manually composing type information, use `SymbolDisplayFormat` to format the response according to the predefined rules:

 - default `SymbolDisplayFormat.FullyQualifiedFormat` but without `global::` for regular C# syntax
 - `SymbolDisplayFormat.FullyQualifiedFormat`but without `global::` and without namespace for script/interactive syntax

Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/394 (currently OmniSharp doesn't show type lookup information for nested types correctly)