### PR TITLE
replaced `InteractiveScriptGlobals` with `CommandLineScriptGlobals ` as CSX host object type

### DIFF
--- a/src/OmniSharp.Script/ScriptContextModel.cs
+++ b/src/OmniSharp.Script/ScriptContextModel.cs
@@ -10,7 +10,7 @@ namespace OmniSharp.Script
         {
             Path = csxPath;
             ImplicitAssemblyReferences = implicitAssemblyReferences;
-            CommonUsings = ScriptProjectSystem.DefaultNamespaces;
+            CommonUsings = ScriptHelper.DefaultNamespaces;
             GlobalsType = project.HostObjectType;
         }
 

--- a/src/OmniSharp.Script/ScriptHelper.cs
+++ b/src/OmniSharp.Script/ScriptHelper.cs
@@ -59,7 +59,7 @@ namespace OmniSharp.Script
             return compilationOptions;
         });
 
-        public static ProjectInfo CreateProject(string csxFileName, IEnumerable<MetadataReference> references)
+        public static ProjectInfo CreateProject(string csxFileName, IEnumerable<MetadataReference> references, IEnumerable<string> namespaces = null)
         {
             var project = ProjectInfo.Create(
                 id: ProjectId.CreateNewId(),
@@ -67,7 +67,7 @@ namespace OmniSharp.Script
                 name: csxFileName,
                 assemblyName: $"{csxFileName}.dll",
                 language: LanguageNames.CSharp,
-                compilationOptions: CompilationOptions.Value,
+                compilationOptions: namespaces == null ? CompilationOptions.Value : CompilationOptions.Value.WithUsings(namespaces),
                 metadataReferences: references,
                 parseOptions: ParseOptions,
                 isSubmission: true,

--- a/src/OmniSharp.Script/ScriptHelper.cs
+++ b/src/OmniSharp.Script/ScriptHelper.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Scripting;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+
+namespace OmniSharp.Script
+{
+    public static class ScriptHelper
+    {
+        // aligned with CSI.exe
+        // https://github.com/dotnet/roslyn/blob/version-2.0.0-rc3/src/Interactive/csi/csi.rsp
+        internal static readonly IEnumerable<string> DefaultNamespaces = new[]
+        {
+            "System",
+            "System.IO",
+            "System.Collections.Generic",
+            "System.Console",
+            "System.Diagnostics",
+            "System.Dynamic",
+            "System.Linq",
+            "System.Linq.Expressions",
+            "System.Text",
+            "System.Threading.Tasks"
+        };
+
+        private static readonly CSharpParseOptions ParseOptions = new CSharpParseOptions(LanguageVersion.Default, DocumentationMode.Parse, SourceCodeKind.Script);
+
+        private static readonly Lazy<CSharpCompilationOptions> CompilationOptions = new Lazy<CSharpCompilationOptions>(() =>
+        {
+            var compilationOptions = new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                usings: DefaultNamespaces,
+                allowUnsafe: true,
+                metadataReferenceResolver: new CachingScriptMetadataResolver(),
+                sourceReferenceResolver: ScriptSourceResolver.Default,
+                assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default).
+                WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic>
+                {
+                    // ensure that specific warnings about assembly references are always suppressed
+                    // https://github.com/dotnet/roslyn/issues/5501
+                    { "CS1701", ReportDiagnostic.Suppress },
+                    { "CS1702", ReportDiagnostic.Suppress },
+                    { "CS1705", ReportDiagnostic.Suppress }
+                 });
+
+            var topLevelBinderFlagsProperty = typeof(CSharpCompilationOptions).GetProperty("TopLevelBinderFlags", BindingFlags.Instance | BindingFlags.NonPublic);
+            var binderFlagsType = typeof(CSharpCompilationOptions).GetTypeInfo().Assembly.GetType("Microsoft.CodeAnalysis.CSharp.BinderFlags");
+
+            var ignoreCorLibraryDuplicatedTypesMember = binderFlagsType?.GetField("IgnoreCorLibraryDuplicatedTypes", BindingFlags.Static | BindingFlags.Public);
+            var ignoreCorLibraryDuplicatedTypesValue = ignoreCorLibraryDuplicatedTypesMember?.GetValue(null);
+            if (ignoreCorLibraryDuplicatedTypesValue != null)
+            {
+                topLevelBinderFlagsProperty?.SetValue(compilationOptions, ignoreCorLibraryDuplicatedTypesValue);
+            }
+
+            return compilationOptions;
+        });
+
+        public static ProjectInfo CreateProject(string csxFileName, IEnumerable<MetadataReference> references)
+        {
+            var project = ProjectInfo.Create(
+                id: ProjectId.CreateNewId(),
+                version: VersionStamp.Create(),
+                name: csxFileName,
+                assemblyName: $"{csxFileName}.dll",
+                language: LanguageNames.CSharp,
+                compilationOptions: CompilationOptions.Value,
+                metadataReferences: references,
+                parseOptions: ParseOptions,
+                isSubmission: true,
+                hostObjectType: typeof(CommandLineScriptGlobals));
+
+            return project;
+        }
+    }
+}

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -185,7 +185,7 @@ namespace OmniSharp.Script
                         metadataReferences: commonReferences,
                         parseOptions: ParseOptions,
                         isSubmission: true,
-                        hostObjectType: typeof(InteractiveScriptGlobals));
+                        hostObjectType: typeof(CommandLineScriptGlobals));
 
                     // add CSX project to workspace
                     _workspace.AddProject(project);

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -7,8 +7,6 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Scripting;
-using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.DotNet.ProjectModel;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyModel;
@@ -21,56 +19,7 @@ namespace OmniSharp.Script
     [Export(typeof(IProjectSystem)), Shared]
     public class ScriptProjectSystem : IProjectSystem
     {
-        // aligned with CSI.exe
-        // https://github.com/dotnet/roslyn/blob/version-2.0.0-rc3/src/Interactive/csi/csi.rsp
-        internal static readonly IEnumerable<string> DefaultNamespaces = new[]
-        {
-            "System",
-            "System.IO",
-            "System.Collections.Generic",
-            "System.Console",
-            "System.Diagnostics",
-            "System.Dynamic",
-            "System.Linq",
-            "System.Linq.Expressions",
-            "System.Text",
-            "System.Threading.Tasks"
-        };
-
         private const string CsxExtension = ".csx";
-        private static readonly CSharpParseOptions ParseOptions = new CSharpParseOptions(LanguageVersion.Default, DocumentationMode.Parse, SourceCodeKind.Script);
-
-        private static readonly Lazy<CSharpCompilationOptions> CompilationOptions = new Lazy<CSharpCompilationOptions>(() =>
-        {
-            var compilationOptions = new CSharpCompilationOptions(
-                OutputKind.DynamicallyLinkedLibrary,
-                usings: DefaultNamespaces,
-                allowUnsafe: true,
-                metadataReferenceResolver: new CachingScriptMetadataResolver(),
-                sourceReferenceResolver: ScriptSourceResolver.Default,
-                assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default).
-                WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic>
-                {
-                    // ensure that specific warnings about assembly references are always suppressed
-                    // https://github.com/dotnet/roslyn/issues/5501
-                    { "CS1701", ReportDiagnostic.Suppress },
-                    { "CS1702", ReportDiagnostic.Suppress },
-                    { "CS1705", ReportDiagnostic.Suppress }
-                 });
-
-            var topLevelBinderFlagsProperty = typeof(CSharpCompilationOptions).GetProperty("TopLevelBinderFlags", BindingFlags.Instance | BindingFlags.NonPublic);
-            var binderFlagsType = typeof(CSharpCompilationOptions).GetTypeInfo().Assembly.GetType("Microsoft.CodeAnalysis.CSharp.BinderFlags");
-
-            var ignoreCorLibraryDuplicatedTypesMember = binderFlagsType?.GetField("IgnoreCorLibraryDuplicatedTypes", BindingFlags.Static | BindingFlags.Public);
-            var ignoreCorLibraryDuplicatedTypesValue = ignoreCorLibraryDuplicatedTypesMember?.GetValue(null);
-            if (ignoreCorLibraryDuplicatedTypesValue != null)
-            {
-                topLevelBinderFlagsProperty?.SetValue(compilationOptions, ignoreCorLibraryDuplicatedTypesValue);
-            }
-
-            return compilationOptions;
-        });
-
         private readonly MetadataFileReferenceCache _metadataFileReferenceCache;
 
         // used for tracking purposes only
@@ -175,17 +124,7 @@ namespace OmniSharp.Script
                 try
                 {
                     var csxFileName = Path.GetFileName(csxPath);
-                    var project = ProjectInfo.Create(
-                        id: ProjectId.CreateNewId(),
-                        version: VersionStamp.Create(),
-                        name: csxFileName,
-                        assemblyName: $"{csxFileName}.dll",
-                        language: LanguageNames.CSharp,
-                        compilationOptions: CompilationOptions.Value,
-                        metadataReferences: commonReferences,
-                        parseOptions: ParseOptions,
-                        isSubmission: true,
-                        hostObjectType: typeof(CommandLineScriptGlobals));
+                    var project = ScriptHelper.CreateProject(csxFileName, commonReferences);
 
                     // add CSX project to workspace
                     _workspace.AddProject(project);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -310,7 +310,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         public async Task Returns_host_object_members_in_csx()
         {
             const string source =
-                "Pri$$";
+                "Prin$$";
 
             var completions = await FindCompletionsAsync("dummy.csx", source);
             ContainsCompletions(completions.Select(c => c.CompletionText), new[] { "Print", "PrintOptions" }); 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -306,6 +306,16 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             ContainsCompletions(completions.Select(c => c.CompletionText).Take(1), "MyClass1");
         }
 
+        [Fact]
+        public async Task Returns_host_object_members_in_csx()
+        {
+            const string source =
+                "Pri$$";
+
+            var completions = await FindCompletionsAsync("dummy.csx", source);
+            ContainsCompletions(completions.Select(c => c.CompletionText), new[] { "Print", "PrintOptions" }); 
+        }
+
         private void ContainsCompletions(IEnumerable<string> completions, params string[] expected)
         {
             if (!completions.SequenceEqual(expected))

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -20,17 +20,15 @@ namespace TestUtility
 
         public static void AddCsxProjectToWorkspace(OmniSharpWorkspace workspace, TestFile testFile)
         {
-            var references = GetReferences();
-            var project = ScriptHelper.CreateProject(testFile.FileName, references);
-
+            var project = ScriptHelper.CreateProject(testFile.FileName, GetReferences());
             workspace.AddProject(project);
+
             var documentInfo = DocumentInfo.Create(
                 id: DocumentId.CreateNewId(project.Id),
                 name: testFile.FileName,
                 sourceCodeKind: SourceCodeKind.Script,
                 loader: TextLoader.From(TextAndVersion.Create(testFile.Content.Text, VersionStamp.Create())),
                 filePath: testFile.FileName);
-
             workspace.AddDocument(documentInfo);
         }
 

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using OmniSharp;
+using OmniSharp.Script;
 using OmniSharp.Services;
 
 namespace TestUtility
@@ -20,22 +21,7 @@ namespace TestUtility
         public static void AddCsxProjectToWorkspace(OmniSharpWorkspace workspace, TestFile testFile)
         {
             var references = GetReferences();
-            var parseOptions = new CSharpParseOptions(
-                LanguageVersion.Default,
-                DocumentationMode.Parse,
-                SourceCodeKind.Script);
-
-            var project = ProjectInfo.Create(
-                id: ProjectId.CreateNewId(),
-                version: VersionStamp.Create(),
-                name: testFile.FileName,
-                assemblyName: $"{testFile.FileName}.dll",
-                language: LanguageNames.CSharp,
-                filePath: testFile.FileName,
-                compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
-                metadataReferences: references,
-                parseOptions: parseOptions,
-                isSubmission: true);
+            var project = ScriptHelper.CreateProject(testFile.FileName, references);
 
             workspace.AddProject(project);
             var documentInfo = DocumentInfo.Create(

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -3,11 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Scripting.Hosting;using OmniSharp;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+using OmniSharp;
 using OmniSharp.Script;
 using OmniSharp.Services;
-
-
 
 namespace TestUtility
 {

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using OmniSharp;
+using Microsoft.CodeAnalysis.Scripting.Hosting;using OmniSharp;
 using OmniSharp.Script;
 using OmniSharp.Services;
+
+
 
 namespace TestUtility
 {
@@ -20,7 +22,8 @@ namespace TestUtility
 
         public static void AddCsxProjectToWorkspace(OmniSharpWorkspace workspace, TestFile testFile)
         {
-            var project = ScriptHelper.CreateProject(testFile.FileName, GetReferences());
+            var references = GetReferences();
+            var project = ScriptHelper.CreateProject(testFile.FileName, references.Union(new[] { MetadataReference.CreateFromFile(typeof(CommandLineScriptGlobals).GetTypeInfo().Assembly.Location) }), Enumerable.Empty<string>());
             workspace.AddProject(project);
 
             var documentInfo = DocumentInfo.Create(

--- a/tests/TestUtility/TestUtility.csproj
+++ b/tests/TestUtility/TestUtility.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\src\OmniSharp.Host\OmniSharp.Host.csproj" />
     <ProjectReference Include="..\..\src\OmniSharp.MSBuild\OmniSharp.MSBuild.csproj" />
     <ProjectReference Include="..\..\src\OmniSharp.Roslyn.CSharp\OmniSharp.Roslyn.CSharp.csproj" />
+    <ProjectReference Include="..\..\src\OmniSharp.Script\OmniSharp.Script.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Replaced `InteractiveScriptGlobals` with `CommandLineScriptGlobals ` as CSX host object type. This is required, because CSI uses `CommandLineScriptGlobals` as host object for CSX script execution. `InteractiveScriptGlobals` is **only** used for REPL mode ([reference](https://github.com/dotnet/roslyn/blob/master/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs#L176-L196)), so naturally it makes sense to offer `CommandLineScriptGlobals` in OmniSharp intellisense. 

As a bonus, I extracted some of the project/compilation set up logic from `ScriptProjectSystem` into `ScriptHelper`. This way, it can be used in the tests as well, to ensure that the test set up is using the same logic as the project system would. This makes tests more reliable than before, where the code to create CSX project/compilation was maintained in tests separately and needed to always stay in sync with project system to be trustworthy.