### PR TITLE
Move back to NuGet 4.0.0 RTM packages

### DIFF
--- a/src/OmniSharp.Abstractions/OmniSharp.Abstractions.csproj
+++ b/src/OmniSharp.Abstractions/OmniSharp.Abstractions.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-    <PackageReference Include="NuGet.Versioning" Version="4.3.0-beta1-2418" />
+    <PackageReference Include="NuGet.Versioning" Version="4.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/OmniSharp.MSBuild/OmniSharp.MSBuild.csproj
+++ b/src/OmniSharp.MSBuild/OmniSharp.MSBuild.csproj
@@ -20,9 +20,9 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="15.3.0-preview-000117-01" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.0-preview-000117-01" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.0-preview-000117-01" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="4.3.0-beta1-2418" />
-    <PackageReference Include="NuGet.ProjectModel" Version="4.3.0-beta1-2418" />
-    <PackageReference Include="NuGet.Versioning" Version="4.3.0-beta1-2418" />
+    <PackageReference Include="NuGet.Packaging.Core" Version="4.0.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="4.0.0" />
+    <PackageReference Include="NuGet.Versioning" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
   </ItemGroup>
 

--- a/tests/app.config
+++ b/tests/app.config
@@ -23,23 +23,23 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Packaging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Packaging.Core.Types" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.RuntimeModel" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Composition.AttributedModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>


### PR DESCRIPTION
The NuGet 4.3.0 preview packages really aren't ready for prime time yet. Moving back to 4.0.0 packages.