### PR TITLE
Get NUnit test running/debugging working

### DIFF
--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -20,6 +20,8 @@ namespace OmniSharp.DotNetTest
 {
     internal class VSTestManager : TestManager
     {
+        private const string DefaultRunSettings = "<RunSettings />";
+
         public VSTestManager(Project project, string workingDirectory, DotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
             : base(project, workingDirectory, dotNetCli, eventEmitter, loggerFactory.CreateLogger<VSTestManager>())
         {
@@ -27,7 +29,7 @@ namespace OmniSharp.DotNetTest
 
         protected override string GetCliTestArguments(int port, int parentProcessId)
         {
-            return $"vstest  --Port:{port} --ParentProcessId:{parentProcessId}";
+            return $"vstest --Port:{port} --ParentProcessId:{parentProcessId}";
         }
 
         protected override void VersionCheck()
@@ -86,7 +88,8 @@ namespace OmniSharp.DotNetTest
                 new
                 {
                     TestCases = testCases,
-                    DebuggingEnabled = true
+                    DebuggingEnabled = true,
+                    RunSettings = DefaultRunSettings
                 });
 
             var message = ReadMessage();
@@ -110,7 +113,8 @@ namespace OmniSharp.DotNetTest
                 new
                 {
                     TestCases = testCases,
-                    DebuggingEnabled = true
+                    DebuggingEnabled = true,
+                    RunSettings = DefaultRunSettings
                 });
 
             var message = await ReadMessageAsync(cancellationToken);
@@ -170,7 +174,8 @@ namespace OmniSharp.DotNetTest
                 SendMessage(MessageType.TestRunSelectedTestCasesDefaultHost,
                     new
                     {
-                        TestCases = testCases
+                        TestCases = testCases,
+                        RunSettings = DefaultRunSettings
                     });
 
                 var done = false;
@@ -224,7 +229,8 @@ namespace OmniSharp.DotNetTest
                     Sources = new[]
                     {
                         Project.OutputFilePath
-                    }
+                    },
+                    RunSettings = DefaultRunSettings
                 });
 
             var testCases = new List<TestCase>();

--- a/test-assets/test-projects/NUnitTestProject/NUnitTestProject.csproj
+++ b/test-assets/test-projects/NUnitTestProject/NUnitTestProject.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.7.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0-ci-00452-pr-313" />
   </ItemGroup>
 
 </Project>

--- a/test-assets/test-projects/NUnitTestProject/NuGet.config
+++ b/test-assets/test-projects/NUnitTestProject/NuGet.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="AppVeyor NUnit CI Feed" value="https://ci.appveyor.com/nuget/nunit" />
+    <add key="AppVeyor NUnit Engine CI Feed" value="https://ci.appveyor.com/nuget/nunit-console" />
+    <add key="AppVeyor NUnit Adapter CI Feed" value="https://ci.appveyor.com/nuget/nunit3-vs-adapter" />
+    <add key="NUnit MyGet Feed" value="https://www.myget.org/F/nunit/api/v2" />
+  </packageSources>
+</configuration>

--- a/tests/OmniSharp.DotNetTest.Tests/AbstractRunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/AbstractRunTestFacts.cs
@@ -13,7 +13,7 @@ namespace OmniSharp.DotNetTest.Tests
         protected const string LegacyXunitTestProject = "LegacyXunitTestProject";
         protected const string LegacyNunitTestProject = "LegacyNunitTestProject";
         protected const string XunitTestProject = "XunitTestProject";
-        protected const string NunitTestProject = "NunitTestProject";
+        protected const string NUnitTestProject = "NUnitTestProject";
 
         public AbstractRunTestFacts(ITestOutputHelper testOutput)
             : base(testOutput)

--- a/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
@@ -65,10 +65,7 @@ namespace OmniSharp.DotNetTest.Tests
             Assert.Equal(1, response.Results.Length);
         }
 
-        // NUnit does not work with .NET CLI RTM yet. https://github.com/nunit/dotnet-test-nunit/issues/108
-        // When it does, the NUnitTestProject should be updated and the tests below re-enabled.
-
-        //[Fact]
+        [Fact]
         public async Task RunNunitTest()
         {
             await RunDotNetTestAsync(
@@ -78,7 +75,7 @@ namespace OmniSharp.DotNetTest.Tests
                 shouldPass: true);
         }
 
-        //[Fact]
+        [Fact]
         public async Task RunNunitDataDriveTest1()
         {
             await RunDotNetTestAsync(
@@ -88,7 +85,7 @@ namespace OmniSharp.DotNetTest.Tests
                 shouldPass: false);
         }
 
-        //[Fact]
+        [Fact]
         public async Task RunNunitDataDriveTest2()
         {
             await RunDotNetTestAsync(
@@ -98,7 +95,7 @@ namespace OmniSharp.DotNetTest.Tests
                 shouldPass: true);
         }
 
-        //[Fact]
+        [Fact]
         public async Task RunNunitSourceDataDrivenTest()
         {
             await RunDotNetTestAsync(

--- a/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
@@ -69,7 +69,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task RunNunitTest()
         {
             await RunDotNetTestAsync(
-                NunitTestProject,
+                NUnitTestProject,
                 methodName: "Main.Test.MainTest.Test",
                 testFramework: "nunit",
                 shouldPass: true);
@@ -79,7 +79,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task RunNunitDataDriveTest1()
         {
             await RunDotNetTestAsync(
-                NunitTestProject,
+                NUnitTestProject,
                 methodName: "Main.Test.MainTest.DataDrivenTest1",
                 testFramework: "nunit",
                 shouldPass: false);
@@ -89,7 +89,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task RunNunitDataDriveTest2()
         {
             await RunDotNetTestAsync(
-                NunitTestProject,
+                NUnitTestProject,
                 methodName: "Main.Test.MainTest.DataDrivenTest2",
                 testFramework: "nunit",
                 shouldPass: true);
@@ -99,7 +99,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task RunNunitSourceDataDrivenTest()
         {
             await RunDotNetTestAsync(
-                NunitTestProject,
+                NUnitTestProject,
                 methodName: "Main.Test.MainTest.SourceDataDrivenTest",
                 testFramework: "nunit",
                 shouldPass: true);


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1434

This change updates the test manager to pass dummy `RunSettings`, which allows the latest NUnit alpha to work (the NUnit test adapter does not handle null RunSettings). In addition, this updates our NUnit test project to use the latest NUnitTestAdapter CI build and uncomments the NUnit tests. When there's an official NUnitTestAdapter release, we'll want to update the test project to reference that and get rid of its NuGet.config.

cc @bernardbr and @rprouse