### PR TITLE
In MSBuildProjectSystem, add NoWarn values that do not parse as ushorts

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
@@ -133,10 +133,13 @@ namespace OmniSharp.MSBuild.ProjectFile
 
             foreach (var id in values)
             {
-                ushort number;
-                if (ushort.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out number))
+                if (ushort.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number))
                 {
                     result.Add("CS" + number.ToString("0000"));
+                }
+                else
+                {
+                    result.Add(id);
                 }
             }
 
@@ -145,8 +148,7 @@ namespace OmniSharp.MSBuild.ProjectFile
 
         public static Guid ToGuid(string propertyValue)
         {
-            Guid result;
-            if (!Guid.TryParse(propertyValue, out result))
+            if (!Guid.TryParse(propertyValue, out var result))
             {
                 return Guid.Empty;
             }


### PR DESCRIPTION
Fixes #826 