### PR TITLE
Update Roslyn dependency to 2.3.0-beta2

### DIFF
--- a/src/OmniSharp.Abstractions/Configuration.cs
+++ b/src/OmniSharp.Abstractions/Configuration.cs
@@ -4,7 +4,7 @@ namespace OmniSharp
     {
         public static bool ZeroBasedIndices = false;
 
-        public const string RoslynVersion = "2.1.0.0";
+        public const string RoslynVersion = "2.3.0.0";
         public const string RoslynPublicKeyToken = "31bf3856ad364e35";
 
         public readonly static string RoslynFeatures = GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.Features");

--- a/src/OmniSharp.DotNet/OmniSharp.DotNet.csproj
+++ b/src/OmniSharp.DotNet/OmniSharp.DotNet.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.0-beta2" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel" Version="1.0.0-rc3-1-003177" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />

--- a/src/OmniSharp.DotNetTest/OmniSharp.DotNetTest.csproj
+++ b/src/OmniSharp.DotNetTest/OmniSharp.DotNetTest.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.0-beta2" />
   </ItemGroup>
 
   <!-- Legacy 'dotnet test' support -->

--- a/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
+++ b/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.0-beta2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.3.0-beta2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.0-beta2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">

--- a/src/OmniSharp.Roslyn/OmniSharp.Roslyn.csproj
+++ b/src/OmniSharp.Roslyn/OmniSharp.Roslyn.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.3.0-beta2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.3.0-beta2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.0" />
   </ItemGroup>
 

--- a/src/OmniSharp.Script/OmniSharp.Script.csproj
+++ b/src/OmniSharp.Script/OmniSharp.Script.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dotnet.Script.NuGetMetadataResolver" Version="2.0.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.3.0-beta2" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel" Version="1.0.0-rc3-1-003177" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>

--- a/tests/OmniSharp.Stdio.Tests/OmniSharp.Stdio.Tests.csproj
+++ b/tests/OmniSharp.Stdio.Tests/OmniSharp.Stdio.Tests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.3.0-beta2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />

--- a/tests/TestUtility/TestUtility.csproj
+++ b/tests/TestUtility/TestUtility.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.0-beta2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.3.0-beta2" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel" Version="1.0.0-rc3-1-003177" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel.Workspaces" Version="1.0.0-preview2-1-003177" />
     <PackageReference Include="xunit" Version="2.2.0" />


### PR DESCRIPTION
This change also tweaks the BufferManager to fix some bugs that the latest Roslyn now exposes (an OmniSharp test started failing without this change).