### PR TITLE
removed suppressing CS1024 in scripts

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticService.cs
@@ -148,13 +148,6 @@ namespace OmniSharp.Workers.Diagnostics
                     var semanticModel = await document.GetSemanticModelAsync();
                     IEnumerable<Diagnostic> diagnostics = semanticModel.GetDiagnostics();
 
-                    //script files can have custom directives such as #load which will be deemed invalid by Roslyn
-                    //we suppress the CS1024 diagnostic for script files for this reason. Roslyn will fix it later too, so this is temporary.
-                    if (document.SourceCodeKind != SourceCodeKind.Regular)
-                    {
-                        diagnostics = diagnostics.Where(diagnostic => diagnostic.Id != "CS1024");
-                    }
-
                     foreach (var quickFix in diagnostics.Select(MakeQuickFix))
                     {
                         var existingQuickFix = items.FirstOrDefault(q => q.Equals(quickFix));


### PR DESCRIPTION
This is a leftover from old scripting logic. It's not needed anymore because we now use the [default](https://github.com/OmniSharp/omnisharp-roslyn/blob/dev/src/OmniSharp.Script/ScriptProjectSystem.cs#L50) `#load` resolver.