### PR TITLE
Stop deploying SDKs with OmniSharp

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -179,59 +179,6 @@ Task("SetupMSBuild")
 
     CopyDirectory(msbuildNetCoreAppInstallFolder, msbuildNetCoreAppFolder);
 
-    var sdks = new []
-    {
-        "Microsoft.NET.Sdk",
-        "Microsoft.NET.Sdk.Publish",
-        "Microsoft.NET.Sdk.Web",
-        "Microsoft.NET.Sdk.Web.ProjectSystem",
-        "NuGet.Build.Tasks.Pack"
-    };
-
-    var net46SdkFolder = CombinePaths(msbuildNet46Folder, "Sdks");
-    var netCoreAppSdkFolder = CombinePaths(msbuildNetCoreAppFolder, "Sdks");
-
-    foreach (var sdk in sdks)
-    {
-        var sdkInstallFolder = CombinePaths(env.Folders.Tools, sdk);
-        var net46SdkTargetFolder = CombinePaths(net46SdkFolder, sdk);
-        var netCoreAppSdkTargetFolder = CombinePaths(netCoreAppSdkFolder, sdk);
-
-        CopyDirectory(sdkInstallFolder, net46SdkTargetFolder);
-        CopyDirectory(sdkInstallFolder, netCoreAppSdkTargetFolder);
-
-        // Ensure that we don't leave the .nupkg unnecessarily hanging around.
-        DeleteFiles(CombinePaths(net46SdkTargetFolder, "*.nupkg"));
-        DeleteFiles(CombinePaths(netCoreAppSdkTargetFolder, "*.nupkg"));
-    }
-
-    // Copy NuGet ImportAfter targets
-    var nugetImportAfterTargetsName = "Microsoft.NuGet.ImportAfter.targets";
-    var nugetImportAfterTargetsFolder = CombinePaths("15.0", "Microsoft.Common.targets", "ImportAfter");
-    var nugetImportAfterTargetsPath = CombinePaths(nugetImportAfterTargetsFolder, nugetImportAfterTargetsName);
-
-    CreateDirectory(CombinePaths(msbuildNet46Folder, nugetImportAfterTargetsFolder));
-    CreateDirectory(CombinePaths(msbuildNetCoreAppFolder, nugetImportAfterTargetsFolder));
-
-    CopyFile(CombinePaths(env.Folders.MSBuild, nugetImportAfterTargetsPath), CombinePaths(msbuildNet46Folder, nugetImportAfterTargetsPath));
-    CopyFile(CombinePaths(env.Folders.MSBuild, nugetImportAfterTargetsPath), CombinePaths(msbuildNetCoreAppFolder, nugetImportAfterTargetsPath));
-
-    nugetImportAfterTargetsFolder = CombinePaths("15.0", "SolutionFile", "ImportAfter");
-    nugetImportAfterTargetsPath = CombinePaths(nugetImportAfterTargetsFolder, nugetImportAfterTargetsName);
-
-    CreateDirectory(CombinePaths(msbuildNet46Folder, nugetImportAfterTargetsFolder));
-    CreateDirectory(CombinePaths(msbuildNetCoreAppFolder, nugetImportAfterTargetsFolder));
-
-    CopyFile(CombinePaths(env.Folders.MSBuild, nugetImportAfterTargetsPath), CombinePaths(msbuildNet46Folder, nugetImportAfterTargetsPath));
-    CopyFile(CombinePaths(env.Folders.MSBuild, nugetImportAfterTargetsPath), CombinePaths(msbuildNetCoreAppFolder, nugetImportAfterTargetsPath));
-
-    // Copy NuGet.targets from NuGet.Build.Tasks
-    var nugetTargetsName = "NuGet.targets";
-    var nugetTargetsPath = CombinePaths(env.Folders.Tools, "NuGet.Build.Tasks", "runtimes", "any", "native", nugetTargetsName);
-
-    CopyFile(nugetTargetsPath, CombinePaths(msbuildNet46Folder, nugetTargetsName));
-    CopyFile(nugetTargetsPath, CombinePaths(msbuildNetCoreAppFolder, nugetTargetsName));
-
     // Finally, copy Microsoft.CSharp.Core.targets from Microsoft.Net.Compilers
     var csharpTargetsName = "Microsoft.CSharp.Core.targets";
     var csharpTargetsPath = CombinePaths(env.Folders.Tools, "Microsoft.Net.Compilers", "tools", csharpTargetsName);

--- a/src/OmniSharp.Abstractions/Services/DotNetCliService.cs
+++ b/src/OmniSharp.Abstractions/Services/DotNetCliService.cs
@@ -39,7 +39,6 @@ namespace OmniSharp.Services
             // the .NET CLI is not launched with the wrong values.
             environment.Remove("MSBUILD_EXE_PATH");
             environment.Remove("MSBuildExtensionsPath");
-            environment.Remove("MSBuildSDKsPath");
         }
 
         public void SetDotNetPath(string path)

--- a/src/OmniSharp.Abstractions/Services/DotNetCliService.cs
+++ b/src/OmniSharp.Abstractions/Services/DotNetCliService.cs
@@ -120,6 +120,34 @@ namespace OmniSharp.Services
             return SemanticVersion.Parse(output);
         }
 
+        public DotNetInfo GetInfo(string workingDirectory = null)
+        {
+            Process process;
+            try
+            {
+                process = Start("--info", workingDirectory);
+            }
+            catch
+            {
+                return DotNetInfo.Empty;
+            }
+
+            var lines = new List<string>();
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (!string.IsNullOrWhiteSpace(e.Data))
+                {
+                    lines.Add(e.Data);
+                }
+            };
+
+            process.BeginOutputReadLine();
+
+            process.WaitForExit();
+
+            return DotNetInfo.Parse(lines);
+        }
+
         /// <summary>
         /// Checks to see if this is a "legacy" .NET CLI. If true, this .NET CLI supports project.json
         /// development; otherwise, it supports .csproj development.

--- a/src/OmniSharp.Abstractions/Services/DotNetInfo.cs
+++ b/src/OmniSharp.Abstractions/Services/DotNetInfo.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using NuGet.Versioning;
+
+namespace OmniSharp.Services
+{
+    public class DotNetInfo
+    {
+        public static DotNetInfo Empty { get; } = new DotNetInfo();
+
+        public bool IsEmpty { get; }
+
+        public SemanticVersion Version { get; }
+        public string OSName { get; }
+        public string OSVersion { get; }
+        public string OSPlatform { get; }
+        public string RID { get; }
+        public string BasePath { get; }
+
+        private DotNetInfo()
+        {
+            IsEmpty = true;
+        }
+
+        private DotNetInfo(string version, string osName, string osVersion, string osPlatform, string rid, string basePath)
+        {
+            IsEmpty = false;
+
+            Version = SemanticVersion.Parse(version);
+            OSName = osName;
+            OSVersion = osVersion;
+            OSPlatform = osPlatform;
+            RID = rid;
+            BasePath = basePath;
+        }
+
+        public static DotNetInfo Parse(List<string> lines)
+        {
+            var version = string.Empty;
+            var osName = string.Empty;
+            var osVersion = string.Empty;
+            var osPlatform = string.Empty;
+            var rid = string.Empty;
+            var basePath = string.Empty;
+
+            foreach (var line in lines)
+            {
+                var colonIndex = line.IndexOf(':');
+                if (colonIndex >= 0)
+                {
+                    var name = line.Substring(0, colonIndex).Trim();
+                    var value = line.Substring(colonIndex + 1).Trim();
+
+                    if (name.Equals("Version", StringComparison.OrdinalIgnoreCase))
+                    {
+                        version = value;
+                    }
+                    else if (name.Equals("OS Name", StringComparison.OrdinalIgnoreCase))
+                    {
+                        osName = value;
+                    }
+                    else if (name.Equals("OS Version", StringComparison.OrdinalIgnoreCase))
+                    {
+                        osVersion = value;
+                    }
+                    else if (name.Equals("OS Platform", StringComparison.OrdinalIgnoreCase))
+                    {
+                        osPlatform = value;
+                    }
+                    else if (name.Equals("RID", StringComparison.OrdinalIgnoreCase))
+                    {
+                        rid = value;
+                    }
+                    else if (name.Equals("Base Path", StringComparison.OrdinalIgnoreCase))
+                    {
+                        basePath = value;
+                    }
+                }
+            }
+
+            return new DotNetInfo(version, osName, osVersion, osPlatform, rid, basePath);
+        }
+    }
+}

--- a/src/OmniSharp.MSBuild/Extensions.cs
+++ b/src/OmniSharp.MSBuild/Extensions.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 
 namespace OmniSharp.MSBuild
 {
     internal static class Extensions
     {
-        public static void AddPropertyIfNeeded(this Dictionary<string, string> properties, string name, string userOptionValue, string environmentValue)
+        public static void AddPropertyIfNeeded(this Dictionary<string, string> properties, ILogger logger, string name, string userOptionValue, string environmentValue)
         {
             if (!string.IsNullOrWhiteSpace(userOptionValue))
             {
@@ -15,6 +16,11 @@ namespace OmniSharp.MSBuild
             {
                 // If we have a custom environment value, we should use that.
                 properties.Add(name, environmentValue);
+            }
+
+            if (properties.TryGetValue(name, out var value))
+            {
+                logger.LogDebug($"Using {name}: {value}");
             }
         }
     }

--- a/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
+++ b/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
@@ -8,7 +8,6 @@ namespace OmniSharp.MSBuild
     {
         public const string MSBuildExePathName = "MSBUILD_EXE_PATH";
         public const string MSBuildExtensionsPathName = "MSBuildExtensionsPath";
-        public const string MSBuildSDKsPathName = "MSBuildSDKsPath";
 
         private static bool s_isInitialized;
 
@@ -16,7 +15,6 @@ namespace OmniSharp.MSBuild
 
         private static string s_msbuildExePath;
         private static string s_msbuildExtensionsPath;
-        private static string s_msbuildSDKsPath;
 
         public static bool IsInitialized => s_isInitialized;
 
@@ -47,15 +45,6 @@ namespace OmniSharp.MSBuild
             }
         }
 
-        public static string MSBuildSDKsPath
-        {
-            get
-            {
-                ThrowIfNotInitialized();
-                return s_msbuildSDKsPath;
-            }
-        }
-
         private static void ThrowIfNotInitialized()
         {
             if (!s_isInitialized)
@@ -79,12 +68,11 @@ namespace OmniSharp.MSBuild
                 s_usingVisualStudio = true;
                 s_isInitialized = true;
             }
-            else if (TryWithLocalMSBuild(logger, out var msbuildExePath, out var msbuildExtensionsPath, out var msbuildSDKsPath))
+            else if (TryWithLocalMSBuild(logger, out var msbuildExePath, out var msbuildExtensionsPath))
             {
                 logger.LogInformation("MSBuild will use local OmniSharp installation.");
                 s_msbuildExePath = msbuildExePath;
                 s_msbuildExtensionsPath = msbuildExtensionsPath;
-                s_msbuildSDKsPath = msbuildSDKsPath;
                 s_isInitialized = true;
             }
 
@@ -94,11 +82,10 @@ namespace OmniSharp.MSBuild
             }
         }
 
-        private static bool TryWithLocalMSBuild(ILogger logger, out string msbuildExePath, out string msbuildExtensionsPath, out string msbuildSDKsPath)
+        private static bool TryWithLocalMSBuild(ILogger logger, out string msbuildExePath, out string msbuildExtensionsPath)
         {
             msbuildExePath = null;
             msbuildExtensionsPath = null;
-            msbuildSDKsPath = null;
 
             var msbuildDirectory = FindMSBuildDirectory(logger);
             if (msbuildDirectory == null)
@@ -118,22 +105,11 @@ namespace OmniSharp.MSBuild
             // Set the MSBuildExtensionsPath environment variable to the local msbuild directory.
             msbuildExtensionsPath = msbuildDirectory;
 
-            // Set the MSBuildSDKsPath environment variable to the location of the SDKs.
-            msbuildSDKsPath = FindMSBuildSDKsPath(msbuildDirectory);
-            if (msbuildSDKsPath == null)
-            {
-                logger.LogError("Could not locate MSBuild Sdks path");
-                return false;
-            }
-
             Environment.SetEnvironmentVariable(MSBuildExePathName, msbuildExePath);
             logger.LogInformation($"{MSBuildExePathName} environment variable set to {msbuildExePath}");
 
             Environment.SetEnvironmentVariable(MSBuildExtensionsPathName, msbuildExtensionsPath);
             logger.LogInformation($"{MSBuildExtensionsPathName} environment variable set to {msbuildExtensionsPath}");
-
-            Environment.SetEnvironmentVariable(MSBuildSDKsPathName, msbuildSDKsPath);
-            logger.LogInformation($"{MSBuildSDKsPathName} environment variable set to {msbuildSDKsPath}");
 
             return true;
         }
@@ -200,15 +176,6 @@ namespace OmniSharp.MSBuild
             }
 
             return null;
-        }
-
-        private static string FindMSBuildSDKsPath(string directory)
-        {
-            var msbuildSDKsPath = Path.Combine(directory, "Sdks");
-
-            return Directory.Exists(msbuildSDKsPath)
-                ? msbuildSDKsPath
-                : null;
         }
     }
 }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -70,7 +70,7 @@ namespace OmniSharp.MSBuild.ProjectFile
         }
 
         public static ProjectFileInfo Create(
-            string filePath, string solutionDirectory, ILogger logger,
+            string filePath, string solutionDirectory, string sdksPath, ILogger logger,
             MSBuildOptions options = null, ICollection<MSBuildDiagnosticsMessage> diagnostics = null)
         {
             if (!File.Exists(filePath))
@@ -78,7 +78,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 return null;
             }
 
-            var projectInstance = LoadProject(filePath, solutionDirectory, logger, options, diagnostics, out var targetFrameworks);
+            var projectInstance = LoadProject(filePath, solutionDirectory, sdksPath, logger, options, diagnostics, out var targetFrameworks);
             if (projectInstance == null)
             {
                 return null;
@@ -91,12 +91,12 @@ namespace OmniSharp.MSBuild.ProjectFile
         }
 
         private static ProjectInstance LoadProject(
-            string filePath, string solutionDirectory, ILogger logger,
+            string filePath, string solutionDirectory, string sdksPath, ILogger logger,
             MSBuildOptions options, ICollection<MSBuildDiagnosticsMessage> diagnostics, out ImmutableArray<string> targetFrameworks)
         {
             options = options ?? new MSBuildOptions();
 
-            var globalProperties = GetGlobalProperties(options, solutionDirectory, logger);
+            var globalProperties = GetGlobalProperties(options, solutionDirectory, sdksPath, logger);
 
             var collection = new ProjectCollection(globalProperties);
 
@@ -168,10 +168,10 @@ namespace OmniSharp.MSBuild.ProjectFile
         }
 
         public ProjectFileInfo Reload(
-            string solutionDirectory, ILogger logger,
+            string solutionDirectory, string sdksPath, ILogger logger,
             MSBuildOptions options = null, ICollection<MSBuildDiagnosticsMessage> diagnostics = null)
         {
-            var projectInstance = LoadProject(FilePath, solutionDirectory, logger, options, diagnostics, out var targetFrameworks);
+            var projectInstance = LoadProject(FilePath, solutionDirectory, sdksPath, logger, options, diagnostics, out var targetFrameworks);
             if (projectInstance == null)
             {
                 return null;
@@ -193,7 +193,7 @@ namespace OmniSharp.MSBuild.ProjectFile
             });
         }
 
-        private static Dictionary<string, string> GetGlobalProperties(MSBuildOptions options, string solutionDirectory, ILogger logger)
+        private static Dictionary<string, string> GetGlobalProperties(MSBuildOptions options, string solutionDirectory, string sdksPath, ILogger logger)
         {
             var globalProperties = new Dictionary<string, string>
             {
@@ -211,7 +211,7 @@ namespace OmniSharp.MSBuild.ProjectFile
             globalProperties.AddPropertyIfNeeded(
                 PropertyNames.MSBuildSDKsPath,
                 userOptionValue: options.MSBuildSDKsPath,
-                environmentValue: MSBuildEnvironment.MSBuildSDKsPath);
+                environmentValue: sdksPath);
 
             globalProperties.AddPropertyIfNeeded(
                 PropertyNames.VisualStudioVersion,

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -204,16 +204,19 @@ namespace OmniSharp.MSBuild.ProjectFile
             };
 
             globalProperties.AddPropertyIfNeeded(
+                logger,
                 PropertyNames.MSBuildExtensionsPath,
                 userOptionValue: options.MSBuildExtensionsPath,
                 environmentValue: MSBuildEnvironment.MSBuildExtensionsPath);
 
             globalProperties.AddPropertyIfNeeded(
+                logger,
                 PropertyNames.MSBuildSDKsPath,
                 userOptionValue: options.MSBuildSDKsPath,
                 environmentValue: sdksPath);
 
             globalProperties.AddPropertyIfNeeded(
+                logger,
                 PropertyNames.VisualStudioVersion,
                 userOptionValue: options.VisualStudioVersion,
                 environmentValue: null);

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OmniSharp.MSBuild.ProjectFile;
+using OmniSharp.Services;
 using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
@@ -25,14 +26,23 @@ namespace OmniSharp.MSBuild.Tests
             }
         }
 
+        private static string GetSdksPath(OmniSharpTestHost host)
+        {
+            var dotNetCli = host.GetExport<DotNetCliService>();
+            var info = dotNetCli.GetInfo();
+
+            return Path.Combine(info.BasePath, "Sdks");
+        }
+
         [Fact]
         public async Task HelloWorld_has_correct_property_values()
         {
-            using (var testProejct = await _testAssets.GetTestProjectAsync("HelloWorld"))
+            using (var host = CreateOmniSharpHost())
+            using (var testProject = await _testAssets.GetTestProjectAsync("HelloWorld"))
             {
-                var projectFilePath = Path.Combine(testProejct.Directory, "HelloWorld.csproj");
+                var projectFilePath = Path.Combine(testProject.Directory, "HelloWorld.csproj");
 
-                var projectFileInfo = ProjectFileInfo.Create(projectFilePath, testProejct.Directory, this._logger);
+                var projectFileInfo = ProjectFileInfo.Create(projectFilePath, testProject.Directory, GetSdksPath(host), this._logger);
 
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
@@ -46,11 +56,12 @@ namespace OmniSharp.MSBuild.Tests
         [Fact]
         public async Task HelloWorldSlim_has_correct_property_values()
         {
+            using (var host = CreateOmniSharpHost())
             using (var testProject = await _testAssets.GetTestProjectAsync("HelloWorldSlim"))
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "HelloWorldSlim.csproj");
 
-                var projectFileInfo = ProjectFileInfo.Create(projectFilePath, testProject.Directory, this._logger);
+                var projectFileInfo = ProjectFileInfo.Create(projectFilePath, testProject.Directory, GetSdksPath(host), this._logger);
 
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
@@ -64,11 +75,12 @@ namespace OmniSharp.MSBuild.Tests
         [Fact]
         public async Task NetStandardAndNetCoreApp_has_correct_property_values()
         {
+            using (var host = CreateOmniSharpHost())
             using (var testProject = await _testAssets.GetTestProjectAsync("NetStandardAndNetCoreApp"))
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "NetStandardAndNetCoreApp.csproj");
 
-                var projectFileInfo = ProjectFileInfo.Create(projectFilePath, testProject.Directory, this._logger);
+                var projectFileInfo = ProjectFileInfo.Create(projectFilePath, testProject.Directory, GetSdksPath(host), this._logger);
 
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);

--- a/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
+++ b/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
@@ -29,6 +29,22 @@ namespace OmniSharp.Tests
         }
 
         [Fact]
+        public void LegacyGetInfo()
+        {
+            using (var host = CreateOmniSharpHost(useLegacyDotNetCli: true))
+            {
+                var dotNetCli = host.GetExport<DotNetCliService>();
+
+                var info = dotNetCli.GetInfo();
+
+                Assert.Equal(1, info.Version.Major);
+                Assert.Equal(0, info.Version.Minor);
+                Assert.Equal(0, info.Version.Patch);
+                Assert.Equal("preview2-1-003177", info.Version.Release);
+            }
+        }
+
+        [Fact]
         public void GetVersion()
         {
             using (var host = CreateOmniSharpHost(useLegacyDotNetCli: false))
@@ -41,6 +57,22 @@ namespace OmniSharp.Tests
                 Assert.Equal(0, version.Minor);
                 Assert.Equal(1, version.Patch);
                 Assert.Equal("", version.Release);
+            }
+        }
+
+        [Fact]
+        public void GetInfo()
+        {
+            using (var host = CreateOmniSharpHost(useLegacyDotNetCli: false))
+            {
+                var dotNetCli = host.GetExport<DotNetCliService>();
+
+                var info = dotNetCli.GetInfo();
+
+                Assert.Equal(1, info.Version.Major);
+                Assert.Equal(0, info.Version.Minor);
+                Assert.Equal(1, info.Version.Patch);
+                Assert.Equal("", info.Version.Release);
             }
         }
     }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -2,12 +2,6 @@
 <packages>
     <package id="Cake" version="0.17.0" />
     <package id="Microsoft.Build.Runtime" version="15.1.548" />
-    <package id="Microsoft.NET.Sdk" version="1.0.0-alpha-20170224-6" />
-    <package id="Microsoft.NET.Sdk.Web" version="1.0.0-alpha-20170130-3-281" />
-    <package id="Microsoft.NET.Sdk.Publish" version="1.0.0-alpha-20170130-3-281" />
-    <package id="Microsoft.NET.Sdk.Web.ProjectSystem" version="1.0.0-alpha-20170130-3-281" />
     <package id="Microsoft.Net.Compilers" version="2.0.1" />
-    <package id="NuGet.Build.Tasks" version="4.0.0" />
-    <package id="NuGet.Build.Tasks.Pack" version="4.0.0" />
     <package id="xunit.runner.console" version="2.2.0" />
 </packages>


### PR DESCRIPTION
Fixes #765

This change stops deploying the .NET Core MSBuild SDKs with OmniSharp. That was a stop gap for .NET Core 1.0. However, with .NET Core 2.0 around the corner, it's time to stop deploying them and rely on the .NET Core SDK installed on the user's machine.

To locate the correct .NET Core SDK, we simply launch `dotnet --info` in the working directory of the project. That should properly handle the case where the SDK is specified in a global.json file. Then, we process the text returned by `dotnet --info` and locate the "Base Path" value. Combining this with "Sdks" should be the correct value.