### PR TITLE
Added Microsoft.Extensions.CommandLineUtils

### DIFF
--- a/src/OmniSharp.Abstractions/Services/IOmnisharpEnvironment.cs
+++ b/src/OmniSharp.Abstractions/Services/IOmnisharpEnvironment.cs
@@ -10,5 +10,6 @@ namespace OmniSharp.Services
         string Path { get; }
         string SolutionFilePath { get; }
         TransportType TransportType { get; }
+        string[] OtherArgs { get; }
     }
 }

--- a/src/OmniSharp.Host/Internal/CommandOptionExtensions.cs
+++ b/src/OmniSharp.Host/Internal/CommandOptionExtensions.cs
@@ -3,9 +3,9 @@ using Microsoft.Extensions.CommandLineUtils;
 
 namespace OmniSharp.Host.Internal
 {
-    public static class CommandOptionExtensions
+    internal static class CommandOptionExtensions
     {
-        public static T GetValueOrDefault<T>(this CommandOption opt, T defaultValue)
+        internal static T GetValueOrDefault<T>(this CommandOption opt, T defaultValue)
         {
             if (opt.HasValue())
             {

--- a/src/OmniSharp.Host/Internal/CommandOptionExtensions.cs
+++ b/src/OmniSharp.Host/Internal/CommandOptionExtensions.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel;
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace OmniSharp.Host.Internal
+{
+    public static class CommandOptionExtensions
+    {
+        public static T GetValueOrDefault<T>(this CommandOption opt, T defaultValue)
+        {
+            if (opt.HasValue())
+            {
+                return (T)TypeDescriptor.GetConverter(typeof(T)).ConvertFrom(opt.Value());
+            }
+
+            return defaultValue;
+        }
+    }
+}

--- a/src/OmniSharp.Host/Program.cs
+++ b/src/OmniSharp.Host/Program.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -16,170 +18,157 @@ using OmniSharp.Utilities;
 
 namespace OmniSharp
 {
+    public static class CommandOptionExtensions
+    {
+        public static T GetValueOrDefault<T>(this CommandOption opt, T defaultValue)
+        {
+            if (opt.HasValue())
+            {
+                return (T)TypeDescriptor.GetConverter(typeof(T)).ConvertFrom(opt.Value());
+            }
+
+            return defaultValue;
+        }
+    }
+
     public class Program
     {
         public static OmniSharpEnvironment Environment { get; set; }
 
-        public static void Main(string[] args)
+        public static int Main(string[] args)
+        {
+            try
+            {
+                return Run(args);
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine(e.GetBaseException().Message);
+                return 0xbad;
+            }
+        }
+
+        public static int Run(string[] args)
         {
             Console.WriteLine($"OmniSharp: {string.Join(" ", args)}");
 
-            var applicationRoot = Directory.GetCurrentDirectory();
-            var serverPort = 2000;
-            var logLevel = LogLevel.Information;
-            var hostPID = -1;
-            var transportType = TransportType.Http;
-            var otherArgs = new List<string>();
-            var plugins = new List<string>();
-            var serverInterface = "localhost";
-            Encoding encoding = null;
+            var omnisharpApp = new CommandLineApplication(throwOnUnexpectedArg: false) {AllowArgumentSeparator = true};
+            omnisharpApp.HelpOption("-? | -h | --help");
 
-            var enumerator = args.GetEnumerator();
+            var applicationRootOption = omnisharpApp.Option("-s | --solution", "Solution / project file or directory for OmniSharp to point at.", CommandOptionType.SingleValue);
+            var portOption = omnisharpApp.Option("-p | --port", "OmniSharp port.", CommandOptionType.SingleValue);
+            var logLevelOption = omnisharpApp.Option("-l | --loglevel", "Level of logging.", CommandOptionType.SingleValue);
+            var verboseOption = omnisharpApp.Option("-v | --verbose", "Explicitly set 'Debug' log level.", CommandOptionType.NoValue);
+            var hostPidOption = omnisharpApp.Option("-hpid | --hostPID", "Host process ID.", CommandOptionType.SingleValue);
+            var stdioOption = omnisharpApp.Option("-stdio | --stdio", "Use STDIO over HTTP as OmniSharp commincation protocol.", CommandOptionType.NoValue);
+            var zeroBasedIndicesOption = omnisharpApp.Option("-z | --zero-based-indices", "Use zero based indices in request/responses.", CommandOptionType.NoValue);
+            var serverInterfaceOption = omnisharpApp.Option("-i | --interface", "Server interface address.", CommandOptionType.SingleValue);
+            var encodingOption = omnisharpApp.Option("-e | --encoding", "Input / output encoding for STDIO protocol.", CommandOptionType.SingleValue);
+            var pluginOption = omnisharpApp.Option("-pl | --plugin", "Plugin name(s).", CommandOptionType.MultipleValue);
 
-            while (enumerator.MoveNext())
+            omnisharpApp.OnExecute(() =>
             {
-                var arg = (string)enumerator.Current;
-                if (arg == "-s")
+                var applicationRoot = applicationRootOption.GetValueOrDefault(Directory.GetCurrentDirectory());
+                var serverPort = portOption.GetValueOrDefault(2000);
+                var logLevel = verboseOption.HasValue() ? LogLevel.Debug : logLevelOption.GetValueOrDefault(LogLevel.Information);
+                var hostPid = hostPidOption.GetValueOrDefault(-1);
+                var transportType = stdioOption.HasValue() ? TransportType.Stdio : TransportType.Http;
+                var serverInterface = serverInterfaceOption.GetValueOrDefault("localhost");
+                var encodingString = encodingOption.GetValueOrDefault<string>(null);
+                var plugins = pluginOption.Values;
+                var otherArgs = omnisharpApp.RemainingArguments;
+                Configuration.ZeroBasedIndices = zeroBasedIndicesOption.HasValue();
+
+#if NET46
+                if (PlatformHelper.IsMono)
                 {
-                    enumerator.MoveNext();
-                    applicationRoot = Path.GetFullPath((string)enumerator.Current);
-                }
-                else if (arg == "-p")
-                {
-                    enumerator.MoveNext();
-                    serverPort = int.Parse((string)enumerator.Current);
-                }
-                else if (string.Equals(arg, "--loglevel", StringComparison.OrdinalIgnoreCase))
-                {
-                    enumerator.MoveNext();
-                    LogLevel level;
-                    if (Enum.TryParse((string) enumerator.Current, true, out level))
+                    // Mono uses ThreadPool threads for its async/await implementation.
+                    // Ensure we have an acceptable lower limit on the threadpool size to avoid deadlocks and ThreadPool starvation.
+                    const int MIN_WORKER_THREADS = 8;
+
+                    int currentWorkerThreads, currentCompletionPortThreads;
+                    System.Threading.ThreadPool.GetMinThreads(out currentWorkerThreads, out currentCompletionPortThreads);
+
+                    if (currentWorkerThreads < MIN_WORKER_THREADS)
                     {
-                        logLevel = level;
+                        System.Threading.ThreadPool.SetMinThreads(MIN_WORKER_THREADS, currentCompletionPortThreads);
                     }
                 }
-                else if (arg == "-v")
+#endif
+
+                Environment = new OmniSharpEnvironment(applicationRoot, serverPort, hostPid, logLevel, transportType, otherArgs.ToArray());
+
+                var config = new ConfigurationBuilder()
+                    .AddCommandLine(new[] { "--server.urls", $"http://{serverInterface}:{serverPort}" });
+
+                // If the --encoding switch was specified, we need to set the InputEncoding and OutputEncoding before
+                // constructing the SharedConsoleWriter. Otherwise, it might be created with the wrong encoding since
+                // it wraps around Console.Out, which gets recreated when OutputEncoding is set.
+                if (transportType == TransportType.Stdio && encodingString != null)
                 {
-                    logLevel = LogLevel.Debug;
+                    var encoding = Encoding.GetEncoding(encodingString);
+                    Console.InputEncoding = encoding;
+                    Console.OutputEncoding = encoding;
                 }
-                else if (arg == "--hostPID")
+
+                var writer = new SharedConsoleWriter();
+
+                var builder = new WebHostBuilder()
+                    .UseConfiguration(config.Build())
+                    .UseEnvironment("OmniSharp")
+                    .UseStartup(typeof(Startup))
+                    .ConfigureServices(serviceCollection =>
+                    {
+                        serviceCollection.AddSingleton<IOmniSharpEnvironment>(Environment);
+                        serviceCollection.AddSingleton<ISharedTextWriter>(writer);
+                        serviceCollection.AddSingleton<PluginAssemblies>(new PluginAssemblies(plugins));
+                        serviceCollection.AddSingleton<IAssemblyLoader, AssemblyLoader>();
+                    });
+
+                if (transportType == TransportType.Stdio)
                 {
-                    enumerator.MoveNext();
-                    hostPID = int.Parse((string)enumerator.Current);
-                }
-                else if (arg == "--stdio")
-                {
-                    transportType = TransportType.Stdio;
-                }
-                else if (arg == "--plugin")
-                {
-                    enumerator.MoveNext();
-                    plugins.Add((string)enumerator.Current);
-                }
-                else if (arg == "--zero-based-indices")
-                {
-                    Configuration.ZeroBasedIndices = true;
-                }
-                else if (arg == "--interface")
-                {
-                    enumerator.MoveNext();
-                    serverInterface = (string)enumerator.Current;
-                }
-                else if (arg == "--encoding")
-                {
-                    enumerator.MoveNext();
-                    encoding = Encoding.GetEncoding((string)enumerator.Current);
+                    builder.UseServer(new StdioServer(Console.In, writer));
                 }
                 else
                 {
-                    otherArgs.Add((string)enumerator.Current);
+                    builder.UseKestrel();
                 }
-            }
 
-#if NET46
-            if (PlatformHelper.IsMono)
-            {
-                // Mono uses ThreadPool threads for its async/await implementation.
-                // Ensure we have an acceptable lower limit on the threadpool size to avoid deadlocks and ThreadPool starvation.
-                const int MIN_WORKER_THREADS = 8;
-
-                int currentWorkerThreads, currentCompletionPortThreads;
-                System.Threading.ThreadPool.GetMinThreads(out currentWorkerThreads, out currentCompletionPortThreads);
-
-                if (currentWorkerThreads < MIN_WORKER_THREADS)
+                using (var app = builder.Build())
                 {
-                    System.Threading.ThreadPool.SetMinThreads(MIN_WORKER_THREADS, currentCompletionPortThreads);
-                }
-            }
-#endif
+                    app.Start();
 
-            Environment = new OmniSharpEnvironment(applicationRoot, serverPort, hostPID, logLevel, transportType, otherArgs.ToArray());
+                    var appLifeTime = app.Services.GetRequiredService<IApplicationLifetime>();
 
-            var config = new ConfigurationBuilder()
-                .AddCommandLine(new[] { "--server.urls", $"http://{serverInterface}:{serverPort}" });
-
-            // If the --encoding switch was specified, we need to set the InputEncoding and OutputEncoding before
-            // constructing the SharedConsoleWriter. Otherwise, it might be created with the wrong encoding since
-            // it wraps around Console.Out, which gets recreated when OutputEncoding is set.
-            if (transportType == TransportType.Stdio && encoding != null)
-            {
-                Console.InputEncoding = encoding;
-                Console.OutputEncoding = encoding;
-            }
-
-            var writer = new SharedConsoleWriter();
-
-            var builder = new WebHostBuilder()
-                .UseConfiguration(config.Build())
-                .UseEnvironment("OmniSharp")
-                .UseStartup(typeof(Startup))
-                .ConfigureServices(serviceCollection =>
-                {
-                    serviceCollection.AddSingleton<IOmniSharpEnvironment>(Environment);
-                    serviceCollection.AddSingleton<ISharedTextWriter>(writer);
-                    serviceCollection.AddSingleton<PluginAssemblies>(new PluginAssemblies(plugins));
-                    serviceCollection.AddSingleton<IAssemblyLoader, AssemblyLoader>();
-                });
-
-            if (transportType == TransportType.Stdio)
-            {
-                builder.UseServer(new StdioServer(Console.In, writer));
-            }
-            else
-            {
-                builder.UseKestrel();
-            }
-
-            using (var app = builder.Build())
-            {
-                app.Start();
-
-                var appLifeTime = app.Services.GetRequiredService<IApplicationLifetime>();
-
-                Console.CancelKeyPress += (sender, e) =>
-                {
-                    appLifeTime.StopApplication();
-                    e.Cancel = true;
-                };
-
-                if (hostPID != -1)
-                {
-                    try
+                    Console.CancelKeyPress += (sender, e) =>
                     {
-                        var hostProcess = Process.GetProcessById(hostPID);
-                        hostProcess.EnableRaisingEvents = true;
-                        hostProcess.OnExit(() => appLifeTime.StopApplication());
-                    }
-                    catch
-                    {
-                        // If the process dies before we get here then request shutdown
-                        // immediately
                         appLifeTime.StopApplication();
+                        e.Cancel = true;
+                    };
+
+                    if (hostPid != -1)
+                    {
+                        try
+                        {
+                            var hostProcess = Process.GetProcessById(hostPid);
+                            hostProcess.EnableRaisingEvents = true;
+                            hostProcess.OnExit(() => appLifeTime.StopApplication());
+                        }
+                        catch
+                        {
+                            // If the process dies before we get here then request shutdown
+                            // immediately
+                            appLifeTime.StopApplication();
+                        }
                     }
+
+                    appLifeTime.ApplicationStopping.WaitHandle.WaitOne();
                 }
 
-                appLifeTime.ApplicationStopping.WaitHandle.WaitOne();
-            }
+                return 0;
+            });
+
+            return omnisharpApp.Execute(args);
         }
     }
 }

--- a/src/OmniSharp.Host/Program.cs
+++ b/src/OmniSharp.Host/Program.cs
@@ -46,12 +46,12 @@ namespace OmniSharp
             }
             catch (Exception e)
             {
-                Console.Error.WriteLine(e.GetBaseException().Message);
+                Console.Error.WriteLine(e.ToString());
                 return 0xbad;
             }
         }
 
-        public static int Run(string[] args)
+        private static int Run(string[] args)
         {
             Console.WriteLine($"OmniSharp: {string.Join(" ", args)}");
 
@@ -62,7 +62,7 @@ namespace OmniSharp
             var omnisharpApp = new CommandLineApplication(throwOnUnexpectedArg: false);
             omnisharpApp.HelpOption("-? | -h | --help");
 
-            var applicationRootOption = omnisharpApp.Option("-s | --solution", "Solution, project file or directory for OmniSharp to point at (defaults to current directory).", CommandOptionType.SingleValue);
+            var applicationRootOption = omnisharpApp.Option("-s | --source", "Solution, project file or directory for OmniSharp to point at (defaults to current directory).", CommandOptionType.SingleValue);
             var portOption = omnisharpApp.Option("-p | --port", "OmniSharp port (defaults to 2000).", CommandOptionType.SingleValue);
             var logLevelOption = omnisharpApp.Option("-l | --loglevel", "Level of logging (defaults to 'Information').", CommandOptionType.SingleValue);
             var verboseOption = omnisharpApp.Option("-v | --verbose", "Explicitly set 'Debug' log level.", CommandOptionType.NoValue);

--- a/src/OmniSharp.Host/Program.cs
+++ b/src/OmniSharp.Host/Program.cs
@@ -20,8 +20,6 @@ namespace OmniSharp
 {
     public class Program
     {
-        public static OmniSharpEnvironment Environment { get; set; }
-
         public static int Main(string[] args)
         {
             try
@@ -83,7 +81,7 @@ namespace OmniSharp
                 var otherArgs = omnisharpApp.RemainingArguments;
                 Configuration.ZeroBasedIndices = zeroBasedIndicesOption.HasValue();
 
-                Environment = new OmniSharpEnvironment(applicationRoot, serverPort, hostPid, logLevel, transportType, otherArgs.ToArray());
+                var omniSharpEnvironment = new OmniSharpEnvironment(applicationRoot, serverPort, hostPid, logLevel, transportType, otherArgs.ToArray());
 
                 var config = new ConfigurationBuilder()
                     .AddCommandLine(new[] { "--server.urls", $"http://{serverInterface}:{serverPort}" });
@@ -103,14 +101,14 @@ namespace OmniSharp
                 var builder = new WebHostBuilder()
                     .UseConfiguration(config.Build())
                     .UseEnvironment("OmniSharp")
-                    .UseStartup(typeof(Startup))
                     .ConfigureServices(serviceCollection =>
                     {
-                        serviceCollection.AddSingleton<IOmniSharpEnvironment>(Environment);
+                        serviceCollection.AddSingleton<IOmniSharpEnvironment>(omniSharpEnvironment);
                         serviceCollection.AddSingleton<ISharedTextWriter>(writer);
                         serviceCollection.AddSingleton<PluginAssemblies>(new PluginAssemblies(plugins));
                         serviceCollection.AddSingleton<IAssemblyLoader, AssemblyLoader>();
-                    });
+                    })
+                    .UseStartup(typeof(Startup));
 
                 if (transportType == TransportType.Stdio)
                 {

--- a/src/OmniSharp.Host/Startup.cs
+++ b/src/OmniSharp.Host/Startup.cs
@@ -74,7 +74,7 @@ namespace OmniSharp
             services.Configure<OmniSharpOptions>(Configuration);
         }
 
-        public CompositionHost ConfigureMef(
+        public static CompositionHost ConfigureMef(
             IServiceProvider serviceProvider,
             OmniSharpOptions options,
             IEnumerable<Assembly> assemblies)
@@ -91,6 +91,7 @@ namespace OmniSharp
 
             var memoryCache = serviceProvider.GetService<IMemoryCache>();
             var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
+            var env = serviceProvider.GetService<IOmniSharpEnvironment>();
             var writer = serviceProvider.GetService<ISharedTextWriter>();
             var applicationLifetime = serviceProvider.GetService<IApplicationLifetime>();
             var loader = serviceProvider.GetService<IAssemblyLoader>();
@@ -100,7 +101,7 @@ namespace OmniSharp
                 .WithProvider(MefValueProvider.From<IFileSystemWatcher>(new ManualFileSystemWatcher()))
                 .WithProvider(MefValueProvider.From(memoryCache))
                 .WithProvider(MefValueProvider.From(loggerFactory))
-                .WithProvider(MefValueProvider.From(_omniSharpEnvironment))
+                .WithProvider(MefValueProvider.From(env))
                 .WithProvider(MefValueProvider.From(writer))
                 .WithProvider(MefValueProvider.From(applicationLifetime))
                 .WithProvider(MefValueProvider.From(options))
@@ -108,7 +109,7 @@ namespace OmniSharp
                 .WithProvider(MefValueProvider.From(loader))
                 .WithProvider(MefValueProvider.From(new MetadataHelper(loader))); // other way to do singleton and autowire?
 
-            if (_omniSharpEnvironment.TransportType == TransportType.Stdio)
+            if (env.TransportType == TransportType.Stdio)
             {
                 config = config
                     .WithProvider(MefValueProvider.From<IEventEmitter>(new StdioEventEmitter(writer)));

--- a/src/OmniSharp.Host/project.json
+++ b/src/OmniSharp.Host/project.json
@@ -20,7 +20,8 @@
     "Microsoft.Extensions.FileSystemGlobbing": "1.1.0",
     "Microsoft.Extensions.Logging.Console": "1.1.0",
     "Microsoft.Extensions.Options": "1.1.0",
-    "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.0"
+    "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.0",
+    "Microsoft.Extensions.CommandLineUtils": "1.1.0" 
   },
   "frameworks": {
     "net46": {

--- a/src/OmniSharp/Program.cs
+++ b/src/OmniSharp/Program.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 public class Program
 {
-    public static void Main(string[] args)
+    public static int Main(string[] args)
     {
         var argsList = new List<string>(args);
         if (argsList.Contains("--debug"))
@@ -18,6 +18,6 @@ public class Program
             }
         }
 
-        OmniSharp.Program.Main(argsList.ToArray());
+        return OmniSharp.Program.Main(argsList.ToArray());
     }
 }

--- a/tests/TestUtility/Fake/FakeOmniSharpEnvironment.cs
+++ b/tests/TestUtility/Fake/FakeOmniSharpEnvironment.cs
@@ -12,5 +12,6 @@ namespace TestUtility.Fake
         public string SolutionFilePath { get; }
         public string ConfigurationPath { get; }
         public TransportType TransportType { get; }
+        public string[] OtherArgs { get; }
     }
 }


### PR DESCRIPTION
Removed manual arg parsing in favor of https://www.nuget.org/packages/Microsoft.Extensions.CommandLineUtils/
Fixes #744 

This has a couple of benefits:
 - obviously no need to maintain the arg parsing code anymore
 - automatic help generation
 - better/automatic support for short/long names of options
 - automatic support for no value / single value / multi value options
 - in the future we could easily introduce **commands** that could do interesting things (at the moment we have only **options**) i.e. `omnisharp plugin foo`

<img width="1006" alt="screenshot 2017-02-05 12 57 41" src="https://cloud.githubusercontent.com/assets/1710369/22626031/23e68e8a-eba4-11e6-8110-ea5230193076.png">

Note that we have a feature that supports passing `omnisharp.json` values via command line. This is great but is a bit of mess since "real/fixed" OmniSharp options are mixed up with `omnisharp.json` args which are then integrated into the runtime configuration. Ideally the `omnisharp.json`stuff would come at the end or even better be delimited with `--` as it's a general practice for building CLI tools. I have not done that as part of this part (though it would be very easy) as I didn't want to introduce a big breaking change straight away.

Also clean up some code around DI and changed OmniSharp to have a result code and better error message in case it crashes at startup.