### PR TITLE
Rework code action service

### DIFF
--- a/src/OmniSharp.Abstractions/Configuration.cs
+++ b/src/OmniSharp.Abstractions/Configuration.cs
@@ -11,7 +11,7 @@ namespace OmniSharp
         public readonly static string RoslynCSharpFeatures = GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.CSharp.Features");
         public readonly static string RoslynWorkspaces = GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.Workspaces");
 
-        public static string GetRoslynAssemblyFullName(string name)
+        private static string GetRoslynAssemblyFullName(string name)
         {
             return $"{name}, Version={RoslynVersion}, Culture=neutral, PublicKeyToken={RoslynPublicKeyToken}";
         }

--- a/src/OmniSharp.Abstractions/Utilities/DictionaryExtensions.cs
+++ b/src/OmniSharp.Abstractions/Utilities/DictionaryExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace OmniSharp.Utilities
+{
+    internal static class DictionaryExtensions
+    {
+        public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, Func<TKey, TValue> valueGetter)
+        {
+            if (!dictionary.TryGetValue(key, out var value))
+            {
+                value = valueGetter(key);
+                dictionary.Add(key, value);
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/OmniSharp.Roslyn.CSharp/CodeActions/ExternalCodeActionProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/CodeActions/ExternalCodeActionProvider.cs
@@ -3,12 +3,13 @@ using OmniSharp.Services;
 
 namespace OmniSharp.Roslyn.CSharp.Services.CodeActions
 {
+    [Shared]
     [Export(typeof(ICodeActionProvider))]
     public class ExternalCodeActionProvider : AbstractCodeActionProvider
     {
         [ImportingConstructor]
-        public ExternalCodeActionProvider(ExternalFeaturesHostServicesProvider featuresHostServicesProvider)
-            : base("ExternalCodeActions", featuresHostServicesProvider.Assemblies)
+        public ExternalCodeActionProvider(ExternalFeaturesHostServicesProvider hostServicesProvider)
+            : base("ExternalCodeActions", hostServicesProvider.Assemblies)
         {
         }
     }

--- a/src/OmniSharp.Roslyn.CSharp/CodeActions/RoslynCodeActionProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/CodeActions/RoslynCodeActionProvider.cs
@@ -3,6 +3,7 @@ using OmniSharp.Services;
 
 namespace OmniSharp.Roslyn.CSharp.Services.CodeActions
 {
+    [Shared]
     [Export(typeof(ICodeActionProvider))]
     public class RoslynCodeActionProvider : AbstractCodeActionProvider
     {

--- a/src/OmniSharp.Roslyn.CSharp/Services/ExternalFeaturesHostServicesProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/ExternalFeaturesHostServicesProvider.cs
@@ -7,19 +7,19 @@ using OmniSharp.Services;
 
 namespace OmniSharp.Roslyn.CSharp.Services
 {
+    [Shared]
     [Export(typeof(IHostServicesProvider))]
     [Export(typeof(ExternalFeaturesHostServicesProvider))]
-    [Shared]
     public class ExternalFeaturesHostServicesProvider : IHostServicesProvider
     {
         public ImmutableArray<Assembly> Assemblies { get; }
 
         [ImportingConstructor]
-        public ExternalFeaturesHostServicesProvider(IAssemblyLoader loader, OmniSharpOptions options, IOmniSharpEnvironment env)
+        public ExternalFeaturesHostServicesProvider(IAssemblyLoader loader, OmniSharpOptions options, IOmniSharpEnvironment environment)
         {
             var builder = ImmutableArray.CreateBuilder<Assembly>();
 
-            var roslynExtensionsLocations = options.RoslynExtensionsOptions.GetNormalizedLocationPaths(env);
+            var roslynExtensionsLocations = options.RoslynExtensionsOptions.GetNormalizedLocationPaths(environment);
             if (roslynExtensionsLocations?.Any() == true)
             {
                 foreach (var roslynExtensionsLocation in roslynExtensionsLocations)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/GetCodeActionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/GetCodeActionService.cs
@@ -60,7 +60,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring
             {
                 foreach (var provider in _codeActionProviders)
                 {
-                    var providers = provider.Refactorings;
+                    var providers = provider.CodeRefactoringProviders;
 
                     foreach (var codeActionProvider in providers)
                     {

--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/RunCodeActionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/RunCodeActionService.cs
@@ -93,7 +93,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring
             {
                 foreach (var provider in _codeActionProviders)
                 {
-                    var providers = provider.Refactorings;
+                    var providers = provider.CodeRefactoringProviders;
 
                     foreach (var codeActionProvider in providers)
                     {

--- a/src/OmniSharp.Roslyn.CSharp/Services/RoslynFeaturesHostServicesProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/RoslynFeaturesHostServicesProvider.cs
@@ -1,14 +1,13 @@
 ﻿using System.Collections.Immutable;
 using System.Composition;
 using System.Reflection;
-using OmniSharp.Options;
 using OmniSharp.Services;
 
 namespace OmniSharp.Roslyn.CSharp.Services
 {
+    [Shared]
     [Export(typeof(IHostServicesProvider))]
     [Export(typeof(RoslynFeaturesHostServicesProvider))]
-    [Shared]
     public class RoslynFeaturesHostServicesProvider : IHostServicesProvider
     {
         public ImmutableArray<Assembly> Assemblies { get; }
@@ -17,13 +16,7 @@ namespace OmniSharp.Roslyn.CSharp.Services
         public RoslynFeaturesHostServicesProvider(IAssemblyLoader loader)
         {
             var builder = ImmutableArray.CreateBuilder<Assembly>();
-
-            var Features = Configuration.GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.Features");
-            var CSharpFeatures = Configuration.GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.CSharp.Features");
-
-            builder.AddRange(loader.Load(Features, CSharpFeatures));
-
-
+            builder.AddRange(loader.Load(Configuration.RoslynFeatures, Configuration.RoslynCSharpFeatures));
             Assemblies = builder.ToImmutable();
         }
     }

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Refactoring/FixUsingsWorker.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Refactoring/FixUsingsWorker.cs
@@ -32,7 +32,7 @@ namespace OmniSharp
         {
             _providers = providers;
 
-            var codeFixProviders = providers.SelectMany(p => p.CodeFixes);
+            var codeFixProviders = providers.SelectMany(p => p.CodeFixProviders);
 
             _addImportProvider = FindCodeFixProviderByTypeFullName(codeFixProviders, CodeActionHelper.AddImportProviderName);
             _removeUnnecessaryUsingsProvider = FindCodeFixProviderByTypeFullName(codeFixProviders, CodeActionHelper.RemoveUnnecessaryUsingsProviderName);

--- a/src/OmniSharp.Roslyn/Services/AbstractCodeActionProvider.cs
+++ b/src/OmniSharp.Roslyn/Services/AbstractCodeActionProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
@@ -11,8 +10,8 @@ namespace OmniSharp.Services
     public abstract class AbstractCodeActionProvider : ICodeActionProvider
     {
         public string ProviderName { get; }
-        public ImmutableArray<CodeRefactoringProvider> Refactorings { get; }
-        public ImmutableArray<CodeFixProvider> CodeFixes { get; }
+        public ImmutableArray<CodeRefactoringProvider> CodeRefactoringProviders { get; }
+        public ImmutableArray<CodeFixProvider> CodeFixProviders { get; }
 
         public ImmutableArray<Assembly> Assemblies { get; }
 
@@ -29,13 +28,13 @@ namespace OmniSharp.Services
                                !type.GetTypeInfo().ContainsGenericParameters));
             // TODO: handle providers with generic params
 
-            this.Refactorings = types
+            this.CodeRefactoringProviders = types
                 .Where(t => typeof(CodeRefactoringProvider).IsAssignableFrom(t))
                 .Select(type => CreateInstance<CodeRefactoringProvider>(type))
                 .Where(instance => instance != null)
                 .ToImmutableArray();
 
-            this.CodeFixes = types
+            this.CodeFixProviders = types
                 .Where(t => typeof(CodeFixProvider).IsAssignableFrom(t))
                 .Select(type => CreateInstance<CodeFixProvider>(type))
                 .Where(instance => instance != null)

--- a/src/OmniSharp.Roslyn/Services/ICodeActionProvider.cs
+++ b/src/OmniSharp.Roslyn/Services/ICodeActionProvider.cs
@@ -7,8 +7,8 @@ namespace OmniSharp.Services
 {
     public interface ICodeActionProvider
     {
-        ImmutableArray<CodeRefactoringProvider> Refactorings { get; }
-        ImmutableArray<CodeFixProvider> CodeFixes { get; }
+        ImmutableArray<CodeRefactoringProvider> CodeRefactoringProviders { get; }
+        ImmutableArray<CodeFixProvider> CodeFixProviders { get; }
         ImmutableArray<Assembly> Assemblies { get; }
     }
 }


### PR DESCRIPTION
This change reworks how we compute code fixes and refactorings. Much of this is just basic refactoring and clean up, but there are substantial changes to to code fixes are computed. Now, we'll return code fixes when there are multiple diagnostics with overlapping spans. For example, consider this scenario:

```C#
class C
{
    void M()
    {
        StringBuilder
    }
}
```

There are three diagnostics at the position immediately following `StringBuilder`:

1. CS1001: Identifier expected
2. CS1002: ; expected
3. CS0246: The type or name 'StringBuilder' could not be found

The problem is that the first two diagnostics have a zero-width span immediately following `StringBuilder`, but the last diagnostic has the same span as `StringBuilder`. Previously, if the code action service was called with the line and column after `StringBuilder`, only the first two diagnostics would be considered for fixes because their spans are an exact match. However, it's the last diagnostic that we really want because that's the one for which the 'add import' code fix is triggered by. This change ensures that we'll consider all relevant diagnostics when computing code fixes.