### PR TITLE
Build script work

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -267,11 +267,14 @@ Task("PopulateRuntimes")
             "default", // To allow testing the published artifact
             "ubuntu.14.04-x64",
             "ubuntu.16.04-x64",
+            "ubuntu.16.10-x64",
             "centos.7-x64",
             "rhel.7.2-x64",
             "debian.8-x64",
             "fedora.23-x64",
-            "opensuse.13.2-x64");
+            "fedora.24-x64",
+            "opensuse.13.2-x64",
+            "opensuse.42.1-x64");
     }
     else
     {

--- a/build.cake
+++ b/build.cake
@@ -627,18 +627,24 @@ Task("OnlyPublish")
 
     foreach (var runtime in buildPlan.TargetRids)
     {
-        var rid = runtime.Equals("default")
-            ? buildPlan.GetDefaultRid()
-            : runtime;
-
-        if (completed.Contains(rid))
+        if (completed.Contains(runtime))
         {
             continue;
         }
 
+        var rid = runtime.Equals("default")
+            ? buildPlan.GetDefaultRid()
+            : runtime;
+
         // Restore the OmniSharp.csproj with this runtime.
         PrintBlankLine();
-        Information($"Restoring packages in {projectName} for {rid}...");
+        var runtimeText = runtime;
+        if (runtimeText.Equals("default"))
+        {
+            runtimeText += " (" + rid + ")";
+        }
+
+        Information($"Restoring packages in {projectName} for {runtimeText}...");
 
         RunTool(env.DotNetCommand, $"restore \"{projectFileName}\" --runtime {rid}", env.WorkingDirectory)
             .ExceptionOnError($"Failed to restore {projectName} for {rid}.");
@@ -677,7 +683,7 @@ Task("OnlyPublish")
             }
         }
 
-        completed.Add(rid);
+        completed.Add(runtime);
     }
 
     CreateRunScript(CombinePaths(env.Folders.ArtifactsPublish, project, "default"), env.Folders.ArtifactsScripts);

--- a/scripts/archiving.cake
+++ b/scripts/archiving.cake
@@ -20,19 +20,14 @@ string GetBuildIdentifier(string runtime, string framework)
     }
     else
     {
-        // Remove version number. Note: because there are separate versions for Ubuntu 14 and 16,
-        // we treat Ubuntu as a special case.
-        if (runtime.StartsWith("ubuntu.14"))
+        // Remove version number for Windows and OSX.
+        if (runtime.StartsWith("win") || runtime.StartsWith("osx"))
         {
-            runtimeShort = "ubuntu14-x64";
-        }
-        else if (runtime.StartsWith("ubuntu.16"))
-        {
-            runtimeShort = "ubuntu16-x64";
+            runtimeShort = Regex.Replace(runtime, "(\\d|\\.)*-", "-");
         }
         else
         {
-            runtimeShort = Regex.Replace(runtime, "(\\d|\\.)*-", "-");
+            runtimeShort = runtime;
         }
     }
 

--- a/src/OmniSharp/OmniSharp.csproj
+++ b/src/OmniSharp/OmniSharp.csproj
@@ -5,7 +5,7 @@
     <WarningsAsErrors>true</WarningsAsErrors>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;fedora.24-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #658 
Fixes #639

* Fix issue where de-duping during publish would skip a RID-specific publish step if that RID matched the current machine.
* Show version numbers in archives for Linux distros
* Add more Linux distros, namely ubuntu16.10, fedora24, and opensuse42.1

The additionally Linux distros is really a temporary measure since we'll be moving to an embedded Mono as part of #666. However, this will at least allow folks to build on those machines.