### PR TITLE
cache ScriptMetadataResolver results

### DIFF
--- a/src/OmniSharp.Script/CachingScriptMetadataResolver.cs
+++ b/src/OmniSharp.Script/CachingScriptMetadataResolver.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Scripting;
+
+namespace OmniSharp.Script
+{
+    public class CachingScriptMetadataResolver : MetadataReferenceResolver
+    {
+        private static Dictionary<string, ImmutableArray<PortableExecutableReference>> DirectReferenceCache = new Dictionary<string, ImmutableArray<PortableExecutableReference>>();
+        private static Dictionary<string, PortableExecutableReference> MissingReferenceCache = new Dictionary<string, PortableExecutableReference>();
+        private static MetadataReferenceResolver _defaultRuntimeResolver = ScriptMetadataResolver.Default;
+
+        public override bool Equals(object other)
+        {
+            return _defaultRuntimeResolver.Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return _defaultRuntimeResolver.GetHashCode();
+        }
+
+        public override bool ResolveMissingAssemblies => _defaultRuntimeResolver.ResolveMissingAssemblies;
+
+        public override PortableExecutableReference ResolveMissingAssembly(MetadataReference definition, AssemblyIdentity referenceIdentity)
+        {
+            if (MissingReferenceCache.ContainsKey(referenceIdentity.Name))
+            {
+                return MissingReferenceCache[referenceIdentity.Name];
+            }
+
+            var result = _defaultRuntimeResolver.ResolveMissingAssembly(definition, referenceIdentity);
+            if (result != null)
+            {
+                MissingReferenceCache[referenceIdentity.Name] = result;
+            }
+
+            return result;
+        }
+
+        public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties)
+        {
+            var key = $"{reference}-{baseFilePath}";
+            if (DirectReferenceCache.ContainsKey(key))
+            {
+                return DirectReferenceCache[key];
+            }
+
+            var result = _defaultRuntimeResolver.ResolveReference(reference, baseFilePath, properties);
+            if (result.Length > 0)
+            {
+                DirectReferenceCache[key] = result;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -45,7 +45,7 @@ namespace OmniSharp.Script
                 OutputKind.DynamicallyLinkedLibrary,
                 usings: DefaultNamespaces,
                 allowUnsafe: true,
-                metadataReferenceResolver: ScriptMetadataResolver.Default,
+                metadataReferenceResolver: new CachingScriptMetadataResolver(),
                 sourceReferenceResolver: ScriptSourceResolver.Default,
                 assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default);
 


### PR DESCRIPTION
This fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1306

Basically, instead of letting `ScriptMetadataResolver` run entire reference resolution every time the semantic model is needed (which is how it is right now, and can sky rocket into GBs of memory usage, because it happens pretty much on every request into OmniSharp), we cache the results and reuse the same references over and over. This alleviates the memory usage.

When a new `#r` is added by user, it will still cause a jump in RAM but it would be much much smaller than what can be observed now.
