### PR TITLE
Enable lots of tests to run for CSX

### DIFF
--- a/tests/OmniSharp.Roslyn.CSharp.Tests/AbstractAutoCompleteTestFixture.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/AbstractAutoCompleteTestFixture.cs
@@ -16,9 +16,9 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
         protected override string EndpointName => OmniSharpEndpoints.AutoComplete;
 
-        protected async Task<IEnumerable<AutoCompleteResponse>> FindCompletionsAsync(string source, bool wantSnippet = false)
+        protected async Task<IEnumerable<AutoCompleteResponse>> FindCompletionsAsync(string filename, string source, bool wantSnippet = false)
         {
-            var testFile = new TestFile("dummy.cs", source);
+            var testFile = new TestFile(filename, source);
             using (var host = CreateOmniSharpHost(testFile))
             {
                 var point = testFile.Content.GetPointFromPosition();

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsV2Facts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsV2Facts.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Models.Diagnostics;
 using OmniSharp.Roslyn.CSharp.Services.Diagnostics;
-using OmniSharp.Services;
 using OmniSharp.Workers.Diagnostics;
 using TestUtility;
 using Xunit;
@@ -18,10 +17,12 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         {
         }
 
-        [Fact]
-        public async Task CodeCheckSpecifiedFileOnly()
+        [Theory]
+        [InlineData("a.cs")]
+        [InlineData("a.csx")]
+        public async Task CodeCheckSpecifiedFileOnly(string filename)
         {
-            var testFile = new TestFile("a.cs", "class C { int n = true; }");
+            var testFile = new TestFile(filename, "class C { int n = true; }");
 
             using (var host = CreateOmniSharpHost(testFile))
             {
@@ -33,7 +34,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 };
 
                 var service = new CSharpDiagnosticService(host.Workspace, forwarder, this.LoggerFactory);
-                service.QueueDiagnostics("a.cs");
+                service.QueueDiagnostics(filename);
 
                 await emitter.Emitted;
 
@@ -42,15 +43,17 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 Assert.Equal(1, message.Results.Count());
                 var result = message.Results.First();
                 Assert.Equal(1, result.QuickFixes.Count());
-                Assert.Equal("a.cs", result.FileName);
+                Assert.Equal(filename, result.FileName);
             }
         }
 
-        [Fact]
-        public async Task CheckAllFiles()
+        [Theory]
+        [InlineData("a.cs", "b.cs")]
+        [InlineData("a.csx", "b.csx")]
+        public async Task CheckAllFiles(string filename1, string filename2)
         {
-            var testFile1 = new TestFile("a.cs", "class C1 { int n = true; }");
-            var testFile2 = new TestFile("b.cs", "class C2 { int n = true; }");
+            var testFile1 = new TestFile(filename1, "class C1 { int n = true; }");
+            var testFile2 = new TestFile(filename2, "class C2 { int n = true; }");
 
             using (var host = CreateOmniSharpHost(testFile1, testFile2))
             {
@@ -68,21 +71,23 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 var message = messages.First();
                 Assert.Equal(2, message.Results.Count());
 
-                var a = message.Results.First(x => x.FileName == "a.cs");
+                var a = message.Results.First(x => x.FileName == filename1);
                 Assert.Equal(1, a.QuickFixes.Count());
-                Assert.Equal("a.cs", a.FileName);
+                Assert.Equal(filename1, a.FileName);
 
-                var b = message.Results.First(x => x.FileName == "b.cs");
+                var b = message.Results.First(x => x.FileName == filename2);
                 Assert.Equal(1, b.QuickFixes.Count());
-                Assert.Equal("b.cs", b.FileName);
+                Assert.Equal(filename2, b.FileName);
             }
         }
 
-        [Fact]
-        public async Task EnablesWhenEndPointIsHit()
+        [Theory]
+        [InlineData("a.cs", "b.cs")]
+        [InlineData("a.csx", "b.csx")]
+        public async Task EnablesWhenEndPointIsHit(string filename1, string filename2)
         {
-            var testFile1 = new TestFile("a.cs", "class C1 { int n = true; }");
-            var testFile2 = new TestFile("b.cs", "class C2 { int n = true; }");
+            var testFile1 = new TestFile(filename1, "class C1 { int n = true; }");
+            var testFile2 = new TestFile(filename2, "class C2 { int n = true; }");
 
             using (var host = CreateOmniSharpHost(testFile1, testFile2))
             {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -19,8 +19,10 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             this._logger = this.LoggerFactory.CreateLogger<IntellisenseFacts>();
         }
 
-        [Fact]
-        public async Task DisplayText_is_correct_for_property()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task DisplayText_is_correct_for_property(string filename)
         {
             const string input =
                 @"public class Class1 {
@@ -31,12 +33,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                         }
                     }";
 
-            var completions = await FindCompletionsAsync(input, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, input, wantSnippet: true);
             ContainsCompletions(completions.Select(c => c.DisplayText).Take(1), "Foo");
         }
 
-        [Fact]
-        public async Task DisplayText_is_correct_for_variable()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task DisplayText_is_correct_for_variable(string filename)
         {
             const string input =
                 @"public class Class1 {
@@ -47,12 +51,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                         }
                     }";
 
-            var completions = await FindCompletionsAsync(input, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, input, wantSnippet: true);
             ContainsCompletions(completions.Select(c => c.DisplayText).Take(1), "foo");
         }
 
-        [Fact]
-        public async Task DisplayText_matches_snippet_for_snippet_response()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task DisplayText_matches_snippet_for_snippet_response(string filename)
         {
             const string input =
                 @"public class Class1 {
@@ -65,12 +71,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                         }
                     }";
 
-            var completions = await FindCompletionsAsync(input, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, input, wantSnippet: true);
             ContainsCompletions(completions.Select(c => c.DisplayText).Take(2), "Foo()", "Foo(int bar = 1)");
         }
 
-        [Fact]
-        public async Task DisplayText_matches_snippet_for_non_snippet_response()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task DisplayText_matches_snippet_for_non_snippet_response(string filename)
         {
             const string input =
                 @"public class Class1 {
@@ -83,12 +91,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                         }
                     }";
 
-            var completions = await FindCompletionsAsync(input, wantSnippet: false);
+            var completions = await FindCompletionsAsync(filename, input, wantSnippet: false);
             ContainsCompletions(completions.Select(c => c.DisplayText).Take(1), "Foo(int bar = 1)");
         }
 
-        [Fact]
-        public async Task Returns_camel_case_completions()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Returns_camel_case_completions(string filename)
         {
             const string input =
                 @"public class Class1 {
@@ -98,12 +108,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                         }
                     }";
 
-            var completions = await FindCompletionsAsync(input);
+            var completions = await FindCompletionsAsync(filename, input);
             ContainsCompletions(completions.Select(c => c.CompletionText).Take(1), "TryParse");
         }
 
-        [Fact]
-        public async Task Returns_sub_sequence_completions()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Returns_sub_sequence_completions(string filename)
         {
             const string input =
                 @"public class Class1 {
@@ -113,12 +125,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                         }
                     }";
 
-            var completions = await FindCompletionsAsync(input);
+            var completions = await FindCompletionsAsync(filename, input);
             ContainsCompletions(completions.Select(c => c.CompletionText).Take(1), "NewGuid");
         }
 
-        [Fact]
-        public async Task Returns_method_header()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Returns_method_header(string filename)
         {
             const string input =
                 @"public class Class1 {
@@ -128,12 +142,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                         }
                     }";
 
-            var completions = await FindCompletionsAsync(input);
+            var completions = await FindCompletionsAsync(filename, input);
             ContainsCompletions(completions.Select(c => c.MethodHeader).Take(1), "NewGuid()");
         }
 
-        [Fact]
-        public async Task Returns_variable_before_class()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Returns_variable_before_class(string filename)
         {
             const string input =
                 @"public class MyClass1 {
@@ -145,12 +161,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                         }
                     }";
 
-            var completions = await FindCompletionsAsync(input);
+            var completions = await FindCompletionsAsync(filename, input);
             ContainsCompletions(completions.Select(c => c.CompletionText), "myvar", "MyClass1");
         }
 
-        [Fact]
-        public async Task Returns_class_before_variable()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Returns_class_before_variable(string filename)
         {
             const string input =
                 @"public class MyClass1 {
@@ -162,12 +180,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                         }
                     }";
 
-            var completions = await FindCompletionsAsync(input);
+            var completions = await FindCompletionsAsync(filename, input);
             ContainsCompletions(completions.Select(c => c.CompletionText), "MyClass1", "myvar");
         }
 
-        [Fact]
-        public async Task Returns_empty_sequence_in_invalid_context()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Returns_empty_sequence_in_invalid_context(string filename)
         {
             const string source =
                 @"public class MyClass1 {
@@ -178,7 +198,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                         }
                     }";
 
-            var completions = await FindCompletionsAsync(source);
+            var completions = await FindCompletionsAsync(filename, source);
             ContainsCompletions(completions.Select(c => c.CompletionText), Array.Empty<string>());
         }
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/MetadataFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/MetadataFacts.cs
@@ -16,17 +16,21 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
         protected override string EndpointName => OmniSharpEndpoints.Metadata;
 
-        [Fact]
-        public async Task ReturnsSource_ForSpecialType()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task ReturnsSource_ForSpecialType(string filename)
         {
             var assemblyName = AssemblyHelpers.CorLibName;
             var typeName = "System.String";
 
-            await TestMetadataAsync(assemblyName, typeName);
+            await TestMetadataAsync(filename, assemblyName, typeName);
         }
 
-        [Fact]
-        public async Task ReturnsSource_ForNormalType()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task ReturnsSource_ForNormalType(string filename)
         {
 #if NETCOREAPP1_1
             var assemblyName = "System.Linq";
@@ -36,21 +40,23 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
             var typeName = "System.Linq.Enumerable";
 
-            await TestMetadataAsync(assemblyName, typeName);
+            await TestMetadataAsync(filename, assemblyName, typeName);
         }
 
-        [Fact]
-        public async Task ReturnsSource_ForGenericType()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task ReturnsSource_ForGenericType(string filename)
         {
             var assemblyName = AssemblyHelpers.CorLibName;
             var typeName = "System.Collections.Generic.List`1";
 
-            await TestMetadataAsync(assemblyName, typeName);
+            await TestMetadataAsync(filename, assemblyName, typeName);
         }
 
-        private async Task TestMetadataAsync(string assemblyName, string typeName)
+        private async Task TestMetadataAsync(string filename, string assemblyName, string typeName)
         {
-            var testFile = new TestFile("dummy.cs", "class C {}");
+            var testFile = new TestFile(filename, "class C {}");
 
             using (var host = CreateOmniSharpHost(testFile))
             {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SnippetFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SnippetFacts.cs
@@ -19,8 +19,10 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             this._logger = this.LoggerFactory.CreateLogger<SnippetFacts>();
         }
 
-        [Fact]
-        public async Task Can_template_generic_type_argument()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Can_template_generic_type_argument(string filename)
         {
             const string source =
                 @"public class Class1 {
@@ -30,12 +32,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                         }
                     }";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("List<${1:T}>()$0", completions);
         }
 
-        [Fact]
-        public async Task Can_return_method_type_arguments_snippets()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Can_return_method_type_arguments_snippets(string filename)
         {
             const string source =
                 @"using System.Collections.Generic;
@@ -53,12 +57,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                          }
                      }";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("Get<${1:SomeType}>()$0 : string", completions);
         }
 
-        [Fact]
-        public async Task Does_not_include_tsource_argument_type()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Does_not_include_tsource_argument_type(string filename)
         {
             const string source =
                 @"using System.Collections.Generic;
@@ -71,13 +77,15 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                     }
                 }";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("First()$0 : string", completions);
             ContainsSnippet("FirstOrDefault(${1:Func<string, bool> predicate})$0 : string", completions);
         }
 
-        [Fact]
-        public async Task Does_not_include_tresult_argument_type()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Does_not_include_tresult_argument_type(string filename)
         {
             const string source =
                 @"using System.Collections.Generic;
@@ -90,12 +98,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                          }
                      }";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("Select(${1:Func<KeyValuePair<string, object>, TResult> selector})$0 : IEnumerable<TResult>", completions);
         }
 
-        [Fact]
-        public async Task Can_template_field()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Can_template_field(string filename)
         {
             const string source =
                 @"using System.Collections.Generic;
@@ -108,12 +118,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                      }
                  }";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("someField$0 : int", completions);
         }
 
-        [Fact]
-        public async Task Can_return_all_constructors()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Can_return_all_constructors(string filename)
         {
             const string source =
                 @"public class MyClass {
@@ -129,15 +141,17 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                     }
                 }";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("MyClass()$0", completions);
             ContainsSnippet("MyClass(${1:int param})$0", completions);
             ContainsSnippet("MyClass(${1:int param}, ${2:string param})$0", completions);
         }
 
 
-        [Fact]
-        public async Task Can_template_generic_type_arguments()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Can_template_generic_type_arguments(string filename)
         {
             const string source =
                 @"using System.Collections.Generic;
@@ -148,12 +162,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                       }
                   }";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("Dictionary<${1:TKey}, ${2:TValue}>()$0", completions);
         }
 
-        [Fact]
-        public async Task Can_template_parameter()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Can_template_parameter(string filename)
         {
             const string source =
                 @"using System.Collections.Generic;
@@ -164,22 +180,26 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                       }
                   }";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("List<${1:T}>(${2:IEnumerable<T> collection})$0", completions);
 
         }
 
-        [Fact]
-        public async Task Can_complete_namespace()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Can_complete_namespace(string filename)
         {
             const string source = "using Sys$$";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("System$0", completions);
         }
 
-        [Fact]
-        public async Task Can_complete_variable()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Can_complete_variable(string filename)
         {
             const string source = @"
                 public class Class1
@@ -192,12 +212,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 }
             ";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("aVariable$0 : int", completions);
         }
 
-        [Fact]
-        public async Task Void_methods_end_with_semicolons()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Void_methods_end_with_semicolons(string filename)
         {
             const string source = @"
                 using System;
@@ -210,12 +232,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 }
             ";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("Sort(${1:Array array});$0 : void", completions);
         }
 
-        [Fact]
-        public async Task Fuzzy_matches_are_returned_when_first_letters_match()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Fuzzy_matches_are_returned_when_first_letters_match(string filename)
         {
             const string source = @"
                 using System;
@@ -228,12 +252,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 }
             ";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("NewGuid()$0 : Guid", completions);
         }
 
-        [Fact]
-        public async Task Fuzzy_matches_are_not_returned_when_first_letters_do_not_match()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Fuzzy_matches_are_not_returned_when_first_letters_do_not_match(string filename)
         {
             const string source = @"
                 using System;
@@ -246,13 +272,15 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 }
             ";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             var snippetTexts = GetSnippetTexts(completions);
             Assert.DoesNotContain("WriteLine();$0 : void", snippetTexts);
         }
 
-        [Fact]
-        public async Task Can_complete_parameter()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Can_complete_parameter(string filename)
         {
             const string source = @"
                 public class Class1
@@ -267,21 +295,25 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 }
             ";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("class1$0 : Class1", completions);
         }
 
-        [Fact]
-        public async Task Can_return_keywords()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Can_return_keywords(string filename)
         {
             const string source = "usin$$";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("using", completions);
         }
 
-        [Fact]
-        public async Task Returns_enums()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Returns_enums(string filename)
         {
             const string source =
                 @"public enum Colors { Red, Blue }
@@ -294,13 +326,15 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                       }
                   }";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             Assert.Equal(1, completions.Count());
             ContainsSnippet("Colors$0", completions);
         }
 
-        [Fact]
-        public async Task Returns_event_without_event_keyword()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Returns_event_without_event_keyword(string filename)
         {
             const string source =
                 @"
@@ -313,13 +347,15 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                     }
                 }";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             Assert.Equal(1, completions.Count());
             ContainsSnippet("TickChanged$0 : TickHandler", completions);
         }
 
-        [Fact]
-        public async Task Returns_method_without_optional_params()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Returns_method_without_optional_params(string filename)
         {
             const string source = @"
                 public class Class1
@@ -334,7 +370,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 }
             ";
 
-            var completions = await FindCompletionsAsync(source, wantSnippet: true);
+            var completions = await FindCompletionsAsync(filename, source, wantSnippet: true);
             ContainsSnippet("OptionalParam(${1:int i});$0 : void", completions);
             ContainsSnippet("OptionalParam(${1:int i}, ${2:string s = null});$0 : void", completions);
         }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SnippetFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SnippetFacts.cs
@@ -375,6 +375,35 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             ContainsSnippet("OptionalParam(${1:int i}, ${2:string s = null});$0 : void", completions);
         }
 
+        [Fact]
+        public async Task Can_complete_global_variable_in_CSX()
+        {
+            const string source = @"
+                        var aVariable = 1;
+                        av$$
+            ";
+
+            var completions = await FindCompletionsAsync("dummy.csx", source, wantSnippet: true);
+            ContainsSnippet("aVariable$0 : int", completions);
+        }
+
+        [Fact]
+        public async Task Can_return_global_method_type_arguments_snippets_in_CSX()
+        {
+            const string source =
+                @"using System.Collections.Generic;
+
+                         public string Get<SomeType>()
+                         {
+                         }
+
+                         G$$
+                 ";
+
+            var completions = await FindCompletionsAsync("dummy.csx", source, wantSnippet: true);
+            ContainsSnippet("Get<${1:SomeType}>()$0 : string", completions);
+        }
+
         private static IEnumerable<string> GetSnippetTexts(IEnumerable<AutoCompleteResponse> responses)
         {
             return responses.Select(r =>

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -5,8 +5,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using OmniSharp;
 using OmniSharp.Services;
-using System.IO;
-using System.Reflection;
 
 namespace TestUtility
 {


### PR DESCRIPTION
In the last PR I introduced a possibility to run our regular `AbstractTestFixture`-based tests against CSX files. 
In this PR I enabled a bunch of existing tests to run both against `.cs` files and against `.csx` files.

As a result there are 36 more tests.