### PR TITLE
Don't set completion text to full signature unless its override or partial method completion

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
@@ -12,15 +12,17 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
 {
     internal static class CompletionItemExtensions
     {
-        private const string GetSymbolsAsync = "GetSymbolsAsync";
+        private const string GetSymbolsAsync = nameof(GetSymbolsAsync);
+        private const string InsertionText = nameof(InsertionText);
+        private const string NamedParameterCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.NamedParameterCompletionProvider";
         private const string OverrideCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.OverrideCompletionProvider";
         private const string ParitalMethodCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.PartialMethodCompletionProvider";
-        private const string Provider = "Provider";
+        private const string Provider = nameof(Provider);
         private const string SymbolCompletionItem = "Microsoft.CodeAnalysis.Completion.Providers.SymbolCompletionItem";
         private const string SymbolCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.SymbolCompletionProvider";
-        private const string SymbolKind = "SymbolKind";
-        private const string SymbolName = "SymbolName";
-        private const string Symbols = "Symbols";
+        private const string SymbolKind = nameof(SymbolKind);
+        private const string SymbolName = nameof(SymbolName);
+        private const string Symbols = nameof(Symbols);
 
         private static MethodInfo _getSymbolsAsync;
 
@@ -58,7 +60,12 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
         public static bool UseDisplayTextAsCompletionText(this CompletionItem completionItem)
         {
             return completionItem.Properties.TryGetValue(Provider, out var provider)
-                && (provider == OverrideCompletionProvider || provider == ParitalMethodCompletionProvider);
+                && (provider == NamedParameterCompletionProvider || provider == OverrideCompletionProvider || provider == ParitalMethodCompletionProvider);
+        }
+
+        public static bool TryGetInsertionText(this CompletionItem completionItem, out string insertionText)
+        {
+            return completionItem.Properties.TryGetValue(InsertionText, out insertionText);
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
@@ -13,24 +12,36 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
 {
     internal static class CompletionItemExtensions
     {
+        private const string GetSymbolsAsync = "GetSymbolsAsync";
+        private const string OverrideCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.OverrideCompletionProvider";
+        private const string ParitalMethodCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.PartialMethodCompletionProvider";
+        private const string Provider = "Provider";
+        private const string SymbolCompletionItem = "Microsoft.CodeAnalysis.Completion.Providers.SymbolCompletionItem";
+        private const string SymbolCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.SymbolCompletionProvider";
+        private const string SymbolKind = "SymbolKind";
+        private const string SymbolName = "SymbolName";
+        private const string Symbols = "Symbols";
+
         private static MethodInfo _getSymbolsAsync;
 
         static CompletionItemExtensions()
         {
-            var symbolCompletionItemType = typeof(CompletionItem).GetTypeInfo().Assembly.GetType("Microsoft.CodeAnalysis.Completion.Providers.SymbolCompletionItem");
-            _getSymbolsAsync = symbolCompletionItemType.GetMethod("GetSymbolsAsync", BindingFlags.Public | BindingFlags.Static);
+            var symbolCompletionItemType = typeof(CompletionItem).GetTypeInfo().Assembly.GetType(SymbolCompletionItem);
+            _getSymbolsAsync = symbolCompletionItemType.GetMethod(GetSymbolsAsync, BindingFlags.Public | BindingFlags.Static);
         }
 
         public static async Task<IEnumerable<ISymbol>> GetCompletionSymbolsAsync(this CompletionItem completionItem, IEnumerable<ISymbol> recommendedSymbols, Document document)
         {
+            var properties = completionItem.Properties;
+
             // for SymbolCompletionProvider, use the logic of extracting information from recommended symbols
-            if (completionItem.Properties.ContainsKey("Provider") && completionItem.Properties["Provider"] == "Microsoft.CodeAnalysis.CSharp.Completion.Providers.SymbolCompletionProvider")
+            if (properties.TryGetValue(Provider, out var provider) && provider == SymbolCompletionProvider)
             {
-                return recommendedSymbols.Where(x => x.Name == completionItem.Properties["SymbolName"] && (int)x.Kind == int.Parse(completionItem.Properties["SymbolKind"])).Distinct();
+                return recommendedSymbols.Where(x => x.Name == properties[SymbolName] && (int)x.Kind == int.Parse(properties[SymbolKind])).Distinct();
             }
 
             // if the completion provider encoded symbols into Properties, we can return them
-            if (completionItem.Properties.ContainsKey("Symbols"))
+            if (properties.ContainsKey(Symbols))
             {
                 // the API to decode symbols is not public at the moment
                 // http://source.roslyn.io/#Microsoft.CodeAnalysis.Features/Completion/Providers/SymbolCompletionItem.cs,93
@@ -42,6 +53,12 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
             }
 
             return Enumerable.Empty<ISymbol>();
+        }
+
+        public static bool UseDisplayTextAsCompletionText(this CompletionItem completionItem)
+        {
+            return completionItem.Properties.TryGetValue(Provider, out var provider)
+                && (provider == OverrideCompletionProvider || provider == ParitalMethodCompletionProvider);
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/IntellisenseService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/IntellisenseService.cs
@@ -57,9 +57,18 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
                             {
                                 foreach (var symbol in symbols)
                                 {
-                                    completionText = item.UseDisplayTextAsCompletionText()
-                                        ? item.DisplayText
-                                        : symbol.Name;
+                                    if (item.UseDisplayTextAsCompletionText())
+                                    {
+                                        completionText = item.DisplayText;
+                                    }
+                                    else if (item.TryGetInsertionText(out var insertionText))
+                                    {
+                                        completionText = insertionText;
+                                    }
+                                    else
+                                    {
+                                        completionText = symbol.Name;
+                                    }
 
                                     if (symbol != null)
                                     {

--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/IntellisenseService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/IntellisenseService.cs
@@ -57,18 +57,22 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
                             {
                                 foreach (var symbol in symbols)
                                 {
+                                    completionText = item.UseDisplayTextAsCompletionText()
+                                        ? item.DisplayText
+                                        : symbol.Name;
+
                                     if (symbol != null)
                                     {
                                         if (request.WantSnippet)
                                         {
-                                            foreach (var completion in MakeSnippetedResponses(request, symbol, item.DisplayText))
+                                            foreach (var completion in MakeSnippetedResponses(request, symbol, completionText))
                                             {
                                                 completions.Add(completion);
                                             }
                                         }
                                         else
                                         {
-                                            completions.Add(MakeAutoCompleteResponse(request, symbol, item.DisplayText));
+                                            completions.Add(MakeAutoCompleteResponse(request, symbol, completionText));
                                         }
                                     }
                                 }
@@ -104,50 +108,60 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
                 .ThenBy(c => c.CompletionText, StringComparer.OrdinalIgnoreCase);
         }
 
-        private IEnumerable<AutoCompleteResponse> MakeSnippetedResponses(AutoCompleteRequest request, ISymbol symbol, string displayName)
+        private IEnumerable<AutoCompleteResponse> MakeSnippetedResponses(AutoCompleteRequest request, ISymbol symbol, string completionText)
+        {
+            switch (symbol)
+            {
+                case IMethodSymbol methodSymbol:
+                    return MakeSnippetedResponses(request, methodSymbol, completionText);
+                case INamedTypeSymbol typeSymbol:
+                    return MakeSnippetedResponses(request, typeSymbol, completionText);
+
+                default:
+                    return new[] { MakeAutoCompleteResponse(request, symbol, completionText) };
+            }
+        }
+
+        private IEnumerable<AutoCompleteResponse> MakeSnippetedResponses(AutoCompleteRequest request, IMethodSymbol methodSymbol, string completionText)
         {
             var completions = new List<AutoCompleteResponse>();
 
-            var methodSymbol = symbol as IMethodSymbol;
-            if (methodSymbol != null)
+            if (methodSymbol.Parameters.Any(p => p.IsOptional))
             {
-                if (methodSymbol.Parameters.Any(p => p.IsOptional))
-                {
-                    completions.Add(MakeAutoCompleteResponse(request, symbol, displayName, false));
-                }
-
-                completions.Add(MakeAutoCompleteResponse(request, symbol, displayName));
-
-                return completions;
+                completions.Add(MakeAutoCompleteResponse(request, methodSymbol, completionText, includeOptionalParams: false));
             }
 
-            var typeSymbol = symbol as INamedTypeSymbol;
-            if (typeSymbol != null)
-            {
-                completions.Add(MakeAutoCompleteResponse(request, symbol, displayName));
+            completions.Add(MakeAutoCompleteResponse(request, methodSymbol, completionText));
 
-                if (typeSymbol.TypeKind != TypeKind.Enum)
-                {
-                    foreach (var ctor in typeSymbol.InstanceConstructors)
-                    {
-                        completions.Add(MakeAutoCompleteResponse(request, ctor, displayName));
-                    }
-                }
-
-                return completions;
-            }
-
-            return new[] { MakeAutoCompleteResponse(request, symbol, displayName) };
+            return completions;
         }
 
-        private AutoCompleteResponse MakeAutoCompleteResponse(AutoCompleteRequest request, ISymbol symbol, string displayName, bool includeOptionalParams = true)
+        private IEnumerable<AutoCompleteResponse> MakeSnippetedResponses(AutoCompleteRequest request, INamedTypeSymbol typeSymbol, string completionText)
+        {
+            var completions = new List<AutoCompleteResponse>
+            {
+                MakeAutoCompleteResponse(request, typeSymbol, completionText)
+            };
+
+            if (typeSymbol.TypeKind != TypeKind.Enum)
+            {
+                foreach (var ctor in typeSymbol.InstanceConstructors)
+                {
+                    completions.Add(MakeAutoCompleteResponse(request, ctor, completionText));
+                }
+            }
+
+            return completions;
+        }
+
+        private AutoCompleteResponse MakeAutoCompleteResponse(AutoCompleteRequest request, ISymbol symbol, string completionText, bool includeOptionalParams = true)
         {
             var displayNameGenerator = new SnippetGenerator();
             displayNameGenerator.IncludeMarkers = false;
             displayNameGenerator.IncludeOptionalParameters = includeOptionalParams;
 
             var response = new AutoCompleteResponse();
-            response.CompletionText = displayName;
+            response.CompletionText = completionText;
 
             // TODO: Do something more intelligent here
             response.DisplayText = displayNameGenerator.Generate(symbol);

--- a/src/OmniSharp.Roslyn/Extensions/SymbolExtensions.cs
+++ b/src/OmniSharp.Roslyn/Extensions/SymbolExtensions.cs
@@ -7,11 +7,23 @@ namespace OmniSharp.Extensions
     {
         public static string GetKind(this ISymbol symbol)
         {
-            var namedType = symbol as INamedTypeSymbol;
-            if (namedType != null)
+            if (symbol is INamedTypeSymbol namedType)
             {
                 return Enum.GetName(namedType.TypeKind.GetType(), namedType.TypeKind);
             }
+
+            if (symbol.Kind == SymbolKind.Field &&
+                symbol.ContainingType?.TypeKind == TypeKind.Enum &&
+                symbol.Name != WellKnownMemberNames.EnumBackingFieldName)
+            {
+                return "EnumMember";
+            }
+
+            if ((symbol as IFieldSymbol)?.IsConst == true)
+            {
+                return "Const";
+            }
+
             return Enum.GetName(symbol.Kind.GetType(), symbol.Kind);
         }
     }


### PR DESCRIPTION
This change fixes a regression where overloads would not be collapsed in the VS Code completion list. In addition, I added a couple of tweaks to ensure that we report the "EnumMember" and "Const" kinds.