### PR TITLE
docs(build): add missing mono-mdk prerequisite for macos (#792)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -11,6 +11,7 @@ In order to build OmniSharp, the [.NET 4.6 targeting pack](http://go.microsoft.c
 ```
 brew update
 brew install mono
+brew install caskroom/cask/mono-mdk
 ```
 
 ## Linux


### PR DESCRIPTION
* add mono-mdk prerequisite to BUILD.md documentation

Closes: #792