### PR TITLE
include System.ValueTuple in C# Scripts

### DIFF
--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -64,6 +64,10 @@ namespace OmniSharp.Script
             var inheritedCompileLibraries = DependencyContext.Default.CompileLibraries.Where(x =>
                     x.Name.ToLowerInvariant().StartsWith("microsoft.codeanalysis")).ToList();
 
+            // explicitly include System.ValueTuple
+            inheritedCompileLibraries.AddRange(DependencyContext.Default.CompileLibraries.Where(x =>
+                    x.Name.ToLowerInvariant().StartsWith("system.valuetuple")));
+
             var runtimeContexts = File.Exists(Path.Combine(Env.Path, "project.json")) ? ProjectContext.CreateContextForEachTarget(Env.Path) : null;
 
             // if we have no context, then we also have no dependencies

--- a/src/OmniSharp.Script/project.json
+++ b/src/OmniSharp.Script/project.json
@@ -7,7 +7,8 @@
     "OmniSharp.Abstractions": "1.0.0",
     "OmniSharp.Roslyn.CSharp": "1.0.0",
     "Microsoft.DotNet.ProjectModel": "1.0.0-rc3-003121",
-    "Microsoft.CodeAnalysis.CSharp.Scripting": "2.0.0-rc"
+    "Microsoft.CodeAnalysis.CSharp.Scripting": "2.0.0-rc",
+    "System.ValueTuple": "4.3.0"
   },
   "frameworks": {
     "net46": {


### PR DESCRIPTION
This PR adds `System.ValueTuple` automatically into the compilation references.

This is required because it's already part of "standard scripting" - CSI also automatically adds it https://github.com/dotnet/roslyn/commit/4d6c590f42fc5558aea5ed45f0d1698719533793, allowing users to use tuples straight away without any extra manual set up.

### Before the change

<img width="601" alt="screenshot 2017-01-10 08 43 43" src="https://cloud.githubusercontent.com/assets/1710369/21797835/9e222e22-d711-11e6-9441-fc2ddbb09238.png">

### After the change

<img width="270" alt="screenshot 2017-01-10 08 40 09" src="https://cloud.githubusercontent.com/assets/1710369/21797831/990686c2-d711-11e6-910d-1408dfac73ec.png">
