### PR TITLE
avoid null reference in TypeLookup

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Types/TypeLookup.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Types/TypeLookup.cs
@@ -44,11 +44,11 @@ namespace OmniSharp.Roslyn.CSharp.Services.Types
                     response.Type = symbol.Kind == SymbolKind.NamedType ? 
                         symbol.ToDisplayString(DefaultFormat) : 
                         symbol.ToMinimalDisplayString(semanticModel, position);
-                }
 
-                if (request.IncludeDocumentation)
-                {
-                    response.Documentation = DocumentationConverter.ConvertDocumentation(symbol.GetDocumentationCommentXml(), _formattingOptions.NewLine);
+                    if (request.IncludeDocumentation)
+                    {
+                        response.Documentation = DocumentationConverter.ConvertDocumentation(symbol.GetDocumentationCommentXml(), _formattingOptions.NewLine);
+                    }
                 }
             }
 


### PR DESCRIPTION
At the moment if there is a symbol miss in `TypeLookup` (which can happen if we have missing unresolved references and so on) OmniSharp will always respond with 500 - due a null reference exception in `TypeLookup`.

This fixes the issue.