### PR TITLE
Update cake to latest version and small cleanup to the cake script on…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ init:
   - git config --global core.autocrlf true
 test: off # this turns of AppVeyor automatic searching for test-assemblies, not the actual testing
 build_script:
-  - ps: .\build.ps1 -target All -archive
+  - ps: .\build.ps1 All -archive
 artifacts:
   - path: artifacts/package/*.zip
 deploy:

--- a/build.cake
+++ b/build.cake
@@ -107,10 +107,7 @@ Task("Cleanup")
 Task("Setup")
     .IsDependentOn("BuildEnvironment")
     .IsDependentOn("PopulateRuntimes")
-    .IsDependentOn("SetupMSBuild")
-    .Does(() =>
-{
-});
+    .IsDependentOn("SetupMSBuild");
 
 /// <summary>
 /// Acquire additional NuGet packages included with OmniSharp (such as MSBuild).
@@ -396,7 +393,7 @@ Task("PrepareTestAssets")
 
         RunTool(env.LegacyDotNetCommand, "restore", folder)
             .ExceptionOnError($"Failed to restore '{folder}'.");
- 
+
         Information($"Building {folder}...");
 
         RunTool(env.LegacyDotNetCommand, $"build", folder)
@@ -464,8 +461,7 @@ Task("TestAll")
 /// </summary>
 Task("TravisTestAll")
     .IsDependentOn("Cleanup")
-    .IsDependentOn("TestAll")
-    .Does(() =>{});
+    .IsDependentOn("TestAll");
 
 /// <summary>
 ///  Run tests for .NET Core (using .NET CLI).
@@ -537,7 +533,7 @@ bool IsNetFrameworkOnUnix(string framework)
 string GetPublishArguments(string projectFileName, string rid, string framework, string configuration, string outputFolder)
 {
     var argList = new List<string>();
-    
+
     if (IsNetFrameworkOnUnix(framework))
     {
         argList.Add($"\"{projectFileName}\"");
@@ -614,7 +610,7 @@ Task("OnlyPublish")
                 : args;
 
             Information($"Publishing {projectName} for {framework}/{rid}...");
-            
+
             RunTool(command, args, env.WorkingDirectory)
                 .ExceptionOnError($"Failed to publish {project} for {framework}/{rid}");
 
@@ -667,10 +663,7 @@ Task("RestrictToLocalRuntime")
 Task("LocalPublish")
     .IsDependentOn("Restore")
     .IsDependentOn("RestrictToLocalRuntime")
-    .IsDependentOn("OnlyPublish")
-    .Does(() =>
-{
-});
+    .IsDependentOn("OnlyPublish");
 
 /// <summary>
 ///  Test the published binaries if they start up without errors.
@@ -715,10 +708,7 @@ Task("CleanupInstall")
 /// </summary>
 Task("Quick")
     .IsDependentOn("Cleanup")
-    .IsDependentOn("LocalPublish")
-    .Does(() =>
-{
-});
+    .IsDependentOn("LocalPublish");
 
 /// <summary>
 ///  Quick build + install.
@@ -752,10 +742,7 @@ Task("All")
     .IsDependentOn("Restore")
     .IsDependentOn("TestAll")
     .IsDependentOn("AllPublish")
-    .IsDependentOn("TestPublished")
-    .Does(() =>
-{
-});
+    .IsDependentOn("TestPublished");
 
 /// <summary>
 ///  Full build targeting local RID.
@@ -765,10 +752,7 @@ Task("Local")
     .IsDependentOn("Restore")
     .IsDependentOn("TestAll")
     .IsDependentOn("LocalPublish")
-    .IsDependentOn("TestPublished")
-    .Does(() =>
-{
-});
+    .IsDependentOn("TestPublished");
 
 /// <summary>
 ///  Build centered around producing the final artifacts for Travis
@@ -779,19 +763,13 @@ Task("Travis")
     .IsDependentOn("Cleanup")
     .IsDependentOn("Restore")
     .IsDependentOn("AllPublish")
-    .IsDependentOn("TestPublished")
-    .Does(() =>
-{
-});
+    .IsDependentOn("TestPublished");
 
 /// <summary>
 ///  Default Task aliases to Local.
 /// </summary>
 Task("Default")
-    .IsDependentOn("Local")
-    .Does(() =>
-{
-});
+    .IsDependentOn("Local");
 
 /// <summary>
 ///  Default to Local.

--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,3 @@
 $Env:OMNISHARP_PACKAGE_OSNAME = "win-x64"
-.\scripts\cake-bootstrap.ps1 -experimental @args
+.\scripts\cake-bootstrap.ps1 @args
 exit $LASTEXITCODE

--- a/scripts/cake-bootstrap.ps1
+++ b/scripts/cake-bootstrap.ps1
@@ -40,13 +40,14 @@ http://cakebuild.net
 
 [CmdletBinding()]
 Param(
-    [string]$Script = "build.cake",
+    [parameter(position=0)]
     [string]$Target = "Default",
+    [string]$Script = "build.cake",
     [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
     [string]$Verbosity = "Verbose",
-    [switch]$Experimental,
+    [switch]$Experimental = $true,
     [Alias("DryRun","Noop")]
     [switch]$WhatIf,
     [switch]$Mono,

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.17.0" />
+    <package id="Cake" version="0.19.5" />
     <package id="Microsoft.Build.Runtime" version="15.1.548" />
     <package id="Microsoft.Net.Compilers" version="2.0.1" />
     <package id="xunit.runner.console" version="2.2.0" />


### PR DESCRIPTION
… windows

* Calling `.\build.ps1` can be called as `.\build.ps1 <target>` instead of `.\build.ps1 -Target=<target>`.

I need to see if I can make a similar change to build.sh but I'm not there just yet.