### PR TITLE
Expose MsBuild Configuration and Platform setting

### DIFF
--- a/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
+++ b/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
@@ -4,6 +4,8 @@ namespace OmniSharp.Options
     {
         public string ToolsVersion { get; set; }
         public string VisualStudioVersion { get; set; }
+        public string Configuration { get; set; }
+        public string Platform { get; set; }
         public bool EnablePackageAutoRestore { get; set; }
 
         public string MSBuildExtensionsPath { get; set; }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
@@ -8,6 +8,7 @@
             public const string AssemblyName = nameof(AssemblyName);
             public const string AssemblyOriginatorKeyFile = nameof(AssemblyOriginatorKeyFile);
             public const string BuildProjectReferences = nameof(BuildProjectReferences);
+            public const string Configuration = nameof(Configuration);
             public const string DefineConstants = nameof(DefineConstants);
             public const string DesignTimeBuild = nameof(DesignTimeBuild);
             public const string DocumentationFile = nameof(DocumentationFile);
@@ -17,6 +18,7 @@
             public const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
             public const string NoWarn = nameof(NoWarn);
             public const string OutputPath = nameof(OutputPath);
+            public const string Platform = nameof(Platform);
             public const string ProjectAssetsFile = nameof(ProjectAssetsFile);
             public const string ProjectGuid = nameof(ProjectGuid);
             public const string ProjectName = nameof(ProjectName);

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -235,6 +235,18 @@ namespace OmniSharp.MSBuild.ProjectFile
                 userOptionValue: options.VisualStudioVersion,
                 environmentValue: null);
 
+            globalProperties.AddPropertyIfNeeded(
+                logger,
+                PropertyNames.Configuration,
+                userOptionValue: options.Configuration,
+                environmentValue: null);
+
+            globalProperties.AddPropertyIfNeeded(
+                logger,
+                PropertyNames.Platform,
+                userOptionValue: options.Platform,
+                environmentValue: null);
+
             if (PlatformHelper.IsMono)
             {
                 var monoXBuildFrameworksDirPath = PlatformHelper.MonoXBuildFrameworksDirPath;


### PR DESCRIPTION
This allows choosing other (than default) MsBuild configuration, e.g.
`MsBuild:Configuration=Release` `MsBuild:Platform=x64`, especially usable
for projects that are not using default (AnyCPU) platforms.

This relates to #202.

P.S. Do we need to add some tests on that one? Or is there any other particular way to override Configuration/Platform planned?