### PR TITLE
NuGet package identities should be compared case-insensitively

### DIFF
--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -624,7 +624,7 @@ namespace OmniSharp.MSBuild
         {
             foreach (var library in lockFile.Libraries)
             {
-                if (string.Equals(library.Name, reference.Dependency.Id) &&
+                if (string.Equals(library.Name, reference.Dependency.Id, StringComparison.OrdinalIgnoreCase) &&
                     reference.Dependency.VersionRange.Satisfies(library.Version))
                 {
                     return true;


### PR DESCRIPTION
This can result in incorrect package restore prompts in VS Code if the PackageReference name isn't a case-sensitive match of the actual package identity. For example, the restore prompt would appear for `<PackageReference Include="microsoft.codeanalysis"/>`