### PR TITLE
Ensure that MSBuildProjectSystem doesn't add project references twice

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -218,7 +218,8 @@ namespace OmniSharp.MSBuild.ProjectFile
             var projectAssetsFile = projectInstance.GetPropertyValue(PropertyNames.ProjectAssetsFile);
 
             var sourceFiles = GetFullPaths(projectInstance.GetItems(ItemNames.Compile));
-            var references = GetFullPaths(projectInstance.GetItems(ItemNames.ReferencePath));
+            var references = GetFullPaths(
+                projectInstance.GetItems(ItemNames.ReferencePath).Where(ReferenceSourceTargetIsNotProjectReference));
             var projectReferences = GetFullPaths(projectInstance.GetItems(ItemNames.ProjectReference));
             var analyzers = GetFullPaths(projectInstance.GetItems(ItemNames.Analyzer));
 
@@ -231,7 +232,12 @@ namespace OmniSharp.MSBuild.ProjectFile
                 sourceFiles, references, projectReferences, analyzers, packageReferences);
         }
 
-        private static IList<string> GetFullPaths(ICollection<ProjectItemInstance> items)
+        private static bool ReferenceSourceTargetIsNotProjectReference(ProjectItemInstance item)
+        {
+            return item.GetMetadataValue(MetadataNames.ReferenceSourceTarget) != ItemNames.ProjectReference;
+        }
+
+        private static IList<string> GetFullPaths(IEnumerable<ProjectItemInstance> items)
         {
             var sortedSet = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
Fixes #795

It's possible for project references to appear twice within an MSBuild project after execution:

* As a ProjectReference item
* As a ReferencePath item with ReferenceSourceTarget="ProjectReference"

This change makes sure that ReferencePath items that were sourced from project references aren't added. We just use the project references, which is a better experience at designtime when the project is built.

Note: There was code that used to do this, but it was unintentionally removed in a refactoring a few months ago (by me -- oops!): https://github.com/OmniSharp/omnisharp-roslyn/commit/ef4b3838d39666ed5ca9780ea133bfdc08ff5844.