### PR TITLE
When finding partial methods, pick the one with body 

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindSymbolsService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindSymbolsService.cs
@@ -83,17 +83,4 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
         }
 
     }
-
-    public partial class MyClass
-    {
-        partial void Method();
-    }
-
-    public partial class MyClass
-    {
-        partial void Method()
-        {
-            Console.WriteLine("foo");
-        }
-    }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindSymbolsService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindSymbolsService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using System.Threading.Tasks;
@@ -36,11 +37,23 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
         {
             var symbols = await SymbolFinder.FindSourceDeclarationsAsync(_workspace.CurrentSolution, predicate, SymbolFilter.TypeAndMember);
 
-            var quickFixes = (from symbol in symbols
-                              from location in symbol.Locations
-                              select ConvertSymbol(symbol, location)).Distinct();
+            var symbolLocations = new List<QuickFix>();
+            foreach(var symbol in symbols)
+            {
+                // for partial methods, pick the one with body
+                var s = symbol;
+                if (s is IMethodSymbol method)
+                {
+                    s = method.PartialImplementationPart ?? symbol;
+                }
 
-            return new QuickFixResponse(quickFixes);
+                foreach (var location in s.Locations)
+                {
+                    symbolLocations.Add(ConvertSymbol(symbol, location));
+                }
+            }
+
+            return new QuickFixResponse(symbolLocations.Distinct());
         }
 
         private QuickFix ConvertSymbol(ISymbol symbol, Location location)
@@ -69,5 +82,18 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
             };
         }
 
+    }
+
+    public partial class MyClass
+    {
+        partial void Method();
+    }
+
+    public partial class MyClass
+    {
+        partial void Method()
+        {
+            Console.WriteLine("foo");
+        }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionService.cs
@@ -43,6 +43,12 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
 
                 if (symbol != null)
                 {
+                    // for partial methods, pick the one with body
+                    if (symbol is IMethodSymbol method)
+                    {
+                        symbol = method.PartialImplementationPart ?? symbol;
+                    }
+
                     var location = symbol.Locations.First();
 
                     if (location.IsInSource)

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindSymbolsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindSymbolsFacts.cs
@@ -3,7 +3,8 @@ using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Models.FindSymbols;
 using OmniSharp.Roslyn.CSharp.Services.Navigation;
-using Microsoft.CodeAnalysis;using TestUtility;
+using Microsoft.CodeAnalysis;
+using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindSymbolsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindSymbolsFacts.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Models.FindSymbols;
 using OmniSharp.Roslyn.CSharp.Services.Navigation;
+using Microsoft.CodeAnalysis;
 using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
@@ -163,6 +164,30 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             var usages = await FindSymbolsAsync(code);
             var symbols = usages.QuickFixes.Cast<SymbolLocation>().Select(q => q.Kind);
             Assert.Equal("Delegate", symbols.First());
+        }
+
+        [Fact]
+        public async Task Finds_partial_method_with_body()
+        {
+            const string code = @"
+public partial class MyClass  
+{
+    partial void Method();
+}
+
+public partial class MyClass 
+{
+    partial void Method()
+    {
+       // do stuff
+    }
+}";
+
+            var usages = await FindSymbolsAsync(code);
+            var methodSymbol = usages.QuickFixes.Cast<SymbolLocation>().First(x => x.Kind == SymbolKind.Method.ToString());
+
+            // should find the occurrance with body
+            Assert.Equal(8, methodSymbol.Line);
         }
 
         [Fact]

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindSymbolsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindSymbolsFacts.cs
@@ -3,8 +3,7 @@ using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Models.FindSymbols;
 using OmniSharp.Roslyn.CSharp.Services.Navigation;
-using Microsoft.CodeAnalysis;
-using TestUtility;
+using Microsoft.CodeAnalysis;using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
@@ -28,6 +28,33 @@ class {|def:Foo|} {
             await TestGoToSourceAsync(testFile);
         }
 
+        [Theory]
+        [InlineData("bar.cs")]
+        [InlineData("bar.csx")]
+        public async Task ReturnsPartialMethodDefinitionWithBody(string filename)
+        {
+            var testFile = new TestFile(filename, @"
+    public partial class MyClass 
+    {
+        public MyClass()
+        {
+            Met$$hod();
+        }
+        
+        partial void {|def:Method|}()
+        {
+            //do stuff
+        }
+    }
+
+    public partial class MyClass
+    {
+        partial void {|def:Method|}();
+    }");
+
+            await TestGoToSourceAsync(testFile);
+        }
+
         [Fact]
         public async Task ReturnsDefinitionInDifferentFile()
         {


### PR DESCRIPTION
At the moment, when we have the following code:

```
public partial class MyClass 
{
     public MyClass()
    {
          Method();
     } 

      partial void Method()
      {
         Console.WriteLine("foo");
      }
}

  public partial class MyClass  
  {
      partial void Method();
  }
```

 - using `ctrl+T` in VS Code, and typing `Method()` will always send the user to the one without body
 - using "go to definition" in VS Code over the method invocation, will also always send the user to the one without body

This PR ensures that we send the caret to the version with body instead.