### PR TITLE
Add PhysicalFileProvider.WrapForPolling() extension method to avoid using FileSystemWatcher

### DIFF
--- a/src/OmniSharp.Abstractions/OmniSharp.Abstractions.csproj
+++ b/src/OmniSharp.Abstractions/OmniSharp.Abstractions.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />

--- a/src/OmniSharp.Abstractions/Services/FileWatching/FileSystemWatcherWrapper.cs
+++ b/src/OmniSharp.Abstractions/Services/FileWatching/FileSystemWatcherWrapper.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Services.FileWatching
         public FileSystemWatcherWrapper(IOmniSharpEnvironment env)
         {
             // Environment.SetEnvironmentVariable ("MONO_MANAGED_WATCHER", "1");
-            _watcher = new FileSystemWatcher(env.Path);
+            _watcher = new FileSystemWatcher(env.TargetDirectory);
             _watcher.IncludeSubdirectories = true;
             _watcher.EnableRaisingEvents = true;
             _watcher.Changed += OnChanged;

--- a/src/OmniSharp.Abstractions/Services/IOmniSharpEnvironment.cs
+++ b/src/OmniSharp.Abstractions/Services/IOmniSharpEnvironment.cs
@@ -4,13 +4,13 @@ namespace OmniSharp.Services
 {
     public interface IOmniSharpEnvironment
     {
-        LogLevel TraceType { get; }
+        LogLevel LogLevel { get; }
         int Port { get; }
-        int HostPID { get; }
-        string Path { get; }
+        int HostProcessId { get; }
+        string TargetDirectory { get; }
         string SolutionFilePath { get; }
-        string SharedDirectoryPath { get; }
+        string SharedDirectory { get; }
         TransportType TransportType { get; }
-        string[] OtherArgs { get; }
+        string[] AdditionalArguments { get; }
     }
 }

--- a/src/OmniSharp.Abstractions/Utilities/PhysicalFileProviderExtensions.DisposableChangeCallback.cs
+++ b/src/OmniSharp.Abstractions/Utilities/PhysicalFileProviderExtensions.DisposableChangeCallback.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace OmniSharp.Utilities
+{
+    public static partial class PhysicalFileProviderExtensions
+    {
+        private partial class PollingFileChangeToken
+        {
+            private class DisposableChangeCallback : IDisposable
+            {
+                private PollingFileChangeToken _changeToken;
+                private int _callbackId;
+
+                public DisposableChangeCallback(PollingFileChangeToken pollingFileChangeToken, int callbackId)
+                {
+                    _changeToken = pollingFileChangeToken;
+                    _callbackId = callbackId;
+                }
+
+                public void Dispose()
+                {
+                    _changeToken.UnregisterChangeCallback(_callbackId);
+                }
+            }
+        }
+    }
+}

--- a/src/OmniSharp.Abstractions/Utilities/PhysicalFileProviderExtensions.PhysicalFileProviderWrapper.cs
+++ b/src/OmniSharp.Abstractions/Utilities/PhysicalFileProviderExtensions.PhysicalFileProviderWrapper.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+
+namespace OmniSharp.Utilities
+{
+    public static partial class PhysicalFileProviderExtensions
+    {
+        private class PhysicalFileProviderWrapper : DisposableObject, IFileProvider
+        {
+            private readonly string _root;
+            private readonly PhysicalFileProvider _innerFileProvider;
+
+            private Dictionary<string, PollingFileChangeToken> _changeTokens;
+            private readonly object _gate = new object();
+
+            public PhysicalFileProviderWrapper(PhysicalFileProvider fileProvider)
+            {
+                _root = fileProvider.Root;
+                _innerFileProvider = fileProvider;
+            }
+
+            protected override void DisposeCore(bool disposing)
+            {
+                foreach (var kvp in _changeTokens)
+                {
+                    kvp.Value.Dispose();
+                }
+
+                _changeTokens.Clear();
+                _changeTokens = null;
+
+                _innerFileProvider.Dispose();
+            }
+
+            public IDirectoryContents GetDirectoryContents(string subpath)
+            {
+                return _innerFileProvider.GetDirectoryContents(subpath);
+            }
+
+            public IFileInfo GetFileInfo(string subpath)
+            {
+                return _innerFileProvider.GetFileInfo(subpath);
+            }
+
+            public IChangeToken Watch(string filter)
+            {
+                if (filter.IndexOf('*') >= 0)
+                {
+                    throw new ArgumentException($"Wildcards are not allowed", nameof(filter));
+                }
+
+                var filePath = Path.Combine(_root, filter);
+
+                lock (_gate)
+                {
+                    if (_changeTokens == null)
+                    {
+                        _changeTokens = new Dictionary<string, PollingFileChangeToken>(StringComparer.OrdinalIgnoreCase);
+                    }
+
+                    if (!_changeTokens.TryGetValue(filePath, out var changeToken))
+                    {
+                        changeToken = new PollingFileChangeToken(filePath);
+                        _changeTokens.Add(filePath, changeToken);
+                    }
+
+                    return changeToken;
+                }
+            }
+        }
+    }
+}

--- a/src/OmniSharp.Abstractions/Utilities/PhysicalFileProviderExtensions.PollingFileChangeToken.cs
+++ b/src/OmniSharp.Abstractions/Utilities/PhysicalFileProviderExtensions.PollingFileChangeToken.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Primitives;
+
+namespace OmniSharp.Utilities
+{
+    public static partial class PhysicalFileProviderExtensions
+    {
+        private partial class PollingFileChangeToken : DisposableObject, IChangeToken
+        {
+            private readonly static TimeSpan s_pollingInterval = TimeSpan.FromSeconds(2);
+
+            private bool _polling;
+
+            private readonly string _filePath;
+            private bool _hasChanged;
+            private DateTime _previousLastWriteTimeUtc;
+
+            private readonly object _gate = new object();
+            private int _nextCallbackId = 1;
+            private Dictionary<int, Action<object>> _callbacks;
+
+            public PollingFileChangeToken(string filePath)
+            {
+                _filePath = filePath;
+                _previousLastWriteTimeUtc = GetLastWriteTimeUtc();
+            }
+
+            protected override void DisposeCore(bool disposing)
+            {
+                if (disposing)
+                {
+                    lock (_gate)
+                    {
+                        _polling = false;
+                        _callbacks.Clear();
+                        _callbacks = null;
+                    }
+                }
+            }
+
+            private DateTime GetLastWriteTimeUtc() =>
+                File.Exists(_filePath)
+                    ? File.GetLastWriteTimeUtc(_filePath)
+                    : DateTime.MinValue;
+
+            private void StartPolling()
+            {
+                if (_polling)
+                {
+                    return;
+                }
+
+                _polling = true;
+
+                Task.Run(async () =>
+                {
+                    while (_polling)
+                    {
+                        await Task.Delay(s_pollingInterval);
+
+                        lock (_gate)
+                        {
+                            var lastWriteTimeUtc = GetLastWriteTimeUtc();
+                            if (_previousLastWriteTimeUtc != lastWriteTimeUtc)
+                            {
+                                _previousLastWriteTimeUtc = lastWriteTimeUtc;
+                                _hasChanged = true;
+
+                            // Notify callbacks.
+                            if (_callbacks != null)
+                                {
+                                // Once a callback is notified, it is removed from the list. It is up to the callback to
+                                // re-register itself.
+                                var callbacks = _callbacks.ToArray();
+
+                                    foreach (var kvp in callbacks)
+                                    {
+                                        _callbacks.Remove(kvp.Key);
+                                        kvp.Value(null);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+
+            private void StopPolling()
+            {
+                _polling = false;
+            }
+
+            public bool HasChanged
+            {
+                get
+                {
+                    lock (_gate)
+                    {
+                        return _hasChanged;
+                    }
+                }
+            }
+
+            public bool ActiveChangeCallbacks
+            {
+                get
+                {
+                    lock (_gate)
+                    {
+                        return _callbacks?.Count > 0;
+                    }
+                }
+            }
+
+            public IDisposable RegisterChangeCallback(Action<object> callback, object state)
+            {
+                if (state != null)
+                {
+                    throw new ArgumentException($"Stateful callbacks are not supported for {nameof(PollingFileChangeToken)}", nameof(state));
+                }
+
+                lock (_gate)
+                {
+                    if (_callbacks == null)
+                    {
+                        _callbacks = new Dictionary<int, Action<object>>();
+                    }
+
+                    var callbackId = _nextCallbackId++;
+                    _callbacks.Add(callbackId, callback);
+
+                    // Ensure that we're polling when we've got a callback.
+                    if (_callbacks.Count == 1)
+                    {
+                        StartPolling();
+                    }
+
+                    return new DisposableChangeCallback(this, callbackId);
+                }
+            }
+
+            private void UnregisterChangeCallback(int callbackId)
+            {
+                lock (_gate)
+                {
+                    if (_callbacks != null)
+                    {
+                        _callbacks.Remove(callbackId);
+
+                        if (_callbacks.Count == 0)
+                        {
+                            // We don't have any callbacks, so stop polling.
+                            StopPolling();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/OmniSharp.Abstractions/Utilities/PhysicalFileProviderExtensions.cs
+++ b/src/OmniSharp.Abstractions/Utilities/PhysicalFileProviderExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.FileProviders;
+
+namespace OmniSharp.Utilities
+{
+    public static partial class PhysicalFileProviderExtensions
+    {
+        /// <summary>
+        /// Wraps a PhysicalFileProvider with an IFileProvider that handles polling files for for changes
+        /// rather than using FileSystemWatcher.
+        /// </summary>
+        public static IFileProvider WrapForPolling(this PhysicalFileProvider fileProvider)
+        {
+            return new PhysicalFileProviderWrapper(fileProvider);
+        }
+    }
+}

--- a/src/OmniSharp.DotNet/DotNetProjectSystem.cs
+++ b/src/OmniSharp.DotNet/DotNetProjectSystem.cs
@@ -106,7 +106,7 @@ namespace OmniSharp.DotNet
                 return;
             }
 
-            _logger.LogInformation($"Initializing in {_environment.Path}");
+            _logger.LogInformation($"Initializing in {_environment.TargetDirectory}");
 
             if (!bool.TryParse(configuration["enablePackageRestore"], out _enableRestorePackages))
             {
@@ -115,7 +115,7 @@ namespace OmniSharp.DotNet
 
             _logger.LogInformation($"Auto package restore: {_enableRestorePackages}");
 
-            _workspaceContext = new DotNetWorkspace(_environment.Path);
+            _workspaceContext = new DotNetWorkspace(_environment.TargetDirectory);
 
             Update(allowRestore: true);
         }

--- a/src/OmniSharp.Host/Internal/ConfigurationBuilderExtensions.cs
+++ b/src/OmniSharp.Host/Internal/ConfigurationBuilderExtensions.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System;
+using System.IO;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
 using OmniSharp.Services;
-using System;
-using System.IO;
 
 namespace OmniSharp.Host.Internal
 {
@@ -10,18 +10,17 @@ namespace OmniSharp.Host.Internal
     {
         internal static void CreateAndAddGlobalOptionsFile(this IConfigurationBuilder configBuilder, IOmniSharpEnvironment env)
         {
-            if (env?.SharedDirectoryPath == null) return;
+            if (env?.SharedDirectory == null) return;
 
             try
             {
-                if (!Directory.Exists(env.SharedDirectoryPath))
+                if (!Directory.Exists(env.SharedDirectory))
                 {
-                    Directory.CreateDirectory(env.SharedDirectoryPath);
+                    Directory.CreateDirectory(env.SharedDirectory);
                 }
 
-                var omnisharpGlobalFilePath = Path.Combine(env.SharedDirectoryPath, Constants.OptionsFile);
                 configBuilder.AddJsonFile(
-                    new PhysicalFileProvider(env.SharedDirectoryPath),
+                    new PhysicalFileProvider(env.SharedDirectory),
                     Constants.OptionsFile,
                     optional: true,
                     reloadOnChange: true);
@@ -29,7 +28,7 @@ namespace OmniSharp.Host.Internal
             catch (Exception e)
             {
                 // at this point we have no ILogger yet
-                Console.Error.WriteLine($"There was an error when trying to create a global '{Constants.OptionsFile}' file in '{env.SharedDirectoryPath}'. {e.ToString()}");
+                Console.Error.WriteLine($"There was an error when trying to create a global '{Constants.OptionsFile}' file in '{env.SharedDirectory}'. {e.ToString()}");
             }
         }
     }

--- a/src/OmniSharp.Host/Internal/ConfigurationBuilderExtensions.cs
+++ b/src/OmniSharp.Host/Internal/ConfigurationBuilderExtensions.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
 using OmniSharp.Services;
+using OmniSharp.Utilities;
 
 namespace OmniSharp.Host.Internal
 {
@@ -20,7 +21,7 @@ namespace OmniSharp.Host.Internal
                 }
 
                 configBuilder.AddJsonFile(
-                    new PhysicalFileProvider(env.SharedDirectory),
+                    new PhysicalFileProvider(env.SharedDirectory).WrapForPolling(),
                     Constants.OptionsFile,
                     optional: true,
                     reloadOnChange: true);

--- a/src/OmniSharp.Host/Program.cs
+++ b/src/OmniSharp.Host/Program.cs
@@ -61,7 +61,7 @@ namespace OmniSharp
             var omnisharpApp = new CommandLineApplication(throwOnUnexpectedArg: false);
             omnisharpApp.HelpOption("-? | -h | --help");
 
-            var applicationRootOption = omnisharpApp.Option("-s | --source", "Solution, project file or directory for OmniSharp to point at (defaults to current directory).", CommandOptionType.SingleValue);
+            var applicationRootOption = omnisharpApp.Option("-s | --source", "Solution or directory for OmniSharp to point at (defaults to current directory).", CommandOptionType.SingleValue);
             var portOption = omnisharpApp.Option("-p | --port", "OmniSharp port (defaults to 2000).", CommandOptionType.SingleValue);
             var logLevelOption = omnisharpApp.Option("-l | --loglevel", "Level of logging (defaults to 'Information').", CommandOptionType.SingleValue);
             var verboseOption = omnisharpApp.Option("-v | --verbose", "Explicitly set 'Debug' log level.", CommandOptionType.NoValue);

--- a/src/OmniSharp.Host/Startup.cs
+++ b/src/OmniSharp.Host/Startup.cs
@@ -40,9 +40,9 @@ namespace OmniSharp
                 .AddJsonFile(Constants.ConfigFile, optional: true)
                 .AddEnvironmentVariables();
 
-            if (env.OtherArgs?.Length > 0)
+            if (env.AdditionalArguments?.Length > 0)
             {
-                configBuilder.AddCommandLine(env.OtherArgs);
+                configBuilder.AddCommandLine(env.AdditionalArguments);
             }
 
             // Use the global omnisharp config if there's any in the shared path
@@ -50,7 +50,7 @@ namespace OmniSharp
 
             // Use the local omnisharp config if there's any in the root path
             configBuilder.AddJsonFile(
-                new PhysicalFileProvider(env.Path),
+                new PhysicalFileProvider(env.TargetDirectory),
                 Constants.OptionsFile,
                 optional: true,
                 reloadOnChange: true);
@@ -196,11 +196,11 @@ namespace OmniSharp
 
             if (_env.TransportType == TransportType.Stdio)
             {
-                logger.LogInformation($"Omnisharp server running using {nameof(TransportType.Stdio)} at location '{_env.Path}' on host {_env.HostPID}.");
+                logger.LogInformation($"Omnisharp server running using {nameof(TransportType.Stdio)} at location '{_env.TargetDirectory}' on host {_env.HostProcessId}.");
             }
             else
             {
-                logger.LogInformation($"Omnisharp server running on port '{_env.Port}' at location '{_env.Path}' on host {_env.HostPID}.");
+                logger.LogInformation($"Omnisharp server running on port '{_env.Port}' at location '{_env.TargetDirectory}' on host {_env.HostProcessId}.");
             }
 
             InitializeWorkspace(Workspace, PluginHost, Configuration, logger, options.CurrentValue);
@@ -259,7 +259,7 @@ namespace OmniSharp
 
         private static bool LogFilter(string category, LogLevel level, IOmniSharpEnvironment environment)
         {
-            if (environment.TraceType > level)
+            if (environment.LogLevel > level)
             {
                 return false;
             }

--- a/src/OmniSharp.Host/Startup.cs
+++ b/src/OmniSharp.Host/Startup.cs
@@ -21,6 +21,7 @@ using OmniSharp.Services;
 using OmniSharp.Services.FileWatching;
 using OmniSharp.Stdio.Logging;
 using OmniSharp.Stdio.Services;
+using OmniSharp.Utilities;
 
 namespace OmniSharp
 {
@@ -50,7 +51,7 @@ namespace OmniSharp
 
             // Use the local omnisharp config if there's any in the root path
             configBuilder.AddJsonFile(
-                new PhysicalFileProvider(env.TargetDirectory),
+                new PhysicalFileProvider(env.TargetDirectory).WrapForPolling(),
                 Constants.OptionsFile,
                 optional: true,
                 reloadOnChange: true);

--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -130,7 +130,7 @@ namespace OmniSharp.MSBuild
 
             // Otherwise, assume that the path provided is a directory and
             // look for a solution there.
-            var solutionFilePath = FindSolutionFilePath(_environment.Path, _logger);
+            var solutionFilePath = FindSolutionFilePath(_environment.TargetDirectory, _logger);
             if (!string.IsNullOrEmpty(solutionFilePath))
             {
                 _solutionFileOrRootPath = solutionFilePath;
@@ -140,8 +140,8 @@ namespace OmniSharp.MSBuild
 
             // Finally, if there isn't a single solution immediately available,
             // Just process all of the projects beneath the root path.
-            _solutionFileOrRootPath = _environment.Path;
-            AddProjectsFromRootPath(_environment.Path);
+            _solutionFileOrRootPath = _environment.TargetDirectory;
+            AddProjectsFromRootPath(_environment.TargetDirectory);
         }
 
         private void AddProjectsFromSolution(string solutionFilePath)
@@ -169,7 +169,7 @@ namespace OmniSharp.MSBuild
                 // Solution files are assumed to contain relative paths to project files
                 // with Windows-style slashes.
                 var projectFilePath = projectBlock.ProjectPath.Replace('\\', Path.DirectorySeparatorChar);
-                projectFilePath = Path.Combine(_environment.Path, projectFilePath);
+                projectFilePath = Path.Combine(_environment.TargetDirectory, projectFilePath);
                 projectFilePath = Path.GetFullPath(projectFilePath);
 
                 _logger.LogInformation($"Loading project from '{projectFilePath}'.");
@@ -305,7 +305,7 @@ namespace OmniSharp.MSBuild
 
             try
             {
-                projectFileInfo = ProjectFileInfo.Create(projectFilePath, _environment.Path, _loggerFactory.CreateLogger<ProjectFileInfo>(), _options, diagnostics, isUnityProject);
+                projectFileInfo = ProjectFileInfo.Create(projectFilePath, _environment.TargetDirectory, _loggerFactory.CreateLogger<ProjectFileInfo>(), _options, diagnostics, isUnityProject);
 
                 if (projectFileInfo == null)
                 {

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -97,10 +97,10 @@ namespace OmniSharp.Script
 
         public void Initalize(IConfiguration configuration)
         {
-            _logger.LogInformation($"Detecting CSX files in '{_env.Path}'.");
+            _logger.LogInformation($"Detecting CSX files in '{_env.TargetDirectory}'.");
 
             // Nothing to do if there are no CSX files
-            var allCsxFiles = Directory.GetFiles(_env.Path, "*.csx", SearchOption.AllDirectories);
+            var allCsxFiles = Directory.GetFiles(_env.TargetDirectory, "*.csx", SearchOption.AllDirectories);
             if (allCsxFiles.Length == 0)
             {
                 _logger.LogInformation("Could not find any CSX files");
@@ -117,7 +117,7 @@ namespace OmniSharp.Script
             inheritedCompileLibraries.AddRange(DependencyContext.Default.CompileLibraries.Where(x =>
                     x.Name.ToLowerInvariant().StartsWith("system.valuetuple")));
 
-            var runtimeContexts = File.Exists(Path.Combine(_env.Path, "project.json")) ? ProjectContext.CreateContextForEachTarget(_env.Path) : null;
+            var runtimeContexts = File.Exists(Path.Combine(_env.TargetDirectory, "project.json")) ? ProjectContext.CreateContextForEachTarget(_env.TargetDirectory) : null;
 
             var commonReferences = new HashSet<MetadataReference>();
 

--- a/tests/OmniSharp.Tests/OmniSharpEnvironmentFacts.cs
+++ b/tests/OmniSharp.Tests/OmniSharpEnvironmentFacts.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.IO;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Services;
 using Xunit;
 
@@ -17,7 +18,7 @@ namespace OmniSharp.Tests
         public void OmnisharpEnvironmentSetsPathCorrectly()
         {
             var environment = new OmniSharpEnvironment(@"foo.sln", 1000, -1, LogLevel.Information, TransportType.Http, null);
-            Assert.Equal(@"", environment.Path);
+            Assert.Equal(Directory.GetCurrentDirectory(), environment.TargetDirectory);
         }
 
         [Fact]

--- a/tests/OmniSharp.Tests/OmniSharpEnvironmentFacts.cs
+++ b/tests/OmniSharp.Tests/OmniSharpEnvironmentFacts.cs
@@ -1,37 +1,36 @@
-﻿using System.IO;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using OmniSharp.Services;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Tests
 {
     public class OmniSharpEnvironmentFacts
     {
-
         [Fact]
         public void OmnisharpEnvironmentSetsSolutionPathCorrectly()
         {
-            var environment = new OmniSharpEnvironment(@"foo.sln", 1000, -1, LogLevel.Information, TransportType.Http, null);
-            Assert.Equal(@"foo.sln", environment.SolutionFilePath);
+            var environment = new OmniSharpEnvironment(TestAssets.Instance.OmniSharpSolutionPath, 1000, -1, LogLevel.Information, TransportType.Http, null);
+            Assert.Equal(TestAssets.Instance.OmniSharpSolutionPath, environment.SolutionFilePath);
         }
         [Fact]
         public void OmnisharpEnvironmentSetsPathCorrectly()
         {
-            var environment = new OmniSharpEnvironment(@"foo.sln", 1000, -1, LogLevel.Information, TransportType.Http, null);
-            Assert.Equal(Directory.GetCurrentDirectory(), environment.TargetDirectory);
+            var environment = new OmniSharpEnvironment(TestAssets.Instance.OmniSharpSolutionPath, 1000, -1, LogLevel.Information, TransportType.Http, null);
+            Assert.Equal(TestAssets.Instance.RootFolder, environment.TargetDirectory);
         }
 
         [Fact]
         public void OmnisharpEnvironmentSetsPortCorrectly()
         {
-            var environment = new OmniSharpEnvironment(@"foo.sln", 1000, -1, LogLevel.Information, TransportType.Http, null);
+            var environment = new OmniSharpEnvironment(TestAssets.Instance.OmniSharpSolutionPath, 1000, -1, LogLevel.Information, TransportType.Http, null);
             Assert.Equal(1000, environment.Port);
         }
 
         [Fact]
         public void OmnisharpEnvironmentHasNullSolutionFilePathIfDirectorySet()
         {
-            var environment = new OmniSharpEnvironment(@"c:\foo\src\", 1000, -1, LogLevel.Information, TransportType.Http, null);
+            var environment = new OmniSharpEnvironment(TestAssets.Instance.RootFolder, 1000, -1, LogLevel.Information, TransportType.Http, null);
 
             Assert.Null(environment.SolutionFilePath);
         }

--- a/tests/TestUtility/TestAssets.cs
+++ b/tests/TestUtility/TestAssets.cs
@@ -9,12 +9,14 @@ namespace TestUtility
         public static TestAssets Instance { get; } = new TestAssets();
 
         public string RootFolder { get; }
+        public string OmniSharpSolutionPath { get; }
         public string TestAssetsFolder { get; }
         public string TestProjectsFolder { get; }
 
         private TestAssets()
         {
             RootFolder = FindRootFolder();
+            OmniSharpSolutionPath = Path.Combine(RootFolder, "OmniSharp.sln");
             TestAssetsFolder = Path.Combine(RootFolder, "test-assets");
             TestProjectsFolder = Path.Combine(TestAssetsFolder, "test-projects");
         }


### PR DESCRIPTION
Recently, we've added support for reloading the user's local or global OmniSharp options when the relevant "omnisharp.json" file changes on disk. This causes the Microsoft.Extensions.Configuration API to start using a FileSystemWatcher. Unfortunately, this watcher looks for changes recursively, which can easily hit the [ulimit](https://ss64.com/osx/ulimit.html) for open files OSX just to watch for a couple of files.

This change adds a wrapper for PhysicalFileProvider that polls the file system every 2 seconds for just the files we care about.

This change also rationalizes some of the property names in OmniSharpEnvironment and fixes an issue where "Path" could be invalid if it was specified relative to the current working directory. E.g., if the OmniSharp is started with `-s OmniSharp.sln` from the directory where that file exists, Path would be an empty string.