### PR TITLE
Clean up unresolved dependencies check

### DIFF
--- a/src/OmniSharp.Abstractions/Eventing/IEventEmitterExtensions.cs
+++ b/src/OmniSharp.Abstractions/Eventing/IEventEmitterExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using OmniSharp.Models.Events;
 
 namespace OmniSharp.Eventing
@@ -27,6 +28,17 @@ namespace OmniSharp.Eventing
                 {
                     FileName = projectPath,
                     Succeeded = succeeded
+                });
+        }
+
+        public static void UnresolvedDepdendencies(this IEventEmitter emitter, string projectFilePath, IEnumerable<PackageDependency> unresolvedDependencies)
+        {
+            emitter.Emit(
+                EventTypes.UnresolvedDependencies,
+                new UnresolvedDependenciesMessage
+                {
+                    FileName = projectFilePath,
+                    UnresolvedDependencies = unresolvedDependencies
                 });
         }
     }

--- a/src/OmniSharp.DotNet/DotNetProjectSystem.cs
+++ b/src/OmniSharp.DotNet/DotNetProjectSystem.cs
@@ -302,29 +302,30 @@ namespace OmniSharp.DotNet
         {
             var libraryManager = state.ProjectContext.LibraryManager;
             var allDiagnostics = libraryManager.GetAllDiagnostics();
-            var unresolved = libraryManager.GetLibraries().Where(dep => !dep.Resolved);
-            var needRestore = allDiagnostics.Any(diag => diag.ErrorCode == ErrorCodes.NU1006) || unresolved.Any();
+            var unresolvedLibraries = libraryManager.GetLibraries().Where(dep => !dep.Resolved);
+            var needRestore = allDiagnostics.Any(diag => diag.ErrorCode == ErrorCodes.NU1006) || unresolvedLibraries.Any();
 
             if (needRestore)
             {
+                var unresolvedDependencies = unresolvedLibraries.Select(library =>
+                    new PackageDependency
+                    {
+                        Name = library.Identity.Name,
+                        Version = library.Identity.Version?.ToString()
+                    });
+
+                var projectFile = state.ProjectContext.ProjectFile;
+
                 if (allowRestore && _enableRestorePackages)
                 {
-                    _dotNetCliService.RestoreAsync(state.ProjectContext.ProjectFile.ProjectDirectory, onFailure: () =>
+                    _dotNetCliService.RestoreAsync(projectFile.ProjectDirectory, onFailure: () =>
                     {
-                        _eventEmitter.Emit(EventTypes.UnresolvedDependencies, new UnresolvedDependenciesMessage()
-                        {
-                            FileName = state.ProjectContext.ProjectFile.ProjectFilePath,
-                            UnresolvedDependencies = unresolved.Select(d => new PackageDependency { Name = d.Identity.Name, Version = d.Identity.Version?.ToString() })
-                        });
+                        _eventEmitter.UnresolvedDepdendencies(projectFile.ProjectFilePath, unresolvedDependencies);
                     });
                 }
                 else
                 {
-                    _eventEmitter.Emit(EventTypes.UnresolvedDependencies, new UnresolvedDependenciesMessage()
-                    {
-                        FileName = state.ProjectContext.ProjectFile.ProjectFilePath,
-                        UnresolvedDependencies = unresolved.Select(d => new PackageDependency { Name = d.Identity.Name, Version = d.Identity.Version?.ToString() })
-                    });
+                    _eventEmitter.UnresolvedDepdendencies(projectFile.ProjectFilePath, unresolvedDependencies);
                 }
             }
         }

--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -534,9 +534,9 @@ namespace OmniSharp.MSBuild
             }
         }
 
-        private void CheckForUnresolvedDependences(ProjectFileInfo projectFileInfo, bool allowAutoRestore)
+        private void CheckForUnresolvedDependences(ProjectFileInfo projectFile, bool allowAutoRestore)
         {
-            var unresolvedPackageReferences = _packageDepedencyResolver.FindUnresolvedPackageReferences(projectFileInfo);
+            var unresolvedPackageReferences = _packageDepedencyResolver.FindUnresolvedPackageReferences(projectFile);
             if (unresolvedPackageReferences.IsEmpty)
             {
                 return;
@@ -551,25 +551,15 @@ namespace OmniSharp.MSBuild
 
             if (allowAutoRestore && _options.EnablePackageAutoRestore)
             {
-                _dotNetCli.RestoreAsync(projectFileInfo.Directory, onFailure: () =>
+                _dotNetCli.RestoreAsync(projectFile.Directory, onFailure: () =>
                 {
-                    FireUnresolvedDependenciesEvent(projectFileInfo, unresolvedDependencies);
+                    _eventEmitter.UnresolvedDepdendencies(projectFile.FilePath, unresolvedDependencies);
                 });
             }
             else
             {
-                FireUnresolvedDependenciesEvent(projectFileInfo, unresolvedDependencies);
+                _eventEmitter.UnresolvedDepdendencies(projectFile.FilePath, unresolvedDependencies);
             }
-        }
-
-        private void FireUnresolvedDependenciesEvent(ProjectFileInfo projectFileInfo, IEnumerable<PackageDependency> unresolvedDependencies)
-        {
-            _eventEmitter.Emit(EventTypes.UnresolvedDependencies,
-                new UnresolvedDependenciesMessage()
-                {
-                    FileName = projectFileInfo.FilePath,
-                    UnresolvedDependencies = unresolvedDependencies
-                });
         }
 
         private ProjectFileInfo GetProjectFileInfo(string path)

--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using NuGet.ProjectModel;
 using OmniSharp.Eventing;
 using OmniSharp.FileWatching;
 using OmniSharp.Models.Events;
@@ -17,6 +16,7 @@ using OmniSharp.Models.WorkspaceInformation;
 using OmniSharp.MSBuild.Models;
 using OmniSharp.MSBuild.Models.Events;
 using OmniSharp.MSBuild.ProjectFile;
+using OmniSharp.MSBuild.Resolution;
 using OmniSharp.MSBuild.SolutionParsing;
 using OmniSharp.Options;
 using OmniSharp.Services;
@@ -34,6 +34,7 @@ namespace OmniSharp.MSBuild
         private readonly IFileSystemWatcher _fileSystemWatcher;
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger _logger;
+        private readonly PackageDependencyResolver _packageDepedencyResolver;
 
         private readonly object _gate = new object();
         private readonly Queue<ProjectFileInfo> _projectsToProcess;
@@ -67,6 +68,7 @@ namespace OmniSharp.MSBuild
             _projects = new ProjectFileInfoCollection();
             _projectsToProcess = new Queue<ProjectFileInfo>();
             _logger = loggerFactory.CreateLogger<MSBuildProjectSystem>();
+            _packageDepedencyResolver = new PackageDependencyResolver(loggerFactory);
         }
 
         public void Initalize(IConfiguration configuration)
@@ -362,7 +364,7 @@ namespace OmniSharp.MSBuild
                         _projects[projectFilePath] = newProjectFileInfo;
 
                         UpdateProject(newProjectFileInfo);
-                        CheckForUnresolvedDependences(newProjectFileInfo, oldProjectFileInfo, allowAutoRestore);
+                        CheckForUnresolvedDependences(newProjectFileInfo, allowAutoRestore);
                     }
                 }
 
@@ -532,154 +534,35 @@ namespace OmniSharp.MSBuild
             }
         }
 
-        private void CheckForUnresolvedDependences(ProjectFileInfo projectFileInfo, ProjectFileInfo previousProjectFileInfo = null, bool allowAutoRestore = false)
+        private void CheckForUnresolvedDependences(ProjectFileInfo projectFileInfo, bool allowAutoRestore)
         {
-            List<PackageDependency> unresolvedDependencies;
-
-            if (!File.Exists(projectFileInfo.ProjectAssetsFile))
+            var unresolvedPackageReferences = _packageDepedencyResolver.FindUnresolvedPackageReferences(projectFileInfo);
+            if (unresolvedPackageReferences.IsEmpty)
             {
-                // Simplest case: If there's no lock file and the project file has package references,
-                // there are certainly unresolved dependencies.
-                unresolvedDependencies = CreatePackageDependencies(projectFileInfo.PackageReferences);
-            }
-            else
-            {
-                // Note: This is a bit of misnmomer. It's entirely possible that a package reference has been removed
-                // and a restore needs to happen in order to update project.assets.json file. Otherwise, the MSBuild targets
-                // will still resolve the removed reference as a reference in the user's project. In that case, the package
-                // reference isn't so much "unresolved" as "incorrectly resolved".
-                IEnumerable<PackageReference> unresolvedPackageReferences;
-
-                // Did the project file change? Diff the package references and see if there are unresolved dependencies.
-                if (previousProjectFileInfo != null)
-                {
-                    var remainingPackageReferences = new HashSet<PackageReference>(previousProjectFileInfo.PackageReferences);
-                    var packageReferencesToAdd = new HashSet<PackageReference>();
-
-                    foreach (var packageReference in projectFileInfo.PackageReferences)
-                    {
-                        if (remainingPackageReferences.Contains(packageReference))
-                        {
-                            remainingPackageReferences.Remove(packageReference);
-                        }
-                        else
-                        {
-                            packageReferencesToAdd.Add(packageReference);
-                        }
-                    }
-
-                    unresolvedPackageReferences = packageReferencesToAdd.Concat(remainingPackageReferences);
-                }
-                else
-                {
-                    // Finally, if the project.assets.json file exists but there's no old project to compare against,
-                    // we'll just check to ensure that all of the project's package references can be found in the
-                    // current project.assets.json file.
-
-                    var lockFileFormat = new LockFileFormat();
-                    var lockFile = lockFileFormat.Read(projectFileInfo.ProjectAssetsFile);
-
-                    unresolvedPackageReferences = FindUnresolvedPackageReferencesInLockFile(projectFileInfo, lockFile);
-                }
-
-                unresolvedDependencies = CreatePackageDependencies(unresolvedPackageReferences);
+                return;
             }
 
-            if (unresolvedDependencies.Count > 0)
-            {
-                if (allowAutoRestore && _options.EnablePackageAutoRestore)
-                {
-                    _dotNetCli.RestoreAsync(projectFileInfo.Directory, onFailure: () =>
-                    {
-                        FireUnresolvedDependenciesEvent(projectFileInfo, unresolvedDependencies);
-                    });
-                }
-                else
-                {
-                    FireUnresolvedDependenciesEvent(projectFileInfo, unresolvedDependencies);
-                }
-            }
-        }
-
-        private List<PackageDependency> CreatePackageDependencies(IEnumerable<PackageReference> packageReferences)
-        {
-            var list = new List<PackageDependency>();
-
-            foreach (var packageReference in packageReferences)
-            {
-                var dependency = new PackageDependency
+            var unresolvedDependencies = unresolvedPackageReferences.Select(packageReference =>
+                new PackageDependency
                 {
                     Name = packageReference.Dependency.Id,
                     Version = packageReference.Dependency.VersionRange.ToNormalizedString()
-                };
+                });
 
-                list.Add(dependency);
+            if (allowAutoRestore && _options.EnablePackageAutoRestore)
+            {
+                _dotNetCli.RestoreAsync(projectFileInfo.Directory, onFailure: () =>
+                {
+                    FireUnresolvedDependenciesEvent(projectFileInfo, unresolvedDependencies);
+                });
             }
-
-            return list;
+            else
+            {
+                FireUnresolvedDependenciesEvent(projectFileInfo, unresolvedDependencies);
+            }
         }
 
-        private ImmutableArray<PackageReference> FindUnresolvedPackageReferencesInLockFile(ProjectFileInfo projectFileInfo, LockFile lockFile)
-        {
-            if (projectFileInfo.PackageReferences.Length == 0)
-            {
-                return ImmutableArray<PackageReference>.Empty;
-            }
-
-            // Create map of all libraries in the lock file by their name.
-            // Note that the map's key is case-insensitive.
-
-            var libraryMap = new Dictionary<string, List<LockFileLibrary>>(
-                capacity: lockFile.Libraries.Count,
-                comparer: StringComparer.OrdinalIgnoreCase);
-
-            foreach (var library in lockFile.Libraries)
-            {
-                if (!libraryMap.TryGetValue(library.Name, out var libraries))
-                {
-                    libraries = new List<LockFileLibrary>();
-                    libraryMap.Add(library.Name, libraries);
-                }
-
-                libraries.Add(library);
-            }
-
-            var unresolved = ImmutableArray.CreateBuilder<PackageReference>();
-
-            // Iterate through each package reference and see if we can find a library with the same name
-            // that satisfies the reference's version range in the lock file.
-
-            foreach (var reference in projectFileInfo.PackageReferences)
-            {
-                if (!libraryMap.TryGetValue(reference.Dependency.Id, out var libraries))
-                {
-                    _logger.LogWarning($"{projectFileInfo.Name}: Did not find '{reference.Dependency.Id}' in lock file.");
-                    unresolved.Add(reference);
-                }
-                else
-                {
-                    var found = false;
-                    foreach (var library in libraries)
-                    {
-                        if (reference.Dependency.VersionRange.Satisfies(library.Version))
-                        {
-                            found = true;
-                            break;
-                        }
-                    }
-
-                    if (!found)
-                    {
-                        _logger.LogDebug($"{projectFileInfo.Name}: Found '{reference.Dependency.Id}' in lock file, but none of the versions satisfy {reference.Dependency.VersionRange}");
-                        unresolved.Add(reference);
-                    }
-                }
-            }
-
-            return unresolved.ToImmutable();
-        }
-
-        private void FireUnresolvedDependenciesEvent(ProjectFileInfo projectFileInfo, List<PackageDependency> unresolvedDependencies)
+        private void FireUnresolvedDependenciesEvent(ProjectFileInfo projectFileInfo, IEnumerable<PackageDependency> unresolvedDependencies)
         {
             _eventEmitter.Emit(EventTypes.UnresolvedDependencies,
                 new UnresolvedDependenciesMessage()

--- a/src/OmniSharp.MSBuild/Resolution/PackageDependencyResolver.cs
+++ b/src/OmniSharp.MSBuild/Resolution/PackageDependencyResolver.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using NuGet.ProjectModel;
+using OmniSharp.MSBuild.ProjectFile;
+
+namespace OmniSharp.MSBuild.Resolution
+{
+    internal class PackageDependencyResolver
+    {
+        private readonly ILogger _logger;
+
+        public PackageDependencyResolver(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<PackageDependencyResolver>();
+        }
+
+        public ImmutableArray<PackageReference> FindUnresolvedPackageReferences(ProjectFileInfo projectFile)
+        {
+            if (projectFile.PackageReferences.Length == 0)
+            {
+                return ImmutableArray<PackageReference>.Empty;
+            }
+
+            // If the lock file does not exist, all of the package references are unresolved.
+            if (!File.Exists(projectFile.ProjectAssetsFile))
+            {
+                return projectFile.PackageReferences;
+            }
+
+            var lockFileFormat = new LockFileFormat();
+            var lockFile = lockFileFormat.Read(projectFile.ProjectAssetsFile);
+
+            return FindUnresolvedPackageReferencesInLockFile(projectFile, lockFile);
+        }
+
+        private ImmutableArray<PackageReference> FindUnresolvedPackageReferencesInLockFile(ProjectFileInfo projectFile, LockFile lockFile)
+        {
+            var libraryMap = CreateLibraryMap(lockFile);
+
+            var unresolved = ImmutableArray.CreateBuilder<PackageReference>();
+
+            // Iterate through each package reference and see if we can find a library with the same name
+            // that satisfies the reference's version range in the lock file.
+
+            foreach (var reference in projectFile.PackageReferences)
+            {
+                if (!libraryMap.TryGetValue(reference.Dependency.Id, out var libraries))
+                {
+                    _logger.LogWarning($"{projectFile.Name}: Did not find '{reference.Dependency.Id}' in lock file.");
+                    unresolved.Add(reference);
+                }
+                else
+                {
+                    var found = false;
+                    foreach (var library in libraries)
+                    {
+                        if (reference.Dependency.VersionRange.Satisfies(library.Version))
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if (!found)
+                    {
+                        _logger.LogDebug($"{projectFile.Name}: Found '{reference.Dependency.Id}' in lock file, but none of the versions satisfy {reference.Dependency.VersionRange}");
+                        unresolved.Add(reference);
+                    }
+                }
+            }
+
+            return unresolved.ToImmutable();
+        }
+
+        private static Dictionary<string, List<LockFileLibrary>> CreateLibraryMap(LockFile lockFile)
+        {
+            // Create map of all libraries in the lock file by their name.
+            // Note that the map's key is case-insensitive.
+
+            var libraryMap = new Dictionary<string, List<LockFileLibrary>>(
+                capacity: lockFile.Libraries.Count,
+                comparer: StringComparer.OrdinalIgnoreCase);
+
+            foreach (var library in lockFile.Libraries)
+            {
+                if (!libraryMap.TryGetValue(library.Name, out var libraries))
+                {
+                    libraries = new List<LockFileLibrary>();
+                    libraryMap.Add(library.Name, libraries);
+                }
+
+                libraries.Add(library);
+            }
+
+            return libraryMap;
+        }
+    }
+}

--- a/src/OmniSharp.MSBuild/Resolution/PackageDependencyResolver.cs
+++ b/src/OmniSharp.MSBuild/Resolution/PackageDependencyResolver.cs
@@ -66,7 +66,7 @@ namespace OmniSharp.MSBuild.Resolution
 
                     if (!found)
                     {
-                        _logger.LogDebug($"{projectFile.Name}: Found '{reference.Dependency.Id}' in lock file, but none of the versions satisfy {reference.Dependency.VersionRange}");
+                        _logger.LogWarning($"{projectFile.Name}: Found '{reference.Dependency.Id}' in lock file, but none of the versions satisfy {reference.Dependency.VersionRange}");
                         unresolved.Add(reference);
                     }
                 }

--- a/src/OmniSharp.MSBuild/Resolution/PackageDependencyResolver.cs
+++ b/src/OmniSharp.MSBuild/Resolution/PackageDependencyResolver.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using NuGet.ProjectModel;
 using OmniSharp.MSBuild.ProjectFile;
@@ -66,7 +67,13 @@ namespace OmniSharp.MSBuild.Resolution
 
                     if (!found)
                     {
-                        _logger.LogWarning($"{projectFile.Name}: Found '{reference.Dependency.Id}' in lock file, but none of the versions satisfy {reference.Dependency.VersionRange}");
+                        var referenceText = reference.IsImplicitlyDefined
+                            ? "implicit package reference"
+                            : "package reference";
+
+                        var versions = string.Join(", ", libraries.Select(l => '"' + l.Version.ToString() + '"'));
+
+                        _logger.LogWarning($"{projectFile.Name}: Found {referenceText} '{reference.Dependency.Id}', but none of the versions in the lock file ({versions}) satisfy {reference.Dependency.VersionRange}");
                         unresolved.Add(reference);
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1272

This change cleans up the logic (which had gotten kinda messy) that resolves MSBuild package references against a project's lock file. This also adds logging when package references can't be resolved, which should help diagnose situations where VS Code is getting restore prompts unnecessarily.