### PR TITLE
Use SymbolFinder.FindDerivedClassesAsync inside "find implementations" endpoint

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
@@ -6,9 +6,9 @@ using OmniSharp.Models;
 
 namespace OmniSharp.Helpers
 {
-    public static class QuickFixHelper
+    public static class LocationExtensions
     {
-        public static async Task<QuickFix> GetQuickFix(OmniSharpWorkspace workspace, Location location)
+        public static QuickFix GetQuickFix(this Location location, OmniSharpWorkspace workspace)
         {
             if (!location.IsInSource)
                 throw new Exception("Location is not in the source tree");
@@ -17,8 +17,7 @@ namespace OmniSharp.Helpers
             var path = lineSpan.Path;
             var documents = workspace.GetDocuments(path);
             var line = lineSpan.StartLinePosition.Line;
-            var syntaxTree = await documents.First().GetSyntaxTreeAsync();
-            var text = syntaxTree.GetText().Lines[line].ToString();
+            var text = location.SourceTree.GetText().Lines[line].ToString();
 
             return new QuickFix
             {

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/QuickFixExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/QuickFixExtensions.cs
@@ -7,23 +7,23 @@ namespace OmniSharp.Helpers
 {
     internal static class QuickFixExtensions
     {
-        internal static async Task AddQuickFix(this ICollection<QuickFix> quickFixes, OmniSharpWorkspace workspace, Location location)
-        {
-            if (location.IsInSource)
-            {
-                var quickFix = await QuickFixHelper.GetQuickFix(workspace, location);
-                quickFixes.Add(quickFix);
-            }
-        }
-
-        internal static async Task AddQuickFixes(this ICollection<QuickFix> quickFixes, OmniSharpWorkspace workspace, IEnumerable<ISymbol> symbols)
+        internal static void AddRange(this ICollection<QuickFix> quickFixes, IEnumerable<ISymbol> symbols, OmniSharpWorkspace workspace)
         {
             foreach (var symbol in symbols)
             {
                 foreach (var location in symbol.Locations)
                 {
-                    await AddQuickFix(quickFixes, workspace, location);
+                    quickFixes.Add(location, workspace);
                 }
+            }
+        }
+
+        internal static void Add(this ICollection<QuickFix> quickFixes, Location location, OmniSharpWorkspace workspace)
+        {
+            if (location.IsInSource)
+            {
+                var quickFix = location.GetQuickFix(workspace);
+                quickFixes.Add(quickFix);
             }
         }
     }

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/QuickFixExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/QuickFixExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using OmniSharp.Models;
+
+namespace OmniSharp.Helpers
+{
+    internal static class QuickFixExtensions
+    {
+        internal static async Task AddQuickFix(this ICollection<QuickFix> quickFixes, OmniSharpWorkspace workspace, Location location)
+        {
+            if (location.IsInSource)
+            {
+                var quickFix = await QuickFixHelper.GetQuickFix(workspace, location);
+                quickFixes.Add(quickFix);
+            }
+        }
+
+        internal static async Task AddQuickFixes(this ICollection<QuickFix> quickFixes, OmniSharpWorkspace workspace, IEnumerable<ISymbol> symbols)
+        {
+            foreach (var symbol in symbols)
+            {
+                foreach (var location in symbol.Locations)
+                {
+                    await AddQuickFix(quickFixes, workspace, location);
+                }
+            }
+        }
+    }
+}

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/QuickFixHelper.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/QuickFixHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -31,15 +30,6 @@ namespace OmniSharp.Helpers
                 EndColumn = lineSpan.EndLinePosition.Character,
                 Projects = documents.Select(document => document.Project.Name).ToArray()
             };
-        }
-
-        public static async Task AddQuickFix(ICollection<QuickFix> quickFixes, OmniSharpWorkspace workspace, Location location)
-        {
-            if (location.IsInSource)
-            {
-                var quickFix = await GetQuickFix(workspace, location);
-                quickFixes.Add(quickFix);
-            }
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindImplementationsService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindImplementationsService.cs
@@ -38,15 +38,15 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                 var quickFixes = new List<QuickFix>();
 
                 var implementations = await SymbolFinder.FindImplementationsAsync(symbol, _workspace.CurrentSolution);
-                await quickFixes.AddQuickFixes(_workspace, implementations);
+                quickFixes.AddRange(implementations, _workspace);
 
                 var overrides = await SymbolFinder.FindOverridesAsync(symbol, _workspace.CurrentSolution);
-                await quickFixes.AddQuickFixes(_workspace, overrides);
+                quickFixes.AddRange(overrides, _workspace);
 
                 if (symbol is INamedTypeSymbol namedTypeSymbol)
                 {
                     var derivedTypes = await SymbolFinder.FindDerivedClassesAsync(namedTypeSymbol, _workspace.CurrentSolution);
-                    await quickFixes.AddQuickFixes(_workspace, derivedTypes);
+                    quickFixes.AddRange(derivedTypes, _workspace);
                 }
 
                 response = new QuickFixResponse(quickFixes.OrderBy(q => q.FileName)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindImplementationsService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindImplementationsService.cs
@@ -49,6 +49,19 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                     quickFixes.AddRange(derivedTypes, _workspace);
                 }
 
+                // also include the original definition of the symbol
+                if (!symbol.IsAbstract)
+                {
+                    // for partial methods, pick the one with body
+                    if (symbol is IMethodSymbol method)
+                    {
+                        symbol = method.PartialImplementationPart ?? symbol;
+                    }
+
+                    var location = symbol.Locations.First();
+                    quickFixes.Add(location, _workspace);
+                }
+
                 response = new QuickFixResponse(quickFixes.OrderBy(q => q.FileName)
                                                             .ThenBy(q => q.Line)
                                                             .ThenBy(q => q.Column));

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindImplementationsService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindImplementationsService.cs
@@ -38,15 +38,15 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                 var quickFixes = new List<QuickFix>();
 
                 var implementations = await SymbolFinder.FindImplementationsAsync(symbol, _workspace.CurrentSolution);
-                await AddQuickFixes(quickFixes, implementations);
+                await quickFixes.AddQuickFixes(_workspace, implementations);
 
                 var overrides = await SymbolFinder.FindOverridesAsync(symbol, _workspace.CurrentSolution);
-                await AddQuickFixes(quickFixes, overrides);
+                await quickFixes.AddQuickFixes(_workspace, overrides);
 
-                if (symbol is INamedTypeSymbol)
+                if (symbol is INamedTypeSymbol namedTypeSymbol)
                 {
-                    var derivedTypes = await SymbolFinder.FindDerivedClassesAsync((INamedTypeSymbol)symbol, _workspace.CurrentSolution);
-                    await AddQuickFixes(quickFixes, derivedTypes);
+                    var derivedTypes = await SymbolFinder.FindDerivedClassesAsync(namedTypeSymbol, _workspace.CurrentSolution);
+                    await quickFixes.AddQuickFixes(_workspace, derivedTypes);
                 }
 
                 response = new QuickFixResponse(quickFixes.OrderBy(q => q.FileName)
@@ -55,17 +55,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
             }
 
             return response;
-        }
-
-        private async Task AddQuickFixes(ICollection<QuickFix> quickFixes, IEnumerable<ISymbol> symbols)
-        {
-            foreach (var symbol in symbols)
-            {
-                foreach (var location in symbol.Locations)
-                {
-                    await QuickFixHelper.AddQuickFix(quickFixes, _workspace, location);
-                }
-            }
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindImplementationsService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindImplementationsService.cs
@@ -49,7 +49,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                     quickFixes.AddRange(derivedTypes, _workspace);
                 }
 
-                // also include the original definition of the symbol
+                // also include the original declaration of the symbol
                 if (!symbol.IsAbstract)
                 {
                     // for partial methods, pick the one with body

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindUsagesService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindUsagesService.cs
@@ -59,9 +59,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                     }
                 }
 
-                var quickFixTasks = locations.Distinct().Select(async l => await QuickFixHelper.GetQuickFix(_workspace, l));
+                var quickFixes = locations.Distinct().Select(l => l.GetQuickFix(_workspace));
 
-                var quickFixes = await Task.WhenAll(quickFixTasks);
+                //var quickFixes = await Task.WhenAll(quickFixTasks);
                 response = new QuickFixResponse(quickFixes.Distinct()
                                                 .OrderBy(q => q.FileName)
                                                 .ThenBy(q => q.Line)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindUsagesService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindUsagesService.cs
@@ -61,7 +61,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
 
                 var quickFixes = locations.Distinct().Select(l => l.GetQuickFix(_workspace));
 
-                //var quickFixes = await Task.WhenAll(quickFixTasks);
                 response = new QuickFixResponse(quickFixes.Distinct()
                                                 .OrderBy(q => q.FileName)
                                                 .ThenBy(q => q.Line)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoRegionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoRegionService.cs
@@ -38,7 +38,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
 
                 foreach (var regionTrivia in regionTrivias.Distinct())
                 {
-                    regions.Add(await QuickFixHelper.GetQuickFix(_workspace, regionTrivia.GetLocation()));
+                    regions.Add(regionTrivia.GetLocation().GetQuickFix(_workspace));
                 }
             }
             return new QuickFixResponse(regions);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
@@ -92,7 +92,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         [Theory]
         [InlineData("dummy.cs")]
         [InlineData("dummy.csx")]
-        public async Task CanFindOriginalTypeSymbol(string filename)
+        public async Task CanFindTypeDeclaration(string filename)
         {
             const string code = @"
                 public class MyClass 
@@ -113,7 +113,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         [Theory]
         [InlineData("dummy.cs")]
         [InlineData("dummy.csx")]
-        public async Task CanFindOriginalMethodSymbol(string filename)
+        public async Task CanFindMethodDeclaration(string filename)
         {
             const string code = @"
                 public class MyClass 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
@@ -22,21 +22,25 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
         protected override string EndpointName => OmniSharpEndpoints.FindImplementations;
 
-        [Fact]
-        public async Task CanFindInterfaceTypeImplementation()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task CanFindInterfaceTypeImplementation(string filename)
         {
             const string code = @"
                 public interface Som$$eInterface {}
                 public class SomeClass : SomeInterface {}";
 
-            var implementations = await FindImplementationsAsync(code);
+            var implementations = await FindImplementationsAsync(code, filename);
             var implementation = implementations.First();
 
             Assert.Equal("SomeClass", implementation.Name);
         }
 
-        [Fact]
-        public async Task CanFindInterfaceMethodImplementation()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task CanFindInterfaceMethodImplementation(string filename)
         {
             const string code = @"
                 public interface SomeInterface { void Some$$Method(); }
@@ -44,15 +48,17 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                     public void SomeMethod() {}
                 }";
 
-            var implementations = await FindImplementationsAsync(code);
+            var implementations = await FindImplementationsAsync(code, filename);
             var implementation = implementations.First();
 
             Assert.Equal("SomeMethod", implementation.Name);
             Assert.Equal("SomeClass", implementation.ContainingType.Name);
         }
 
-        [Fact]
-        public async Task CanFindOverride()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task CanFindOverride(string filename)
         {
             const string code = @"
                 public class BaseClass { public abstract Some$$Method() {} }
@@ -61,29 +67,31 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                     public override SomeMethod() {}
                 }";
 
-            var implementations = await FindImplementationsAsync(code);
+            var implementations = await FindImplementationsAsync(code, filename);
             var implementation = implementations.First();
 
             Assert.Equal("SomeMethod", implementation.Name);
             Assert.Equal("SomeClass", implementation.ContainingType.Name);
         }
 
-        [Fact]
-        public async Task CanFindSubclass()
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task CanFindSubclass(string filename)
         {
             const string code = @"
                 public class BaseClass {}
                 public class SomeClass : Base$$Class {}";
 
-            var implementations = await FindImplementationsAsync(code);
+            var implementations = await FindImplementationsAsync(code, filename);
             var implementation = implementations.First();
 
             Assert.Equal("SomeClass", implementation.Name);
         }
 
-        private async Task<IEnumerable<ISymbol>> FindImplementationsAsync(string code)
+        private async Task<IEnumerable<ISymbol>> FindImplementationsAsync(string code, string filename)
         {
-            var testFile = new TestFile("dummy.cs", code);
+            var testFile = new TestFile(filename, code);
             using (var host = CreateOmniSharpHost(testFile))
             {
                 var point = testFile.Content.GetPointFromPosition();


### PR DESCRIPTION
Replace the hand-rolled code used to find derived named type symbols with [SymbolFinder.FindDerivedClassesAsync](http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/FindSymbols/SymbolFinder_Hierarchy.cs,dbb07fa6e6e5a08c). That API didn't exist at the time of writing that feature - it was only added, I believe, for VS15.

Also enabled the find implementations code to run on CSX files.