### PR TITLE
allow loglevel to be passed in as an argument 

### DIFF
--- a/src/OmniSharp.Host/Program.cs
+++ b/src/OmniSharp.Host/Program.cs
@@ -48,6 +48,15 @@ namespace OmniSharp
                     enumerator.MoveNext();
                     serverPort = int.Parse((string)enumerator.Current);
                 }
+                else if (arg.ToLowerInvariant() == "-loglevel")
+                {
+                    enumerator.MoveNext();
+                    LogLevel level;
+                    if (Enum.TryParse((string) enumerator.Current, true, out level))
+                    {
+                        logLevel = level;
+                    }
+                }
                 else if (arg == "-v")
                 {
                     logLevel = LogLevel.Debug;

--- a/src/OmniSharp.Host/Program.cs
+++ b/src/OmniSharp.Host/Program.cs
@@ -48,7 +48,7 @@ namespace OmniSharp
                     enumerator.MoveNext();
                     serverPort = int.Parse((string)enumerator.Current);
                 }
-                else if (arg.ToLowerInvariant() == "-loglevel")
+                else if (string.Equals(arg, "-loglevel", StringComparison.OrdinalIgnoreCase))
                 {
                     enumerator.MoveNext();
                     LogLevel level;


### PR DESCRIPTION
This PR introduces a new startup argument `-loglevel {value}`, which allows OmniSharp logging level to be configured from outside.

At the moment there is only a `-v` switch which toggles between `information` and `debug` levels, but there is no way to set up more granular logging levels. For now I have not removed the `-v` switch yet, so as to not break any existing use case.

The PR will allow adding this feature https://github.com/OmniSharp/omnisharp-vscode/issues/993 to the editors.
