### PR TITLE
Fix solution parsing for Unity solutions with multiple projects

### DIFF
--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -5,7 +5,6 @@ using System.Composition;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Build.Construction;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Configuration;
@@ -18,6 +17,7 @@ using OmniSharp.Models.WorkspaceInformation;
 using OmniSharp.MSBuild.Models;
 using OmniSharp.MSBuild.Models.Events;
 using OmniSharp.MSBuild.ProjectFile;
+using OmniSharp.MSBuild.SolutionParsing;
 using OmniSharp.Options;
 using OmniSharp.Services;
 
@@ -140,15 +140,15 @@ namespace OmniSharp.MSBuild
             var processedProjects = new HashSet<string>();
             var result = new List<string>();
 
-            foreach (var project in solutionFile.ProjectsInOrder)
+            foreach (var project in solutionFile.ProjectBlocks)
             {
-                if (project.ProjectType == SolutionProjectType.SolutionFolder)
+                if (project.Kind == ProjectKind.SolutionFolder)
                 {
                     continue;
                 }
 
                 // Solution files are assumed to contain relative paths to project files with Windows-style slashes.
-                var projectFilePath = project.RelativePath.Replace('\\', Path.DirectorySeparatorChar);
+                var projectFilePath = project.ProjectPath.Replace('\\', Path.DirectorySeparatorChar);
                 projectFilePath = Path.Combine(_environment.TargetDirectory, projectFilePath);
                 projectFilePath = Path.GetFullPath(projectFilePath);
 
@@ -158,7 +158,7 @@ namespace OmniSharp.MSBuild
                     continue;
                 }
 
-                if (Path.GetExtension(projectFilePath) == ".csproj")
+                if (project.Kind == ProjectKind.CSharpProject)
                 {
                     result.Add(projectFilePath);
                 }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -186,7 +186,10 @@ namespace OmniSharp.MSBuild.ProjectFile
         {
             return References.Any(filePath =>
             {
-                return string.Equals(Path.GetFileName(filePath), "UnityEngine.dll", StringComparison.OrdinalIgnoreCase);
+                var fileName = Path.GetFileName(filePath);
+
+                return string.Equals(fileName, "UnityEngine.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(fileName, "UnityEditor.dll", StringComparison.OrdinalIgnoreCase);
             });
         }
 

--- a/src/OmniSharp.MSBuild/SolutionParsing/Constants.cs
+++ b/src/OmniSharp.MSBuild/SolutionParsing/Constants.cs
@@ -1,0 +1,14 @@
+﻿namespace OmniSharp.MSBuild.SolutionParsing
+{
+    internal class Constants
+    {
+        public const string Invalid_project_block_expected_after_Project = "Invalid project block, expected \"=\" after Project.";
+        public const string Invalid_project_block_expected_after_project_name = "Invalid project block, expected \",\" after project name.";
+        public const string Invalid_project_block_expected_after_project_path = "Invalid project block, expected \",\" after project path.";
+        public const string Expected_0 = "Expected {0}.";
+        public const string _0_must_be_a_non_null_and_non_empty_string = "\"{0}\" must be a non-null and non-empty string.";
+        public const string Expected_header_colon_0 = "Expected header: \"{0}\".";
+        public const string Expected_end_of_file = "Expected end-of-file.";
+        public const string Expected_0_line = "Expected {0} line.";
+    }
+}

--- a/src/OmniSharp.MSBuild/SolutionParsing/LineScanner.cs
+++ b/src/OmniSharp.MSBuild/SolutionParsing/LineScanner.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// This is a modified copy originally taken from https://github.com/dotnet/roslyn/blob/0d8c31c4531080a822749cd87d6ce77a20ca28ef/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/LineScanner.cs
+
+using System;
+
+namespace OmniSharp.MSBuild.SolutionParsing
+{
+    internal class LineScanner
+    {
+        private readonly string _line;
+        private int _currentPosition;
+
+        public LineScanner(string line)
+        {
+            _line = line;
+        }
+
+        public string ReadUpToAndEat(string delimiter)
+        {
+            int index = _line.IndexOf(delimiter, _currentPosition, StringComparison.Ordinal);
+
+            if (index == -1)
+            {
+                return ReadRest();
+            }
+            else
+            {
+                var upToDelimiter = _line.Substring(_currentPosition, index - _currentPosition);
+                _currentPosition = index + delimiter.Length;
+                return upToDelimiter;
+            }
+        }
+
+        public string ReadRest()
+        {
+            var rest = _line.Substring(_currentPosition);
+            _currentPosition = _line.Length;
+            return rest;
+        }
+    }
+}

--- a/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
+++ b/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// This is a modified copy originally taken from https://github.com/dotnet/roslyn/blob/0a2f70279c4d0125a51a5751dadff345268ece58/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/ProjectBlock.cs
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text;
+
+namespace OmniSharp.MSBuild.SolutionParsing
+{
+    internal sealed partial class ProjectBlock
+    {
+        private static readonly Guid s_csProjectGuid = new Guid("FAE04EC0-301F-11D3-BF4B-00C04F79EFBC");
+        private static readonly Guid s_cpsProjectGuid = new Guid("13B669BE-BB05-4DDF-9536-439F39A36129"); // Used by the .NET CLI when it manipulates solution files
+        private static readonly Guid s_cpsCsProjectGuid = new Guid("9A19103F-16F7-4668-BE54-9A1E7A4F7556");
+        private static readonly Guid s_solutionFolderGuid = new Guid("2150E333-8FDC-42A3-9474-1A3956D46DE8");
+
+        public ProjectKind Kind { get; }
+        public Guid ProjectTypeGuid { get; }
+        public string ProjectName { get; }
+        public string ProjectPath { get; }
+        public Guid ProjectGuid { get; }
+        public ReadOnlyCollection<SectionBlock> ProjectSections { get; }
+
+        private ProjectBlock(Guid projectTypeGuid, string projectName, string projectPath, Guid projectGuid, ReadOnlyCollection<SectionBlock> projectSections)
+        {
+            if (string.IsNullOrEmpty(projectName))
+            {
+                throw new ArgumentException(string.Format(Constants._0_must_be_a_non_null_and_non_empty_string, "projectName"));
+            }
+
+            if (string.IsNullOrEmpty(projectPath))
+            {
+                throw new ArgumentException(string.Format(Constants._0_must_be_a_non_null_and_non_empty_string, "projectPath"));
+            }
+
+            ProjectTypeGuid = projectTypeGuid;
+            ProjectName = projectName;
+            ProjectPath = projectPath;
+            ProjectGuid = projectGuid;
+            ProjectSections = projectSections;
+
+            if (projectTypeGuid == s_csProjectGuid ||
+                projectTypeGuid == s_cpsCsProjectGuid ||
+                projectTypeGuid == s_cpsProjectGuid)
+            {
+                Kind = ProjectKind.CSharpProject;
+            }
+            else if (projectTypeGuid == s_solutionFolderGuid)
+            {
+                Kind = ProjectKind.SolutionFolder;
+            }
+            else
+            {
+                Kind = ProjectKind.Unknown;
+            }
+        }
+
+        internal string GetText()
+        {
+            var builder = new StringBuilder();
+
+            builder.AppendFormat("Project(\"{0}\") = \"{1}\", \"{2}\", \"{3}\"", ProjectTypeGuid.ToString("B").ToUpper(), ProjectName, ProjectPath, ProjectGuid.ToString("B").ToUpper());
+            builder.AppendLine();
+
+            foreach (var block in ProjectSections)
+            {
+                builder.Append(block.GetText(indent: 1));
+            }
+
+            builder.AppendLine("EndProject");
+
+            return builder.ToString();
+        }
+
+        internal static ProjectBlock Parse(TextReader reader)
+        {
+            var startLine = reader.ReadLine().TrimStart(null);
+            var scanner = new LineScanner(startLine);
+
+            if (scanner.ReadUpToAndEat("(\"") != "Project")
+            {
+                throw new Exception(string.Format(Constants.Expected_0, "Project"));
+            }
+
+            var projectTypeGuid = Guid.Parse(scanner.ReadUpToAndEat("\")"));
+
+            // Read chars up to next quote, must contain "=" with optional leading/trailing whitespaces.
+            if (scanner.ReadUpToAndEat("\"").Trim() != "=")
+            {
+                throw new Exception(Constants.Invalid_project_block_expected_after_Project);
+            }
+
+            var projectName = scanner.ReadUpToAndEat("\"");
+
+            // Read chars up to next quote, must contain "," with optional leading/trailing whitespaces.
+            if (scanner.ReadUpToAndEat("\"").Trim() != ",")
+            {
+                throw new Exception(Constants.Invalid_project_block_expected_after_project_name);
+            }
+
+            var projectPath = scanner.ReadUpToAndEat("\"");
+
+            // Read chars up to next quote, must contain "," with optional leading/trailing whitespaces.
+            if (scanner.ReadUpToAndEat("\"").Trim() != ",")
+            {
+                throw new Exception(Constants.Invalid_project_block_expected_after_project_path);
+            }
+
+            var projectGuid = Guid.Parse(scanner.ReadUpToAndEat("\""));
+
+            var projectSections = new List<SectionBlock>();
+
+            while (char.IsWhiteSpace((char)reader.Peek()))
+            {
+                projectSections.Add(SectionBlock.Parse(reader));
+            }
+
+            // Expect to see "EndProject" but be tolerant with missing tags as in Dev12. 
+            // Instead, we may see either P' for "Project" or 'G' for "Global", which will be handled next.
+            if (reader.Peek() != 'P' && reader.Peek() != 'G')
+            {
+                if (reader.ReadLine() != "EndProject")
+                {
+                    throw new Exception(string.Format(Constants.Expected_0, "EndProject"));
+                }
+            }
+
+            return new ProjectBlock(projectTypeGuid, projectName, projectPath, projectGuid, projectSections.AsReadOnly());
+        }
+    }
+}

--- a/src/OmniSharp.MSBuild/SolutionParsing/ProjectKind.cs
+++ b/src/OmniSharp.MSBuild/SolutionParsing/ProjectKind.cs
@@ -1,0 +1,9 @@
+﻿namespace OmniSharp.MSBuild.SolutionParsing
+{
+    public enum ProjectKind
+    {
+        CSharpProject,
+        SolutionFolder,
+        Unknown
+    }
+}

--- a/src/OmniSharp.MSBuild/SolutionParsing/SectionBlock.cs
+++ b/src/OmniSharp.MSBuild/SolutionParsing/SectionBlock.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// This is a modified copy originally taken from https://github.com/dotnet/roslyn/blob/0a2f70279c4d0125a51a5751dadff345268ece58/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/SectionBlock.cs
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text;
+
+namespace OmniSharp.MSBuild.SolutionParsing
+{
+    /// <summary>
+    /// Represents a SectionBlock in a .sln file. Section blocks are of the form:
+    /// 
+    /// Type(ParenthesizedName) = Value
+    ///     Key = Value
+    ///     [more keys/values]
+    /// EndType
+    /// </summary>
+    internal sealed partial class SectionBlock
+    {
+        public string Type { get; }
+        public string ParenthesizedName { get; }
+        public string Value { get; }
+        public ReadOnlyCollection<KeyValuePair<string, string>> KeyValuePairs { get; }
+
+        private SectionBlock(string type, string parenthesizedName, string value, ReadOnlyCollection<KeyValuePair<string, string>> keyValuePairs)
+        {
+            if (string.IsNullOrEmpty(type))
+            {
+                throw new ArgumentException(string.Format(Constants._0_must_be_a_non_null_and_non_empty_string, "type"));
+            }
+
+            if (string.IsNullOrEmpty(parenthesizedName))
+            {
+                throw new ArgumentException(string.Format(Constants._0_must_be_a_non_null_and_non_empty_string, "parenthesizedName"));
+            }
+
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new ArgumentException(string.Format(Constants._0_must_be_a_non_null_and_non_empty_string, "value"));
+            }
+
+            Type = type;
+            ParenthesizedName = parenthesizedName;
+            Value = value;
+            KeyValuePairs = keyValuePairs;
+        }
+
+        internal string GetText(int indent)
+        {
+            var builder = new StringBuilder();
+
+            builder.Append('\t', indent);
+            builder.AppendFormat("{0}({1}) = ", Type, ParenthesizedName);
+            builder.AppendLine(Value);
+
+            foreach (var pair in KeyValuePairs)
+            {
+                builder.Append('\t', indent + 1);
+                builder.Append(pair.Key);
+                builder.Append(" = ");
+                builder.AppendLine(pair.Value);
+            }
+
+            builder.Append('\t', indent);
+            builder.AppendFormat("End{0}", Type);
+            builder.AppendLine();
+
+            return builder.ToString();
+        }
+
+        internal static SectionBlock Parse(TextReader reader)
+        {
+            string startLine;
+            while ((startLine = reader.ReadLine()) != null)
+            {
+                startLine = startLine.TrimStart(null);
+                if (startLine != string.Empty)
+                {
+                    break;
+                }
+            }
+
+            var scanner = new LineScanner(startLine);
+
+            var type = scanner.ReadUpToAndEat("(");
+            var parenthesizedName = scanner.ReadUpToAndEat(") = ");
+            var sectionValue = scanner.ReadRest();
+
+            var keyValuePairs = new List<KeyValuePair<string, string>>();
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                line = line.TrimStart(null);
+
+                // ignore empty lines
+                if (line == string.Empty)
+                {
+                    continue;
+                }
+
+                if (line == "End" + type)
+                {
+                    break;
+                }
+
+                scanner = new LineScanner(line);
+                var key = scanner.ReadUpToAndEat(" = ");
+                var value = scanner.ReadRest();
+
+                keyValuePairs.Add(new KeyValuePair<string, string>(key, value));
+            }
+
+            return new SectionBlock(type, parenthesizedName, sectionValue, keyValuePairs.AsReadOnly());
+        }
+    }
+}

--- a/src/OmniSharp.MSBuild/SolutionParsing/SolutionFile.cs
+++ b/src/OmniSharp.MSBuild/SolutionParsing/SolutionFile.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// This is a modified copy originally taken from https://github.com/dotnet/roslyn/blob/0a2f70279c4d0125a51a5751dadff345268ece58/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/SolutionFile.cs
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace OmniSharp.MSBuild.SolutionParsing
+{
+    internal sealed partial class SolutionFile
+    {
+        public ReadOnlyCollection<string> HeaderLines { get; }
+        public string VisualStudioVersionLineOpt { get; }
+        public string MinimumVisualStudioVersionLineOpt { get; }
+        public ReadOnlyCollection<ProjectBlock> ProjectBlocks { get; }
+        public ReadOnlyCollection<SectionBlock> GlobalSectionBlocks { get; }
+
+        private SolutionFile(
+            ReadOnlyCollection<string> headerLines,
+            string visualStudioVersionLineOpt,
+            string minimumVisualStudioVersionLineOpt,
+            ReadOnlyCollection<ProjectBlock> projectBlocks,
+            ReadOnlyCollection<SectionBlock> globalSectionBlocks)
+        {
+            HeaderLines = headerLines ?? throw new ArgumentNullException(nameof(headerLines));
+            VisualStudioVersionLineOpt = visualStudioVersionLineOpt;
+            MinimumVisualStudioVersionLineOpt = minimumVisualStudioVersionLineOpt;
+            ProjectBlocks = projectBlocks ?? throw new ArgumentNullException(nameof(projectBlocks));
+            GlobalSectionBlocks = globalSectionBlocks ?? throw new ArgumentNullException(nameof(globalSectionBlocks));
+        }
+
+        public string GetText()
+        {
+            var builder = new StringBuilder();
+
+            builder.AppendLine();
+
+            foreach (var headerLine in HeaderLines)
+            {
+                builder.AppendLine(headerLine);
+            }
+
+            foreach (var block in ProjectBlocks)
+            {
+                builder.Append(block.GetText());
+            }
+
+            builder.AppendLine("Global");
+
+            foreach (var block in GlobalSectionBlocks)
+            {
+                builder.Append(block.GetText(indent: 1));
+            }
+
+            builder.AppendLine("EndGlobal");
+
+            return builder.ToString();
+        }
+
+        public static SolutionFile Parse(string solutionFileName)
+        {
+            using (var stream = File.OpenRead(solutionFileName))
+            using (var reader = new StreamReader(stream))
+            {
+                return Parse(reader);
+            }
+        }
+
+        public static SolutionFile Parse(TextReader reader)
+        {
+            var headerLines = new List<string>();
+
+            var headerLine1 = GetNextNonEmptyLine(reader);
+            if (headerLine1 == null || !headerLine1.StartsWith("Microsoft Visual Studio Solution File", StringComparison.Ordinal))
+            {
+                throw new Exception(string.Format(Constants.Expected_header_colon_0, "Microsoft Visual Studio Solution File"));
+            }
+
+            headerLines.Add(headerLine1);
+
+            // skip comment lines and empty lines
+            while (reader.Peek() != -1 && "#\r\n".Contains((char)reader.Peek()))
+            {
+                headerLines.Add(reader.ReadLine());
+            }
+
+            string visualStudioVersionLineOpt = null;
+            if (reader.Peek() == 'V')
+            {
+                visualStudioVersionLineOpt = GetNextNonEmptyLine(reader);
+                if (!visualStudioVersionLineOpt.StartsWith("VisualStudioVersion", StringComparison.Ordinal))
+                {
+                    throw new Exception(string.Format(Constants.Expected_header_colon_0, "VisualStudioVersion"));
+                }
+            }
+
+            string minimumVisualStudioVersionLineOpt = null;
+            if (reader.Peek() == 'M')
+            {
+                minimumVisualStudioVersionLineOpt = GetNextNonEmptyLine(reader);
+                if (!minimumVisualStudioVersionLineOpt.StartsWith("MinimumVisualStudioVersion", StringComparison.Ordinal))
+                {
+                    throw new Exception(string.Format(Constants.Expected_header_colon_0, "MinimumVisualStudioVersion"));
+                }
+            }
+
+            var projectBlocks = new List<ProjectBlock>();
+
+            // Parse project blocks while we have them
+            while (reader.Peek() == 'P')
+            {
+                projectBlocks.Add(ProjectBlock.Parse(reader));
+                while (reader.Peek() != -1 && "#\r\n".Contains((char)reader.Peek()))
+                {
+                    // Comments and Empty Lines between the Project Blocks are skipped
+                    reader.ReadLine();
+                }
+            }
+
+            // We now have a global block
+            var globalSectionBlocks = ParseGlobal(reader);
+
+            // We should now be at the end of the file
+            if (reader.Peek() != -1)
+            {
+                throw new Exception(Constants.Expected_end_of_file);
+            }
+
+            return new SolutionFile(headerLines.AsReadOnly(), visualStudioVersionLineOpt, minimumVisualStudioVersionLineOpt, projectBlocks.AsReadOnly(), globalSectionBlocks);
+        }
+
+        private static readonly ReadOnlyCollection<SectionBlock> s_EmptySectionBlocks = new ReadOnlyCollection<SectionBlock>(Array.Empty<SectionBlock>());
+
+        [SuppressMessage("", "RS0001")] // TODO: This suppression should be removed once we have rulesets in place for Roslyn.sln
+        private static ReadOnlyCollection<SectionBlock> ParseGlobal(TextReader reader)
+        {
+            if (reader.Peek() == -1)
+            {
+                return s_EmptySectionBlocks;
+            }
+
+            if (GetNextNonEmptyLine(reader) != "Global")
+            {
+                throw new Exception(string.Format(Constants.Expected_0_line, "Global"));
+            }
+
+            var globalSectionBlocks = new List<SectionBlock>();
+
+            // The blocks inside here are indented
+            while (reader.Peek() != -1 && char.IsWhiteSpace((char)reader.Peek()))
+            {
+                globalSectionBlocks.Add(SectionBlock.Parse(reader));
+            }
+
+            if (GetNextNonEmptyLine(reader) != "EndGlobal")
+            {
+                throw new Exception(string.Format(Constants.Expected_0_line, "EndGlobal"));
+            }
+
+            // Consume potential empty lines at the end of the global block
+            while (reader.Peek() != -1 && "\r\n".Contains((char)reader.Peek()))
+            {
+                reader.ReadLine();
+            }
+
+            return globalSectionBlocks.AsReadOnly();
+        }
+
+        private static string GetNextNonEmptyLine(TextReader reader)
+        {
+            string line = null;
+
+            do
+            {
+                line = reader.ReadLine();
+            }
+            while (line != null && line.Trim() == string.Empty);
+
+            return line;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #839

Solutions generated by Unity often have multiple projects with the same name but, the MSBuild solution parsing API throws an error if there are any projects with a duplicated name (this error can be seen when passing a Unity solution to MSBuild at the command-line). However, Visual Studio is resilient to solutions where projects have the same name, so we should be too. This change restores the solution parsing logic copied from https://github.com/dotnet/roslyn.