### PR TITLE
Fix Path.Combine exception in MSBuildProjectSystem.GetSdksPath

### DIFF
--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -308,7 +308,7 @@ namespace OmniSharp.MSBuild
         {
             var info = _dotNetCli.GetInfo(Path.GetDirectoryName(projectFilePath));
 
-            if (info.IsEmpty && !string.IsNullOrWhiteSpace(info.BasePath))
+            if (info.IsEmpty || string.IsNullOrWhiteSpace(info.BasePath))
             {
                 return null;
             }


### PR DESCRIPTION
This fixes regression introduced in 2fbcc854f, where null info.BasePath
is passed to Path.Combine causing exception.