### PR TITLE
Handle package reference version ranges in .csproj files

### DIFF
--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -573,8 +573,8 @@ namespace OmniSharp.MSBuild
             {
                 var dependency = new PackageDependency
                 {
-                    Name = packageReference.Identity.Id,
-                    Version = packageReference.Identity.VersionRange.ToNormalizedString()
+                    Name = packageReference.Dependency.Id,
+                    Version = packageReference.Dependency.VersionRange.ToNormalizedString()
                 };
 
                 list.Add(dependency);
@@ -587,8 +587,8 @@ namespace OmniSharp.MSBuild
         {
             foreach (var library in lockFile.Libraries)
             {
-                if (string.Equals(library.Name, reference.Identity.Id) &&
-                    reference.Identity.VersionRange.Satisfies(library.Version))
+                if (string.Equals(library.Name, reference.Dependency.Id) &&
+                    reference.Dependency.VersionRange.Satisfies(library.Version))
                 {
                     return true;
                 }

--- a/src/OmniSharp.MSBuild/ProjectFile/PackageReference.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PackageReference.cs
@@ -5,12 +5,12 @@ namespace OmniSharp.MSBuild.ProjectFile
 {
     public class PackageReference : IEquatable<PackageReference>
     {
-        public PackageDependency Identity { get; }
+        public PackageDependency Dependency { get; }
         public bool IsImplicitlyDefined { get; }
 
         public PackageReference(PackageDependency dependency, bool isImplicitlyDefined)
         {
-            this.Identity = dependency;
+            this.Dependency = dependency;
             this.IsImplicitlyDefined = isImplicitlyDefined;
         }
 
@@ -18,12 +18,12 @@ namespace OmniSharp.MSBuild.ProjectFile
         {
             var implicitSuffix = IsImplicitlyDefined ? " (implicit)" : string.Empty;
 
-            return Identity.Id + ", " + Identity.VersionRange + implicitSuffix;
+            return Dependency.Id + ", " + Dependency.VersionRange + implicitSuffix;
         }
 
         public bool Equals(PackageReference other)
         {
-            if (!Identity.Equals(other.Identity))
+            if (!Dependency.Equals(other.Dependency))
             {
                 return false;
             }
@@ -33,7 +33,7 @@ namespace OmniSharp.MSBuild.ProjectFile
 
         public override int GetHashCode()
         {
-            return this.Identity.GetHashCode() + (IsImplicitlyDefined ? 1 : 0);
+            return this.Dependency.GetHashCode() + (IsImplicitlyDefined ? 1 : 0);
         }
     }
 }

--- a/src/OmniSharp.MSBuild/ProjectFile/PackageReference.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PackageReference.cs
@@ -5,21 +5,20 @@ namespace OmniSharp.MSBuild.ProjectFile
 {
     public class PackageReference : IEquatable<PackageReference>
     {
-        public PackageIdentity Identity { get; }
+        public PackageDependency Identity { get; }
         public bool IsImplicitlyDefined { get; }
 
-        public PackageReference(PackageIdentity identity, bool isImplicitlyDefined)
+        public PackageReference(PackageDependency dependency, bool isImplicitlyDefined)
         {
-            this.Identity = identity;
+            this.Identity = dependency;
             this.IsImplicitlyDefined = isImplicitlyDefined;
         }
 
         public override string ToString()
         {
-            var version = Identity.HasVersion ? ", " + Identity.Version.ToNormalizedString() : string.Empty;
             var implicitSuffix = IsImplicitlyDefined ? " (implicit)" : string.Empty;
 
-            return Identity.Id + version + implicitSuffix;
+            return Identity.Id + ", " + Identity.VersionRange + implicitSuffix;
         }
 
         public bool Equals(PackageReference other)

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Logging;
 using NuGet.Packaging.Core;
-using OmniSharp.Models;
 using OmniSharp.Options;
 using OmniSharp.Utilities;
 
@@ -114,7 +113,7 @@ namespace OmniSharp.MSBuild.ProjectFile
             string solutionDirectory,
             ILogger logger,
             MSBuildOptions options = null,
-            ICollection<MSBuildDiagnosticsMessage> diagnostics = null,
+            ICollection<Models.MSBuildDiagnosticsMessage> diagnostics = null,
             bool isUnityProject = false)
         {
             if (!File.Exists(projectFilePath))
@@ -250,11 +249,11 @@ namespace OmniSharp.MSBuild.ProjectFile
             foreach (var item in items)
             {
                 var name = item.EvaluatedInclude;
-                var version = PropertyConverter.ToNuGetVersion(item.GetMetadataValue(MetadataNames.Version));
-                var identity = new PackageIdentity(name, version);
+                var versionRange = PropertyConverter.ToVersionRange(item.GetMetadataValue(MetadataNames.Version));
+                var dependency = new PackageDependency(name, versionRange);
                 var isImplicitlyDefined = PropertyConverter.ToBoolean(item.GetMetadataValue(MetadataNames.IsImplicitlyDefined), false);
 
-                list.Add(new PackageReference(identity, isImplicitlyDefined));
+                list.Add(new PackageReference(dependency, isImplicitlyDefined));
             }
 
             return list;

--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
@@ -165,10 +165,9 @@ namespace OmniSharp.MSBuild.ProjectFile
             }
         }
 
-        public static NuGetVersion ToNuGetVersion(string propertyValue)
+        public static VersionRange ToVersionRange(string propertyValue)
         {
-            NuGetVersion version;
-            if (NuGetVersion.TryParse(propertyValue.Trim(), out version))
+            if (VersionRange.TryParse(propertyValue.Trim(), out var version))
             {
                 return version;
             }


### PR DESCRIPTION
When I did the initial punch through to get package references working in .csproj, I failed to account for version ranges. This should address the unresolved dependencies warnings reported in #795.