### PR TITLE
use the default ScriptMetadataResolver for scripts

### DIFF
--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.ProjectModel;
@@ -175,7 +176,8 @@ namespace OmniSharp.Script
 
             var compilationOptions = new CSharpCompilationOptions(
                 outputKind: OutputKind.DynamicallyLinkedLibrary,
-                usings: Context.CsxUsings[csxPath]);
+                usings: Context.CsxUsings[csxPath], 
+                metadataReferenceResolver: ScriptMetadataResolver.Default);
 
             // #r references
             var metadataReferencesDeclaredInCsx = new HashSet<MetadataReference>();


### PR DESCRIPTION
Fixes #702.

This allows OmniSharp to support intellisense when GAC reference is used. i.e. instead of:

```
#r "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6\System.Web.dll"
```

we can use:

```
#r "System.Web"
```

This is in line with the default CSI behavior, which supports GAC references.