### PR TITLE
Don't throw null-ref when Roslyn CompletionService doesn't return anything

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/IntellisenseService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/IntellisenseService.cs
@@ -44,24 +44,27 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
                 // Add keywords from the completion list. We'll use the recommender service to get symbols
                 // to create snippets from.
 
-                foreach (var item in completionList.Items)
+                if (completionList != null)
                 {
-                    if (item.Tags.Contains(CompletionTags.Keyword))
+                    foreach (var item in completionList.Items)
                     {
-                        // Note: For keywords, we'll just assume that the completion text is the same
-                        // as the display text.
-                        var keyword = item.DisplayText;
-                        if (keyword.IsValidCompletionFor(wordToComplete))
+                        if (item.Tags.Contains(CompletionTags.Keyword))
                         {
-                            var response = new AutoCompleteResponse()
+                            // Note: For keywords, we'll just assume that the completion text is the same
+                            // as the display text.
+                            var keyword = item.DisplayText;
+                            if (keyword.IsValidCompletionFor(wordToComplete))
                             {
-                                CompletionText = item.DisplayText,
-                                DisplayText = item.DisplayText,
-                                Snippet = item.DisplayText,
-                                Kind = request.WantKind ? "Keyword" : null
-                            };
+                                var response = new AutoCompleteResponse()
+                                {
+                                    CompletionText = item.DisplayText,
+                                    DisplayText = item.DisplayText,
+                                    Snippet = item.DisplayText,
+                                    Kind = request.WantKind ? "Keyword" : null
+                                };
 
-                            completions.Add(response);
+                                completions.Add(response);
+                            }
                         }
                     }
                 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -182,6 +182,22 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             ContainsCompletions(completions.Select(c => c.CompletionText), "MyClass1", "myvar");
         }
 
+        [Fact]
+        public async Task Returns_empty_sequence_in_invalid_context()
+        {
+            var source =
+                @"public class MyClass1 {
+
+                    public MyClass1()
+                        {
+                            var x$
+                        }
+                    }";
+
+            var completions = await FindCompletionsAsync(source);
+            ContainsCompletions(completions.Select(c => c.CompletionText), Array.Empty<string>());
+        }
+
         private void ContainsCompletions(IEnumerable<string> completions, params string[] expected)
         {
             if (!completions.SequenceEqual(expected))
@@ -217,10 +233,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 request = CreateRequest(source);
             }
 
-            var response = await controller.Handle(request);
-            var completions = response as IEnumerable<AutoCompleteResponse>;
-
-            return completions;
+            return await controller.Handle(request);
         }
 
         private AutoCompleteRequest CreateRequest(string source, string fileName = "dummy.cs", bool wantSnippet = false)


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/980