### PR TITLE
use DesktopAssemblyIdentityComparer.Default for scripts

### DIFF
--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -43,7 +43,8 @@ namespace OmniSharp.Script
                 OutputKind.DynamicallyLinkedLibrary,
                 usings: DefaultNamespaces,
                 metadataReferenceResolver: ScriptMetadataResolver.Default, 
-                sourceReferenceResolver: ScriptSourceResolver.Default);
+                sourceReferenceResolver: ScriptSourceResolver.Default, 
+                assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default);
 
         private readonly IMetadataFileReferenceCache _metadataFileReferenceCache;
 


### PR DESCRIPTION
This is a copycat of https://github.com/OmniSharp/omnisharp-roslyn/pull/763

However, since C# script compiler implicitly uses `DesktopAssemblyIdentityComparer.Default` ([ref](https://github.com/dotnet/roslyn/blob/master/src/Scripting/CSharp/CSharpScriptCompiler.cs#L66)) it only makes sense we set up OmniSharp the same way when handling scripts.