### PR TITLE
Fix running unit tests defined in nested classes

### DIFF
--- a/src/OmniSharp.Abstractions/Extensions/ISymbolExtensions.cs
+++ b/src/OmniSharp.Abstractions/Extensions/ISymbolExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+namespace OmniSharp.Extensions
+{
+    public static class ISymbolExtensions
+    {
+        private readonly static CachedStringBuilder s_cachedBuilder;
+
+        public static string GetMetadataName(this ISymbol symbol)
+        {
+            if (symbol == null)
+            {
+                throw new ArgumentNullException(nameof(symbol));
+            }
+
+            var symbols = new Stack<ISymbol>();
+
+            while (symbol != null)
+            {
+                if (symbol.Kind == SymbolKind.Assembly ||
+                    symbol.Kind == SymbolKind.NetModule)
+                {
+                    break;
+                }
+
+                if ((symbol as INamespaceSymbol)?.IsGlobalNamespace == true)
+                {
+                    break;
+                }
+
+                symbols.Push(symbol);
+                symbol = symbol.ContainingSymbol;
+            }
+
+            var builder = s_cachedBuilder.Acquire();
+            try
+            {
+                ISymbol current = null, previous = null;
+
+                while (symbols.Count > 0)
+                {
+                    current = symbols.Pop();
+
+                    if (previous != null)
+                    {
+                        if (previous.Kind == SymbolKind.NamedType &&
+                            current.Kind == SymbolKind.NamedType)
+                        {
+                            builder.Append('+');
+                        }
+                        else
+                        {
+                            builder.Append('.');
+                        }
+                    }
+
+                    builder.Append(current.MetadataName);
+
+                    previous = current;
+                }
+
+                return builder.ToString();
+            }
+            finally
+            {
+                s_cachedBuilder.Release(builder);
+            }
+        }
+    }
+}

--- a/src/OmniSharp.DotNetTest/Helpers/TestFeaturesDiscover.cs
+++ b/src/OmniSharp.DotNetTest/Helpers/TestFeaturesDiscover.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using OmniSharp.Abstractions.Services;
+using OmniSharp.Extensions;
 using OmniSharp.Models;
 
 namespace OmniSharp.DotNetTest.Helpers
@@ -25,7 +26,7 @@ namespace OmniSharp.DotNetTest.Helpers
                 bool isTestMethod = false;
                 string featureName = null;
 
-                if(IsTestMethod(method, semanticModel, IsDerivedFromFactAttribute))
+                if (IsTestMethod(method, semanticModel, IsDerivedFromFactAttribute))
                 {
                     isTestMethod = true;
                     featureName = XunitFeatureName;
@@ -38,8 +39,7 @@ namespace OmniSharp.DotNetTest.Helpers
 
                 if (isTestMethod)
                 {
-                    var methodName = semanticModel.GetDeclaredSymbol(node).ToDisplayString();
-                    methodName = methodName.Substring(0, methodName.IndexOf('('));
+                    var methodName = semanticModel.GetDeclaredSymbol(node).GetMetadataName();
 
                     yield return new SyntaxFeature
                     {
@@ -50,8 +50,7 @@ namespace OmniSharp.DotNetTest.Helpers
             }
         }
 
-        private bool IsTestMethod(MethodDeclarationSyntax node,
-                                         SemanticModel sematicModel, Func<ITypeSymbol, bool> predicate)
+        private bool IsTestMethod(MethodDeclarationSyntax node, SemanticModel sematicModel, Func<ITypeSymbol, bool> predicate)
         {
             return node.DescendantNodes()
                        .OfType<AttributeSyntax>()
@@ -71,7 +70,8 @@ namespace OmniSharp.DotNetTest.Helpers
                 }
 
                 symbol = symbol.BaseType;
-            } while (symbol.Name != "Object");
+            }
+            while (symbol.SpecialType != SpecialType.System_Object);
 
             return false;
         }
@@ -90,7 +90,8 @@ namespace OmniSharp.DotNetTest.Helpers
                 }
 
                 symbol = symbol.BaseType;
-            } while (symbol.Name != "Object");
+            }
+            while (symbol.SpecialType != SpecialType.System_Object);
 
             return false;
         }


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/743 and fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1151

The issue here is that the metadata name for nested classes was not correct. OmniSharp would report "A.B.C" for the following code, but it should be "A.B+C".

```C#
namespace A
{
    class B
    {
        class C
        {
        }
    }
}
```