### PR TITLE
added support for disabling any project system via configuration

### DIFF
--- a/src/OmniSharp.DotNet/DotNetProjectSystem.cs
+++ b/src/OmniSharp.DotNet/DotNetProjectSystem.cs
@@ -102,17 +102,6 @@ namespace OmniSharp.DotNet
 
         public void Initalize(IConfiguration configuration)
         {
-            if (!bool.TryParse(configuration["enabled"], out var enabled))
-            {
-                enabled = true;
-            }
-
-            if (!enabled)
-            {
-                _logger.LogInformation("DotNetProjectSystem is disabled");
-                return;
-            }
-
             _logger.LogInformation($"Initializing in {_environment.TargetDirectory}");
 
             if (!bool.TryParse(configuration["enablePackageRestore"], out _enableRestorePackages))

--- a/src/OmniSharp.Host/Services/WorkspaceHelper.cs
+++ b/src/OmniSharp.Host/Services/WorkspaceHelper.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Composition.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Options;
+using OmniSharp.Roslyn;
+using OmniSharp.Roslyn.Options;
+
+namespace OmniSharp.Services
+{
+    public class WorkspaceHelper
+    {
+        private readonly CompositionHost _compositionHost;
+        private readonly IConfiguration _configuration;
+        private readonly OmniSharpOptions _options;
+        private readonly ILogger _logger;
+
+        public WorkspaceHelper(CompositionHost compositionHost, IConfiguration configuration, OmniSharpOptions options, ILoggerFactory loggerFactory)
+        {
+            _compositionHost = compositionHost;
+            _configuration = configuration;
+            _options = options;
+            _logger = loggerFactory.CreateLogger<WorkspaceHelper>();
+        }
+
+        public void Initialize(OmniSharpWorkspace workspace)
+        {
+            var projectEventForwarder = _compositionHost.GetExport<ProjectEventForwarder>();
+            projectEventForwarder.Initialize();
+
+            // Initialize all the project systems discovered with MEF
+            foreach (var projectSystem in _compositionHost.GetExports<IProjectSystem>())
+            {
+                try
+                {
+                    var projectConfiguration = _configuration.GetSection(projectSystem.Key);
+                    var enabledProjectFlag = projectConfiguration.GetValue<bool>("enabled", defaultValue: true);
+                    if (enabledProjectFlag)
+                    {
+                        projectSystem.Initalize(projectConfiguration);
+                    }
+                    else
+                    {
+                        _logger.LogInformation($"Project system '{projectSystem.GetType().FullName}' is disabled in the configuration.");
+                    }
+                }
+                catch (Exception e)
+                {
+                    var message = $"The project system '{projectSystem.GetType().FullName}' threw exception during initialization.";
+                    // if a project system throws an unhandled exception it should not crash the entire server
+                    _logger.LogError(e, message);
+                }
+            }
+
+            ProvideOptions(workspace, _options);
+
+            // Mark the workspace as initialized
+            workspace.Initialized = true;
+        }
+
+        public void ProvideOptions(OmniSharpWorkspace workspace, OmniSharpOptions options)
+        {
+            // run all workspace options providers discovered with MEF
+            foreach (var workspaceOptionsProvider in _compositionHost.GetExports<IWorkspaceOptionsProvider>())
+            {
+                var providerName = workspaceOptionsProvider.GetType().FullName;
+
+                try
+                {
+                    _logger.LogInformation($"Invoking Workspace Options Provider: {providerName}");
+                    workspace.Options = workspaceOptionsProvider.Process(workspace.Options, options.FormattingOptions);
+                }
+                catch (Exception e)
+                {
+                    var message = $"The workspace options provider '{providerName}' threw exception during initialization.";
+                    _logger.LogError(e, message);
+                }
+            }
+        }
+    }
+}

--- a/src/OmniSharp.Host/Startup.cs
+++ b/src/OmniSharp.Host/Startup.cs
@@ -122,61 +122,6 @@ namespace OmniSharp
             return config.CreateContainer();
         }
 
-        public static void InitializeWorkspace(OmniSharpWorkspace workspace, CompositionHost compositionHost, IConfiguration configuration, ILogger logger, OmniSharpOptions options)
-        {
-            var projectEventForwarder = compositionHost.GetExport<ProjectEventForwarder>();
-            projectEventForwarder.Initialize();
-
-            // Initialize all the project systems
-            foreach (var projectSystem in compositionHost.GetExports<IProjectSystem>())
-            {
-                try
-                {
-                    var projectConfiguration = configuration.GetSection(projectSystem.Key);
-                    var enabledProjectFlag = projectConfiguration.GetValue<bool>("enabled", defaultValue: true);
-                    if (enabledProjectFlag)
-                    {
-                        projectSystem.Initalize(projectConfiguration);
-                    }
-                    else
-                    {
-                        logger.LogInformation($"Project system '{projectSystem.GetType().FullName}' is disabled in the configuration.");
-                    }
-                }
-                catch (Exception e)
-                {
-                    var message = $"The project system '{projectSystem.GetType().FullName}' threw exception during initialization.";
-                    // if a project system throws an unhandled exception it should not crash the entire server
-                    logger.LogError(e, message);
-                }
-            }
-
-            ProvideWorkspaceOptions(workspace, compositionHost, logger, options);
-
-            // Mark the workspace as initialized
-            workspace.Initialized = true;
-        }
-
-        private static void ProvideWorkspaceOptions(OmniSharpWorkspace workspace, CompositionHost compositionHost, ILogger logger, OmniSharpOptions options)
-        {
-            // run all workspace options providers
-            foreach (var workspaceOptionsProvider in compositionHost.GetExports<IWorkspaceOptionsProvider>())
-            {
-                var providerName = workspaceOptionsProvider.GetType().FullName;
-
-                try
-                {
-                    logger.LogInformation($"Invoking Workspace Options Provider: {providerName}");
-                    workspace.Options = workspaceOptionsProvider.Process(workspace.Options, options.FormattingOptions);
-                }
-                catch (Exception e)
-                {
-                    var message = $"The workspace options provider '{providerName}' threw exception during initialization.";
-                    logger.LogError(e, message);
-                }
-            }
-        }
-
         public void Configure(
             IApplicationBuilder app,
             IServiceProvider serviceProvider,
@@ -215,13 +160,14 @@ namespace OmniSharp
                 logger.LogInformation($"Omnisharp server running on port '{_env.Port}' at location '{_env.TargetDirectory}' on host {_env.HostProcessId}.");
             }
 
-            InitializeWorkspace(Workspace, PluginHost, Configuration, logger, options.CurrentValue);
+            var workspaceHelper = new WorkspaceHelper(PluginHost, Configuration, options.CurrentValue, loggerFactory);
+            workspaceHelper.Initialize(Workspace);
 
             // when configuration options change
             // run workspace options providers automatically
             options.OnChange(o =>
             {
-                ProvideWorkspaceOptions(Workspace, PluginHost, logger, o);
+                workspaceHelper.ProvideOptions(Workspace, o);
             });
 
             logger.LogInformation("Configuration finished.");

--- a/src/OmniSharp.Host/Startup.cs
+++ b/src/OmniSharp.Host/Startup.cs
@@ -132,7 +132,16 @@ namespace OmniSharp
             {
                 try
                 {
-                    projectSystem.Initalize(configuration.GetSection(projectSystem.Key));
+                    var projectConfiguration = configuration.GetSection(projectSystem.Key);
+                    var enabledProjectFlag = projectConfiguration.GetValue<bool>("enabled", defaultValue: true);
+                    if (enabledProjectFlag)
+                    {
+                        projectSystem.Initalize(projectConfiguration);
+                    }
+                    else
+                    {
+                        logger.LogInformation($"Project system '{projectSystem.GetType().FullName}' is disabled in the configuration.");
+                    }
                 }
                 catch (Exception e)
                 {

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -109,7 +109,8 @@ namespace TestUtility
             var dotNetCli = compositionHost.GetExport<DotNetCliService>();
             dotNetCli.SetDotNetPath(dotNetPath);
 
-            Startup.InitializeWorkspace(workspace, compositionHost, configuration, logger, omnisharpOptions);
+            var workspaceHelper = new WorkspaceHelper(compositionHost, configuration, omnisharpOptions, loggerFactory);
+            workspaceHelper.Initialize(workspace);
 
             return new OmniSharpTestHost(serviceProvider, loggerFactory, workspace, compositionHost);
         }


### PR DESCRIPTION
At the moment we had [logic in place](https://github.com/OmniSharp/omnisharp-roslyn/blob/dev/src/OmniSharp.DotNet/DotNetProjectSystem.cs#L105-L114) that allowed users to disable the "legacy" `project.json` project system - using a configuration flag from `omnisharp.json` or any other of the several configuration sources we have in place.

For consistency, this PR extends this concept to allow the `"enabled": false` flag to be used against MsBuild and Script project systems too. 
It can help for example performance, as the user can easily (even globally) switch off scanning of the file system done by these project systems.

I also moved out some of the logic from the `Startup` class because, well, SRP.