### PR TITLE
added global.json to enforce an older .net sdk version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
-    "projects": [
-        "src",
-        "tests"
-    ]
+  "projects": [
+    "src",
+    "tests"
+  ],
+  "sdk": { "version": "1.0.0-preview2-003156" } 
 }


### PR DESCRIPTION
At the moment, looks like a lot of people are already on preview3 or preview4 which causes a failure when loading OmniSharp in VS.