### PR TITLE
fixed constructor signature helper

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -172,20 +172,12 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
             return score;
         }
 
-        private SignatureHelpItem BuildSignature(IMethodSymbol symbol)
+        private static SignatureHelpItem BuildSignature(IMethodSymbol symbol)
         {
             var signature = new SignatureHelpItem();
             signature.Documentation = symbol.GetDocumentationCommentXml();
-            if (symbol.MethodKind == MethodKind.Constructor)
-            {
-                signature.Name = symbol.ContainingType.Name;
-                signature.Label = symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-            }
-            else
-            {
-                signature.Name = symbol.Name;
-                signature.Label = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-            }
+            signature.Name = symbol.MethodKind == MethodKind.Constructor ? symbol.ContainingType.Name : symbol.Name;
+            signature.Label = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
 
             signature.Parameters = GetParameters(symbol).Select(parameter =>
             {
@@ -196,6 +188,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
                     Documentation = parameter.GetDocumentationCommentXml()
                 };
             });
+
             return signature;
         }
 


### PR DESCRIPTION
There was a bug when dealing with constructors, OmniSharp was returning `symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)` rather than `symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)`. 

This resulted in all entries being identical for each constructor.

fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/697 and fixes https://github.com/OmniSharp/omnisharp-vscode/issues/36