### PR TITLE
Fix test discovery in VS 2015 by swapping the TFMs

### DIFF
--- a/tests/OmniSharp.DotNet.Tests/project.json
+++ b/tests/OmniSharp.DotNet.Tests/project.json
@@ -9,11 +9,6 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "net46": {
-      "dependencies": {
-        "xunit.runner.console": "2.1.0"
-      }
-    },
     "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
@@ -26,6 +21,11 @@
         },
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "Microsoft.DotNet.InternalAbstractions": "1.0.500-preview2-1-003177"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "xunit.runner.console": "2.1.0"
       }
     }
   },

--- a/tests/OmniSharp.DotNetTest.Tests/project.json
+++ b/tests/OmniSharp.DotNetTest.Tests/project.json
@@ -9,11 +9,6 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "net46": {
-      "dependencies": {
-        "xunit.runner.console": "2.1.0"
-      }
-    },
     "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
@@ -26,6 +21,11 @@
         },
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "Microsoft.DotNet.InternalAbstractions": "1.0.500-preview2-1-003177"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "xunit.runner.console": "2.1.0"
       }
     }
   },

--- a/tests/OmniSharp.MSBuild.Tests/project.json
+++ b/tests/OmniSharp.MSBuild.Tests/project.json
@@ -9,11 +9,6 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "net46": {
-      "dependencies": {
-        "xunit.runner.console": "2.1.0"
-      }
-    },
     "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
@@ -26,6 +21,11 @@
         },
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "Microsoft.DotNet.InternalAbstractions": "1.0.500-preview2-1-003177"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "xunit.runner.console": "2.1.0"
       }
     }
   },

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/project.json
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/project.json
@@ -9,11 +9,6 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "net46": {
-      "dependencies": {
-        "xunit.runner.console": "2.1.0"
-      }
-    },
     "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
@@ -26,6 +21,11 @@
         },
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "Microsoft.DotNet.InternalAbstractions": "1.0.500-preview2-1-003177"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "xunit.runner.console": "2.1.0"
       }
     }
   },

--- a/tests/OmniSharp.Stdio.Tests/project.json
+++ b/tests/OmniSharp.Stdio.Tests/project.json
@@ -9,11 +9,6 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "net46": {
-      "dependencies": {
-        "xunit.runner.console": "2.1.0"
-      }
-    },
     "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
@@ -26,6 +21,11 @@
         },
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "Microsoft.DotNet.InternalAbstractions": "1.0.500-preview2-1-003177"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "xunit.runner.console": "2.1.0"
       }
     }
   },

--- a/tests/OmniSharp.Tests/project.json
+++ b/tests/OmniSharp.Tests/project.json
@@ -10,11 +10,6 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "net46": {
-      "dependencies": {
-        "xunit.runner.console": "2.1.0"
-      }
-    },
     "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
@@ -27,6 +22,11 @@
         },
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "Microsoft.DotNet.InternalAbstractions": "1.0.500-preview2-1-003177"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "xunit.runner.console": "2.1.0"
       }
     }
   },


### PR DESCRIPTION
@filipw [mentioned](https://github.com/OmniSharp/omnisharp-roslyn/pull/770#issuecomment-279510689) that the TFMs can be swapped in the project.json files to make the VS 2015 Test Window properly discover tests. This change does exactly that.