### PR TITLE
Prefix OmniSharp-specific configuration environment variables with "OMNISHARP_"

### DIFF
--- a/src/OmniSharp.Host/Startup.cs
+++ b/src/OmniSharp.Host/Startup.cs
@@ -41,7 +41,7 @@ namespace OmniSharp
             var configBuilder = new ConfigurationBuilder()
                 .SetBasePath(AppContext.BaseDirectory)
                 .AddJsonFile(Constants.ConfigFile, optional: true)
-                .AddEnvironmentVariables();
+                .AddEnvironmentVariables("OMNISHARP_");
 
             if (env.AdditionalArguments?.Length > 0)
             {


### PR DESCRIPTION
This is a breaking change, but of - I believe - small impact because it's very much a power feature to feed configuration into OmniSharp via environment variables (pretty much all current use cases would be via `omnisharp.json` or command line arguments).

However, we still allow to override any of the configuration via environment variables. 
Because we didn't prefix OmniSharp specific env variables, it can lead to unexpected results like https://github.com/OmniSharp/omnisharp-vscode/issues/1512. 

This PR requires that OmniSharp uses for configuration only environment variables following this format: `OMNISHARP_{name}`. 
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1512.