### PR TITLE
Report and exit if installation of SDK fails

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -297,7 +297,7 @@ void InstallDotNetSdk(BuildEnvironment env, BuildPlan plan, string version, stri
     argList.Add("-InstallDir");
     argList.Add(installFolder);
 
-    Run(env.ShellCommand, $"{env.ShellArgument} {scriptFilePath} {string.Join(" ", argList)}");
+    Run(env.ShellCommand, $"{env.ShellArgument} {scriptFilePath} {string.Join(" ", argList)}").ExceptionOnError($"Failed to Install .NET Core SDK {version}");
 }
 
 /// <summary>


### PR DESCRIPTION
I'm using this  [dotnet-cli](https://aur.archlinux.org/packages/dotnet-cli/ ) (binary Ubuntu-based)  package  on Arch Linux which works fine even though Arch Linux is not an _officially_ supported platform.

Thanks to [Stop deploying SDKs with OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn/pull/847)  I'm one step closer to building this project on Arch Linux.

This commit improves error reporting from:

```
...
========================================
BuildEnvironment
========================================
Executing task: BuildEnvironment
/home/juergen/csharp/omnisharp-roslyn/.dotnet-legacy/dotnet-install.sh: line 70: VERSION_ID: unbound variable
Using .NET CLI
  Version: 1.0.4
  RID: ubuntu.16.10-x64
  Base Path: /opt/dotnet/sdk/1.0.4
Finished executing task: BuildEnvironment

========================================
PopulateRuntimes
========================================
Executing task: PopulateRuntimes

```

(execution of build script continues) to

```
...
========================================
BuildEnvironment
========================================
Executing task: BuildEnvironment
/home/juergen/csharp/omnisharp-roslyn/.dotnet-legacy/dotnet-install.sh: line 70: VERSION_ID: unbound variable
An error occurred when executing task 'BuildEnvironment'.
Error: Failed to Install .NET Core SDK 1.0.0-preview2-1-003177
juergen@samson:~/csharp/omnisharp-roslyn → 

```

