### PR TITLE
do not implicity use UTF-8 for SourceText

### DIFF
--- a/src/OmniSharp.DotNet/DotNetProjectSystem.cs
+++ b/src/OmniSharp.DotNet/DotNetProjectSystem.cs
@@ -383,13 +383,11 @@ namespace OmniSharp.DotNet
                 // TODO: performance optimize
                 using (var stream = File.OpenRead(file))
                 {
-                    // TODO: other encoding option?
-                    var sourceText = SourceText.From(stream, encoding: Encoding.UTF8);
+                    var sourceText = SourceText.From(stream);
                     var docId = DocumentId.CreateNewId(state.Id);
                     var version = VersionStamp.Create();
 
                     var loader = TextLoader.From(TextAndVersion.Create(sourceText, version));
-
 
                     var doc = DocumentInfo.Create(docId, file, filePath: file, loader: loader);
                     _omnisharpWorkspace.AddDocument(doc);

--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -365,7 +365,7 @@ namespace OmniSharp.MSBuild
                 // If all is OK, add a new document.
                 using (var stream = File.OpenRead(sourceFile))
                 {
-                    var sourceText = SourceText.From(stream, encoding: Encoding.UTF8);
+                    var sourceText = SourceText.From(stream);
                     var documentId = DocumentId.CreateNewId(project.Id);
                     var version = VersionStamp.Create();
                     var loader = TextLoader.From(TextAndVersion.Create(sourceText, version));

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -234,15 +234,12 @@ namespace OmniSharp.Script
         private void AddFile(string filePath, ProjectId projectId)
         {
             using (var stream = File.OpenRead(filePath))
-            using (var reader = new StreamReader(stream))
             {
                 var fileName = Path.GetFileName(filePath);
-                var csxFile = reader.ReadToEnd();
-
                 var documentId = DocumentId.CreateNewId(projectId, fileName);
                 var documentInfo = DocumentInfo.Create(documentId, fileName, null, SourceCodeKind.Script, null, filePath)
                     .WithSourceCodeKind(SourceCodeKind.Script)
-                    .WithTextLoader(TextLoader.From(TextAndVersion.Create(SourceText.From(csxFile), VersionStamp.Create())));
+                    .WithTextLoader(TextLoader.From(TextAndVersion.Create(SourceText.From(stream), VersionStamp.Create())));
                 Workspace.AddDocument(documentInfo);
             }
         }


### PR DESCRIPTION
`SourceText` will attempt to detect encoding from BOM (and fallback to UTF-8 anyway) so we shouldn't impose it on the loaded files.