### PR TITLE
Missing space in <paramref />

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/DocumentationConverter.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/DocumentationConverter.cs
@@ -65,6 +65,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Documentation
                                     break;
                                 case "paramref":
                                     ret.Append(xml["name"]);
+                                    ret.Append(" ");
                                     break;
                                 case "param":
                                     ret.Append(lineEnding);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/DocumentationConverterFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/DocumentationConverterFacts.cs
@@ -44,5 +44,19 @@ This sample shows how to call the TestNamespace.TestClass.GetZero method.
     ";
             Assert.Equal(expected, plainText, ignoreLineEndingDifferences: true);
         }
+
+        [Fact]
+        public void Has_correct_spacing_around_paramref()
+        {
+            var documentation = @"
+<summary>DoWork is a method in the TestClass class.
+The <paramref name=""arg""/> parameter takes a number and <paramref name=""arg2""/> takes a string.
+</summary>";
+            var plainText = DocumentationConverter.ConvertDocumentation(documentation, "\n");
+            var expected =
+@"DoWork is a method in the TestClass class.
+The arg parameter takes a number and arg2 takes a string.";
+            Assert.Equal(expected, plainText, ignoreLineEndingDifferences: true);
+        }
     }
 }


### PR DESCRIPTION
Missing spacing after `<paramref />` (if spaces are used in the text that follows, it is always trimmed).
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/672