### PR TITLE
Added an option to configure a code actions folder

### DIFF
--- a/src/OmniSharp.Abstractions/Options/CodeActionOptions.cs
+++ b/src/OmniSharp.Abstractions/Options/CodeActionOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -8,21 +9,23 @@ namespace OmniSharp.Options
     {
         public string[] LocationPaths { get; set; }
 
-        public IEnumerable<string> GetLocations(IOmniSharpEnvironment env)
+        public IEnumerable<string> GetNormalizedLocationPaths(IOmniSharpEnvironment env)
         {
-            if (LocationPaths == null) return Enumerable.Empty<string>();
+            if (LocationPaths == null || LocationPaths.Length == 0) return Enumerable.Empty<string>();
 
-            var normalizePaths = new HashSet<string>();
+            var normalizePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var locationPath in LocationPaths)
             {
                 if (Path.IsPathRooted(locationPath))
                 {
                     normalizePaths.Add(locationPath);
                 }
-
-                normalizePaths.Add(Path.Combine(env.TargetDirectory, locationPath));
+                else
+                {
+                    normalizePaths.Add(Path.Combine(env.TargetDirectory, locationPath));
+                }
             }
-
+            
             return normalizePaths;
         }
     }

--- a/src/OmniSharp.Abstractions/Options/CodeActionOptions.cs
+++ b/src/OmniSharp.Abstractions/Options/CodeActionOptions.cs
@@ -1,0 +1,9 @@
+﻿using System.IO;
+
+namespace OmniSharp.Options
+{
+    public class CodeActionOptions
+    {
+        public string LocationPath { get; set; }
+    }
+}

--- a/src/OmniSharp.Abstractions/Options/CodeActionOptions.cs
+++ b/src/OmniSharp.Abstractions/Options/CodeActionOptions.cs
@@ -1,9 +1,29 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace OmniSharp.Options
 {
     public class CodeActionOptions
     {
-        public string LocationPath { get; set; }
+        public string[] LocationPaths { get; set; }
+
+        public IEnumerable<string> GetLocations(IOmniSharpEnvironment env)
+        {
+            if (LocationPaths == null) return Enumerable.Empty<string>();
+
+            var normalizePaths = new HashSet<string>();
+            foreach (var locationPath in LocationPaths)
+            {
+                if (Path.IsPathRooted(locationPath))
+                {
+                    normalizePaths.Add(locationPath);
+                }
+
+                normalizePaths.Add(Path.Combine(env.TargetDirectory, locationPath));
+            }
+
+            return normalizePaths;
+        }
     }
 }

--- a/src/OmniSharp.Abstractions/Options/OmniSharpOptions.cs
+++ b/src/OmniSharp.Abstractions/Options/OmniSharpOptions.cs
@@ -4,15 +4,8 @@ namespace OmniSharp.Options
 {
     public class OmniSharpOptions
     {
-        public CodeActionOptions CodeActions { get; set; } = new CodeActionOptions();
+        public CodeActionOptions CodeActions { get; } = new CodeActionOptions();
 
-        public FormattingOptions FormattingOptions { get; }
-
-        public OmniSharpOptions() : this(new FormattingOptions()) { }
-
-        public OmniSharpOptions(FormattingOptions options)
-        {
-            FormattingOptions = options ?? throw new ArgumentNullException(nameof(options));
-        }
+        public FormattingOptions FormattingOptions { get; } = new FormattingOptions();
     }
 }

--- a/src/OmniSharp.Abstractions/Options/OmniSharpOptions.cs
+++ b/src/OmniSharp.Abstractions/Options/OmniSharpOptions.cs
@@ -4,7 +4,7 @@ namespace OmniSharp.Options
 {
     public class OmniSharpOptions
     {
-        public CodeActionOptions CodeActions { get; } = new CodeActionOptions();
+        public RoslynExtensionsOptions RoslynExtensionsOptions { get; } = new RoslynExtensionsOptions();
 
         public FormattingOptions FormattingOptions { get; } = new FormattingOptions();
     }

--- a/src/OmniSharp.Abstractions/Options/OmniSharpOptions.cs
+++ b/src/OmniSharp.Abstractions/Options/OmniSharpOptions.cs
@@ -4,6 +4,8 @@ namespace OmniSharp.Options
 {
     public class OmniSharpOptions
     {
+        public CodeActionOptions CodeActions { get; set; }
+
         public FormattingOptions FormattingOptions { get; }
 
         public OmniSharpOptions() : this(new FormattingOptions()) { }

--- a/src/OmniSharp.Abstractions/Options/OmniSharpOptions.cs
+++ b/src/OmniSharp.Abstractions/Options/OmniSharpOptions.cs
@@ -4,7 +4,7 @@ namespace OmniSharp.Options
 {
     public class OmniSharpOptions
     {
-        public CodeActionOptions CodeActions { get; set; }
+        public CodeActionOptions CodeActions { get; set; } = new CodeActionOptions();
 
         public FormattingOptions FormattingOptions { get; }
 

--- a/src/OmniSharp.Abstractions/Options/RoslynExtensionsOptions.cs
+++ b/src/OmniSharp.Abstractions/Options/RoslynExtensionsOptions.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace OmniSharp.Options
 {
-    public class CodeActionOptions
+    public class RoslynExtensionsOptions
     {
         public string[] LocationPaths { get; set; }
 

--- a/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
+++ b/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
@@ -8,7 +8,7 @@ namespace OmniSharp.Services
     {
         Assembly Load(AssemblyName name);
 
-        IEnumerable<Assembly> LoadAll(string folderPath);
+        IReadOnlyList<Assembly> LoadAllFrom(string folderPath);
     }
 
     public static class IAssemblyLoaderExtensions

--- a/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
+++ b/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
@@ -7,6 +7,8 @@ namespace OmniSharp.Services
     public interface IAssemblyLoader
     {
         Assembly Load(AssemblyName name);
+
+        IEnumerable<Assembly> LoadAll(string folderPath);
     }
 
     public static class IAssemblyLoaderExtensions

--- a/src/OmniSharp.Host/Services/AssemblyLoader.cs
+++ b/src/OmniSharp.Host/Services/AssemblyLoader.cs
@@ -34,9 +34,9 @@ namespace OmniSharp.Host.Loader
             return result;
         }
 
-        public IEnumerable<Assembly> LoadAll(string folderPath)
+        public IReadOnlyList<Assembly> LoadAllFrom(string folderPath)
         {
-            if (folderPath == null) return Enumerable.Empty<Assembly>();
+            if (string.IsNullOrWhiteSpace(folderPath)) return new Assembly[0];
 
             var assemblies = new List<Assembly>();
             foreach (var filePath in Directory.EnumerateFiles(folderPath, "*.dll"))

--- a/src/OmniSharp.Host/Services/AssemblyLoader.cs
+++ b/src/OmniSharp.Host/Services/AssemblyLoader.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Services;
@@ -11,7 +14,7 @@ namespace OmniSharp.Host.Loader
 
         public AssemblyLoader(ILoggerFactory loggerFactory)
         {
-            this._logger = loggerFactory.CreateLogger<AssemblyLoader>();
+            _logger = loggerFactory.CreateLogger<AssemblyLoader>();
         }
 
         public Assembly Load(AssemblyName name)
@@ -29,6 +32,44 @@ namespace OmniSharp.Host.Loader
 
             _logger.LogTrace($"Assembly loaded: {name}");
             return result;
+        }
+
+        public IEnumerable<Assembly> LoadAll(string folderPath)
+        {
+            if (folderPath == null) return Enumerable.Empty<Assembly>();
+
+            var assemblies = new List<Assembly>();
+            foreach (var filePath in Directory.EnumerateFiles(folderPath, "*.dll"))
+            {
+                var assembly = LoadFromPath(filePath);
+                if (assembly != null)
+                {
+                    assemblies.Add(assembly);
+                }
+            }
+
+            return assemblies;
+        }
+
+        private Assembly LoadFromPath(string assemblyPath)
+        {
+            Assembly assembly = null;
+
+            try
+            {
+#if NET46
+                assembly = Assembly.LoadFrom(assemblyPath);
+#else
+                assembly = System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
+#endif
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Failed to load assembly from path: {assemblyPath}");
+            }
+
+            _logger.LogTrace($"Assembly loaded from path: {assemblyPath}");
+            return assembly;
         }
     }
 }

--- a/src/OmniSharp.Host/Services/AssemblyLoader.cs
+++ b/src/OmniSharp.Host/Services/AssemblyLoader.cs
@@ -36,7 +36,7 @@ namespace OmniSharp.Host.Loader
 
         public IReadOnlyList<Assembly> LoadAllFrom(string folderPath)
         {
-            if (string.IsNullOrWhiteSpace(folderPath)) return new Assembly[0];
+            if (string.IsNullOrWhiteSpace(folderPath)) return Array.Empty<Assembly>();
 
             var assemblies = new List<Assembly>();
             foreach (var filePath in Directory.EnumerateFiles(folderPath, "*.dll"))

--- a/src/OmniSharp.Roslyn.CSharp/CodeActions/ExternalCodeActionProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/CodeActions/ExternalCodeActionProvider.cs
@@ -1,0 +1,15 @@
+﻿using System.Composition;
+using OmniSharp.Services;
+
+namespace OmniSharp.Roslyn.CSharp.Services.CodeActions
+{
+    [Export(typeof(ICodeActionProvider))]
+    public class ExternalCodeActionProvider : AbstractCodeActionProvider
+    {
+        [ImportingConstructor]
+        public ExternalCodeActionProvider(ExternalFeaturesHostServicesProvider featuresHostServicesProvider)
+            : base("ExternalCodeActions", featuresHostServicesProvider.Assemblies)
+        {
+        }
+    }
+}

--- a/src/OmniSharp.Roslyn.CSharp/Services/ExternalFeaturesHostServicesProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/ExternalFeaturesHostServicesProvider.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Reflection;
 using OmniSharp.Options;
 using OmniSharp.Services;
-using System.Linq;
 
 namespace OmniSharp.Roslyn.CSharp.Services
 {

--- a/src/OmniSharp.Roslyn.CSharp/Services/ExternalFeaturesHostServicesProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/ExternalFeaturesHostServicesProvider.cs
@@ -19,12 +19,12 @@ namespace OmniSharp.Roslyn.CSharp.Services
         {
             var builder = ImmutableArray.CreateBuilder<Assembly>();
 
-            var codeActionLocations = options.CodeActions.GetNormalizedLocationPaths(env);
-            if (codeActionLocations?.Any() == true)
+            var roslynExtensionsLocations = options.RoslynExtensionsOptions.GetNormalizedLocationPaths(env);
+            if (roslynExtensionsLocations?.Any() == true)
             {
-                foreach (var codeActionLocation in codeActionLocations)
+                foreach (var roslynExtensionsLocation in roslynExtensionsLocations)
                 {
-                    builder.AddRange(loader.LoadAllFrom(codeActionLocation));
+                    builder.AddRange(loader.LoadAllFrom(roslynExtensionsLocation));
                 }
             }
 

--- a/src/OmniSharp.Roslyn.CSharp/Services/ExternalFeaturesHostServicesProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/ExternalFeaturesHostServicesProvider.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Immutable;
+using System.Composition;
+using System.Reflection;
+using OmniSharp.Options;
+using OmniSharp.Services;
+using System.Linq;
+
+namespace OmniSharp.Roslyn.CSharp.Services
+{
+    [Export(typeof(IHostServicesProvider))]
+    [Export(typeof(ExternalFeaturesHostServicesProvider))]
+    [Shared]
+    public class ExternalFeaturesHostServicesProvider : IHostServicesProvider
+    {
+        public ImmutableArray<Assembly> Assemblies { get; }
+
+        [ImportingConstructor]
+        public ExternalFeaturesHostServicesProvider(IAssemblyLoader loader, OmniSharpOptions options, IOmniSharpEnvironment env)
+        {
+            var builder = ImmutableArray.CreateBuilder<Assembly>();
+
+            var codeActionLocations = options.CodeActions.GetNormalizedLocationPaths(env);
+            if (codeActionLocations?.Any() == true)
+            {
+                foreach (var codeActionLocation in codeActionLocations)
+                {
+                    builder.AddRange(loader.LoadAllFrom(codeActionLocation));
+                }
+            }
+
+            Assemblies = builder.ToImmutable();
+        }
+    }
+}

--- a/src/OmniSharp.Roslyn.CSharp/Services/RoslynFeaturesHostServicesProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/RoslynFeaturesHostServicesProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 using System.Composition;
 using System.Reflection;
+using OmniSharp.Options;
 using OmniSharp.Services;
 
 namespace OmniSharp.Roslyn.CSharp.Services
@@ -12,7 +13,7 @@ namespace OmniSharp.Roslyn.CSharp.Services
         public ImmutableArray<Assembly> Assemblies { get; }
 
         [ImportingConstructor]
-        public RoslynFeaturesHostServicesProvider(IAssemblyLoader loader)
+        public RoslynFeaturesHostServicesProvider(IAssemblyLoader loader, OmniSharpOptions options)
         {
             var builder = ImmutableArray.CreateBuilder<Assembly>();
 
@@ -20,6 +21,11 @@ namespace OmniSharp.Roslyn.CSharp.Services
             var CSharpFeatures = Configuration.GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.CSharp.Features");
 
             builder.AddRange(loader.Load(Features, CSharpFeatures));
+
+            if (options?.CodeActions.LocationPath != null)
+            {
+                builder.AddRange(loader.LoadAll(options.CodeActions.LocationPath));
+            }
 
             this.Assemblies = builder.ToImmutable();
         }

--- a/src/OmniSharp.Roslyn.CSharp/Services/RoslynFeaturesHostServicesProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/RoslynFeaturesHostServicesProvider.cs
@@ -23,7 +23,7 @@ namespace OmniSharp.Roslyn.CSharp.Services
 
             builder.AddRange(loader.Load(Features, CSharpFeatures));
 
-            var codeActionLocations = options?.CodeActions.GetLocations(env);
+            var codeActionLocations = options.CodeActions.GetLocations(env);
             if (codeActionLocations != null && codeActionLocations.Any())
             {
                 foreach (var codeActionLocation in codeActionLocations)

--- a/src/OmniSharp.Roslyn.CSharp/Services/RoslynFeaturesHostServicesProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/RoslynFeaturesHostServicesProvider.cs
@@ -9,12 +9,13 @@ namespace OmniSharp.Roslyn.CSharp.Services
 {
     [Export(typeof(IHostServicesProvider))]
     [Export(typeof(RoslynFeaturesHostServicesProvider))]
+    [Shared]
     public class RoslynFeaturesHostServicesProvider : IHostServicesProvider
     {
         public ImmutableArray<Assembly> Assemblies { get; }
 
         [ImportingConstructor]
-        public RoslynFeaturesHostServicesProvider(IAssemblyLoader loader, OmniSharpOptions options, IOmniSharpEnvironment env)
+        public RoslynFeaturesHostServicesProvider(IAssemblyLoader loader)
         {
             var builder = ImmutableArray.CreateBuilder<Assembly>();
 
@@ -23,16 +24,8 @@ namespace OmniSharp.Roslyn.CSharp.Services
 
             builder.AddRange(loader.Load(Features, CSharpFeatures));
 
-            var codeActionLocations = options.CodeActions.GetLocations(env);
-            if (codeActionLocations != null && codeActionLocations.Any())
-            {
-                foreach (var codeActionLocation in codeActionLocations)
-                {
-                    builder.AddRange(loader.LoadAll(codeActionLocation));
-                }
-            }
 
-            this.Assemblies = builder.ToImmutable();
+            Assemblies = builder.ToImmutable();
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/RoslynFeaturesHostServicesProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/RoslynFeaturesHostServicesProvider.cs
@@ -3,7 +3,6 @@ using System.Composition;
 using System.Reflection;
 using OmniSharp.Options;
 using OmniSharp.Services;
-using System.Linq;
 
 namespace OmniSharp.Roslyn.CSharp.Services
 {

--- a/src/OmniSharp/app.config
+++ b/src/OmniSharp/app.config
@@ -3,4 +3,20 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
   </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>


### PR DESCRIPTION
**Use case**: I'd like to load my own or 3rd party code actions into Omnisharp.

In this PR I added a possibility to add the following `CodeActions` node to the `omnisharp.json`.

```
{
    "FormattingOptions": {
        "IndentationSize": 2
    },
    "CodeActions": {
        "LocationPaths": [
            "C:/codeactions"
        ]
    }
}
```

This will be picked up by `RoslynFeaturesHostServicesProvider` as a source location for loading assemblies containing refactorings and code fixes.
Because `omnisharp.json` is hierarchical (global/local) we can specify code actions on a global and local level if needed.

No I could download something like https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2017 and extract its DLLs into `C:/codeactions` and profit. Relative and absolute paths are supported.
