### PR TITLE
Minor typo in ProjectFileInfo logging message

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -148,7 +148,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                                 Version version;
                                 if (FrameworkReferenceResolver.Default.TryGetAssembly(referenceName, framework, out path, out version))
                                 {
-                                    logger.LogInformation($"Resolved refernce path: {referenceName} => {version} at {path}");
+                                    logger.LogInformation($"Resolved reference path: {referenceName} => {version} at {path}");
                                 }
                                 else
                                 {


### PR DESCRIPTION
Minor typo 'reference' misspelled as 'refernce'