### PR TITLE
Script code check improvements

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Diagnostics/CodeCheckService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Diagnostics/CodeCheckService.cs
@@ -33,13 +33,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
                 var semanticModel = await document.GetSemanticModelAsync();
                 IEnumerable<Diagnostic> diagnostics = semanticModel.GetDiagnostics();
 
-                if (document.SourceCodeKind != SourceCodeKind.Regular)
-                {
-                    // CS8099 needs to be surpressed so that we can use #load directives in scripts
-                    // additionally, we need to suppress CS1701: https://github.com/dotnet/roslyn/issues/5501
-                    diagnostics = diagnostics.Where(diagnostic => diagnostic.Id != "CS8099" && diagnostic.Id != "CS1701");
-                }
-
                 foreach (var quickFix in diagnostics.Select(MakeQuickFix))
                 {
                     var existingQuickFix = quickFixes.FirstOrDefault(q => q.Equals(quickFix));

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -47,7 +47,15 @@ namespace OmniSharp.Script
                 allowUnsafe: true,
                 metadataReferenceResolver: ScriptMetadataResolver.Default,
                 sourceReferenceResolver: ScriptSourceResolver.Default,
-                assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default);
+                assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default).
+                WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic>
+                {
+                    // ensure that specific warnings about assembly references are always suppressed
+                    // https://github.com/dotnet/roslyn/issues/5501
+                    { "CS1701", ReportDiagnostic.Suppress },
+                    { "CS1702", ReportDiagnostic.Suppress },
+                    { "CS1705", ReportDiagnostic.Suppress }
+                 });
 
             var topLevelBinderFlagsProperty = typeof(CSharpCompilationOptions).GetProperty("TopLevelBinderFlags", BindingFlags.Instance | BindingFlags.NonPublic);
             var binderFlagsType = typeof(CSharpCompilationOptions).GetTypeInfo().Assembly.GetType("Microsoft.CodeAnalysis.CSharp.BinderFlags");


### PR DESCRIPTION
 - instead of excluding some diagnostics in the `CodeCheckService` (which was a hack), moved the suppression to the compilation options of the `ScriptProjectSystem`
 - we do not need to suppress `CS8099` anymore, because we are setting `SourceFileResolver` on the compilation (beforehand, it was missing, which generated the diagnostic).