### PR TITLE
Increase the timeout specified when running published bits during build

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -740,7 +740,7 @@ Task("TestPublished")
     {
         var scriptPath = CombinePaths(env.Folders.ArtifactsScripts, script);
         var didNotExitWithError = Run(env.ShellCommand, $"{env.ShellArgument}  \"{scriptPath}\" -s \"{projectFolder}\" --stdio",
-                                    new RunOptions(timeOut: 10000))
+                                    new RunOptions(timeOut: 30000))
                                 .DidTimeOut;
         if (!didNotExitWithError)
         {


### PR DESCRIPTION
Our build script finishes up by running the published OmniSharp bits with a timeout. This timeout is no longer long enough and the bits continue trying to run after the build is finished. I *believe* the reason for this is because the MSBuildProjectSystem now loads referenced projects outside of the directory OmniSharp is started with. More projects means more time processing, which causes the bits run longer. I'm increasing the timeout from 10 seconds to 30 seconds.