### PR TITLE
allow unsafe in C# scripts

### DIFF
--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -42,6 +42,7 @@ namespace OmniSharp.Script
         private static readonly CSharpCompilationOptions CompilationOptions = new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 usings: DefaultNamespaces,
+                allowUnsafe: true,
                 metadataReferenceResolver: ScriptMetadataResolver.Default, 
                 sourceReferenceResolver: ScriptSourceResolver.Default, 
                 assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default);


### PR DESCRIPTION
At the moment C# script compiler APIs in Roslyn implicitly always allows unsafe blocks.
OmniSharp should match that because at the moment we break when defining i.e.

```
unsafe void Print(string txt) {
  // do stuff
}
```