### PR TITLE
Error handling when loading assemblies from an external folder

### DIFF
--- a/src/OmniSharp.Host/Services/AssemblyLoader.cs
+++ b/src/OmniSharp.Host/Services/AssemblyLoader.cs
@@ -38,6 +38,12 @@ namespace OmniSharp.Host.Loader
         {
             if (string.IsNullOrWhiteSpace(folderPath)) return Array.Empty<Assembly>();
 
+            if (!Directory.Exists(folderPath))
+            {
+                _logger.LogWarning($"Attempted to load assemblies from '{folderPath}' but that path doesn't exist.");
+                return Array.Empty<Assembly>();
+            }
+
             var assemblies = new List<Assembly>();
             foreach (var filePath in Directory.EnumerateFiles(folderPath, "*.dll"))
             {

--- a/src/OmniSharp.Host/Services/AssemblyLoader.cs
+++ b/src/OmniSharp.Host/Services/AssemblyLoader.cs
@@ -38,23 +38,26 @@ namespace OmniSharp.Host.Loader
         {
             if (string.IsNullOrWhiteSpace(folderPath)) return Array.Empty<Assembly>();
 
-            if (!Directory.Exists(folderPath))
+            try
             {
-                _logger.LogWarning($"Attempted to load assemblies from '{folderPath}' but that path doesn't exist.");
+                var assemblies = new List<Assembly>();
+
+                foreach (var filePath in Directory.EnumerateFiles(folderPath, "*.dll"))
+                {
+                    var assembly = LoadFromPath(filePath);
+                    if (assembly != null)
+                    {
+                        assemblies.Add(assembly);
+                    }
+                }
+
+                return assemblies;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"An error occurred when attempting to access '{folderPath}'.");
                 return Array.Empty<Assembly>();
             }
-
-            var assemblies = new List<Assembly>();
-            foreach (var filePath in Directory.EnumerateFiles(folderPath, "*.dll"))
-            {
-                var assembly = LoadFromPath(filePath);
-                if (assembly != null)
-                {
-                    assemblies.Add(assembly);
-                }
-            }
-
-            return assemblies;
         }
 
         private Assembly LoadFromPath(string assemblyPath)


### PR DESCRIPTION
Follow up to #848 

Added try/catch to the directory enumeration inside `AssemblyLoader`. It can throw due to a number of problems - directory not found, path too long, lack of permissions etc.
We should gracefully exit with no assemblies loaded and not crash OmniSharp.