### PR TITLE
Add app.config to require .NET 4.6 when launching OmniSharp.exe

### DIFF
--- a/src/OmniSharp/app.config
+++ b/src/OmniSharp/app.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+  </startup>
+</configuration>


### PR DESCRIPTION
This will cause a dialog to be displayed when launching OmniSharp.exe to inform the user that they need to install .NET Framework 4.6 to run it.