### PR TITLE
MSBuild Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ scripts/Omnisharp*
 # Build folder
 .dotnet/
 .dotnet-legacy/
+.dotnet-future/
 tools/*
 !tools/packages.config
 

--- a/build.cake
+++ b/build.cake
@@ -194,9 +194,6 @@ Task("SetupMSBuild")
         DeleteFile(CombinePaths(folder, "Microsoft.VisualBasic.Core.targets"));
         DeleteFile(CombinePaths(folder, "VBCSCompiler.exe"));
         DeleteFile(CombinePaths(folder, "VBCSCompiler.exe.config"));
-        DeleteFile(CombinePaths(folder, "csi.exe"));
-        DeleteFile(CombinePaths(folder, "csi.exe.config"));
-        DeleteFile(CombinePaths(folder, "csi.rsp"));
         DeleteFile(CombinePaths(folder, "vbc.exe"));
         DeleteFile(CombinePaths(folder, "vbc.exe.config"));
         DeleteFile(CombinePaths(folder, "vbc.rsp"));

--- a/build.cake
+++ b/build.cake
@@ -176,18 +176,31 @@ Task("SetupMSBuild")
 
     CopyDirectory(msbuildNetCoreAppInstallFolder, msbuildNetCoreAppFolder);
 
-    // Finally, copy Microsoft.CSharp.Core.targets from Microsoft.Net.Compilers
-    var csharpTargetsName = "Microsoft.CSharp.Core.targets";
-    var csharpTargetsPath = CombinePaths(env.Folders.Tools, "Microsoft.Net.Compilers", "tools", csharpTargetsName);
+    // Finally, copy Microsoft.Net.Compilers
+    var roslynFolder = CombinePaths(env.Folders.Tools, "Microsoft.Net.Compilers", "tools");
+    var roslynNet46Folder = CombinePaths(msbuildNet46Folder, "Roslyn");
+    var roslynNetCoreAppFolder = CombinePaths(msbuildNetCoreAppFolder, "Roslyn");
 
-    var csharpTargetsNet46Folder = CombinePaths(msbuildNet46Folder, "Roslyn");
-    var csharpTargetsNetCoreAppFolder = CombinePaths(msbuildNetCoreAppFolder, "Roslyn");
+    CreateDirectory(roslynNet46Folder);
+    CreateDirectory(roslynNetCoreAppFolder);
 
-    CreateDirectory(csharpTargetsNet46Folder);
-    CreateDirectory(csharpTargetsNetCoreAppFolder);
+    CopyDirectory(roslynFolder, roslynNet46Folder);
+    CopyDirectory(roslynFolder, roslynNetCoreAppFolder);
 
-    CopyFile(csharpTargetsPath, CombinePaths(csharpTargetsNet46Folder, csharpTargetsName));
-    CopyFile(csharpTargetsPath, CombinePaths(csharpTargetsNetCoreAppFolder,csharpTargetsName));
+    // Delete unnecessary files
+    foreach (var folder in new[] { roslynNet46Folder, roslynNetCoreAppFolder })
+    {
+        DeleteFile(CombinePaths(folder, "Microsoft.CodeAnalysis.VisualBasic.dll"));
+        DeleteFile(CombinePaths(folder, "Microsoft.VisualBasic.Core.targets"));
+        DeleteFile(CombinePaths(folder, "VBCSCompiler.exe"));
+        DeleteFile(CombinePaths(folder, "VBCSCompiler.exe.config"));
+        DeleteFile(CombinePaths(folder, "csi.exe"));
+        DeleteFile(CombinePaths(folder, "csi.exe.config"));
+        DeleteFile(CombinePaths(folder, "csi.rsp"));
+        DeleteFile(CombinePaths(folder, "vbc.exe"));
+        DeleteFile(CombinePaths(folder, "vbc.exe.config"));
+        DeleteFile(CombinePaths(folder, "vbc.rsp"));
+    }
 });
 
 /// <summary>

--- a/build.cake
+++ b/build.cake
@@ -30,7 +30,6 @@ public class BuildPlan
     public string DotNetChannel { get; set; }
     public string DotNetVersion { get; set; }
     public string LegacyDotNetVersion { get; set; }
-    public string FutureDotNetVersion { get; set; }
     public string DownloadURL { get; set; }
     public string MSBuildRuntimeForMono { get; set; }
     public string MSBuildLibForMono { get; set; }
@@ -39,7 +38,6 @@ public class BuildPlan
     public string[] TestProjects { get; set; }
     public string[] TestAssets { get; set; }
     public string[] LegacyTestAssets { get; set; }
-    public string[] FutureTestAssets { get; set; }
 
     private string currentRid;
     private string[] targetRids;
@@ -334,11 +332,6 @@ Task("BuildEnvironment")
         installFolder: env.Folders.LegacyDotNetSdk);
 
 
-    // Install future .NET Core SDK (used for testing non-stable future SDK projects)
-    InstallDotNetSdk(env, buildPlan,
-        version: buildPlan.FutureDotNetVersion,
-        installFolder: env.Folders.FutureDotNetSdk);
-
     // Capture 'dotnet --info' output and parse out RID.
     var lines = new List<string>();
 
@@ -418,22 +411,6 @@ Task("PrepareTestAssets")
         Information($"Building {folder}...");
 
         RunTool(env.LegacyDotNetCommand, $"build", folder)
-            .ExceptionOnError($"Failed to restore '{folder}'.");
-    }
-
-    // Restore and build future test assets with future .NET Core SDK
-    foreach (var project in buildPlan.FutureTestAssets)
-    {
-        var folder = CombinePaths(env.Folders.TestAssets, "test-projects", project);
-
-        Information($"Restoring packages in {folder}...");
-
-        RunTool(env.FutureDotNetCommand, "restore", folder)
-            .ExceptionOnError($"Failed to restore '{folder}'.");
-
-        Information($"Building {folder}...");
-
-        RunTool(env.FutureDotNetCommand, $"build", folder)
             .ExceptionOnError($"Failed to restore '{folder}'.");
     }
 });

--- a/build.json
+++ b/build.json
@@ -1,9 +1,8 @@
 {
-  "DotNetInstallScriptURL": "https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain",
+  "DotNetInstallScriptURL": "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain",
   "DotNetChannel": "preview",
   "DotNetVersion": "1.0.4",
   "LegacyDotNetVersion": "1.0.0-preview2-1-003177",
-  "FutureDotNetVersion": "2.0.0-preview2-006497",
   "DownloadURL": "https://omnisharpdownload.blob.core.windows.net/ext",
   "MSBuildRuntimeForMono": "Microsoft.Build.Runtime.Mono-alpha4.zip",
   "MSBuildLibForMono": "Microsoft.Build.Lib.Mono-alpha4.zip",
@@ -35,8 +34,5 @@
     "LegacyNunitTestProject",
     "LegacyXunitTestProject",
     "LegacyMSTestProject"
-  ],
-  "FutureTestAssets": [
-    "ProjectWithSdkProperty"
   ]
 }

--- a/build.json
+++ b/build.json
@@ -1,7 +1,7 @@
 {
   "DotNetInstallScriptURL": "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain",
   "DotNetChannel": "preview",
-  "DotNetVersion": "1.0.1",
+  "DotNetVersion": "1.0.4",
   "LegacyDotNetVersion": "1.0.0-preview2-1-003177",
   "DownloadURL": "https://omnisharpdownload.blob.core.windows.net/ext",
   "MSBuildRuntimeForMono": "Microsoft.Build.Runtime.Mono-alpha4.zip",

--- a/build.json
+++ b/build.json
@@ -25,7 +25,8 @@
     "MSTestProject",
     "ProjectAndSolution",
     "ProjectAndSolutionWithProjectSection",
-    "TwoProjectsWithSolution"
+    "TwoProjectsWithSolution",
+    "ProjectWithGeneratedFile"
   ],
   "LegacyTestAssets": [
     "BasicTestProjectSample01",

--- a/build.json
+++ b/build.json
@@ -1,8 +1,9 @@
 {
-  "DotNetInstallScriptURL": "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain",
+  "DotNetInstallScriptURL": "https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain",
   "DotNetChannel": "preview",
   "DotNetVersion": "1.0.4",
   "LegacyDotNetVersion": "1.0.0-preview2-1-003177",
+  "FutureDotNetVersion": "2.0.0-preview2-006497",
   "DownloadURL": "https://omnisharpdownload.blob.core.windows.net/ext",
   "MSBuildRuntimeForMono": "Microsoft.Build.Runtime.Mono-alpha4.zip",
   "MSBuildLibForMono": "Microsoft.Build.Lib.Mono-alpha4.zip",
@@ -34,5 +35,8 @@
     "LegacyNunitTestProject",
     "LegacyXunitTestProject",
     "LegacyMSTestProject"
+  ],
+  "FutureTestAssets": [
+    "ProjectWithSdkProperty"
   ]
 }

--- a/msbuild.sh
+++ b/msbuild.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SDK_DIR="$(cd "$(dirname "$0")"/.dotnet/sdk/1.0.1/ && pwd -P)"
+SDK_DIR="$(cd "$(dirname "$0")"/.dotnet/sdk/1.0.4/ && pwd -P)"
 
 echo $SDK_DIR
 

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -16,6 +16,7 @@ public class Folders
 {
     public string DotNetSdk { get; }
     public string LegacyDotNetSdk { get; }
+    public string FutureDotNetSdk { get; }
     public string Tools { get; }
 
     public string MSBuild { get; }
@@ -33,6 +34,7 @@ public class Folders
     {
         this.DotNetSdk = PathHelper.Combine(workingDirectory, ".dotnet");
         this.LegacyDotNetSdk = PathHelper.Combine(workingDirectory, ".dotnet-legacy");
+        this.FutureDotNetSdk = PathHelper.Combine(workingDirectory, ".dotnet-future");
         this.Tools = PathHelper.Combine(workingDirectory, "tools");
 
         this.MSBuild = PathHelper.Combine(workingDirectory, "msbuild");
@@ -55,6 +57,7 @@ public class BuildEnvironment
 
     public string DotNetCommand { get; }
     public string LegacyDotNetCommand { get; }
+    public string FutureDotNetCommand { get; }
 
     public string ShellCommand { get; }
     public string ShellArgument { get; }
@@ -71,6 +74,7 @@ public class BuildEnvironment
             : PathHelper.Combine(this.Folders.DotNetSdk, "dotnet");
 
         this.LegacyDotNetCommand = PathHelper.Combine(this.Folders.LegacyDotNetSdk, "dotnet");
+        this.FutureDotNetCommand = PathHelper.Combine(this.Folders.FutureDotNetSdk, "dotnet");
 
         this.ShellCommand = isWindows ? "powershell" : "bash";
         this.ShellArgument = isWindows ? "-NoProfile /Command" : "-C";

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -16,7 +16,6 @@ public class Folders
 {
     public string DotNetSdk { get; }
     public string LegacyDotNetSdk { get; }
-    public string FutureDotNetSdk { get; }
     public string Tools { get; }
 
     public string MSBuild { get; }
@@ -34,7 +33,6 @@ public class Folders
     {
         this.DotNetSdk = PathHelper.Combine(workingDirectory, ".dotnet");
         this.LegacyDotNetSdk = PathHelper.Combine(workingDirectory, ".dotnet-legacy");
-        this.FutureDotNetSdk = PathHelper.Combine(workingDirectory, ".dotnet-future");
         this.Tools = PathHelper.Combine(workingDirectory, "tools");
 
         this.MSBuild = PathHelper.Combine(workingDirectory, "msbuild");
@@ -57,7 +55,6 @@ public class BuildEnvironment
 
     public string DotNetCommand { get; }
     public string LegacyDotNetCommand { get; }
-    public string FutureDotNetCommand { get; }
 
     public string ShellCommand { get; }
     public string ShellArgument { get; }
@@ -74,7 +71,6 @@ public class BuildEnvironment
             : PathHelper.Combine(this.Folders.DotNetSdk, "dotnet");
 
         this.LegacyDotNetCommand = PathHelper.Combine(this.Folders.LegacyDotNetSdk, "dotnet");
-        this.FutureDotNetCommand = PathHelper.Combine(this.Folders.FutureDotNetSdk, "dotnet");
 
         this.ShellCommand = isWindows ? "powershell" : "bash";
         this.ShellArgument = isWindows ? "-NoProfile /Command" : "-C";

--- a/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
+++ b/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
@@ -62,7 +62,7 @@ namespace OmniSharp.MSBuild
 
             // If MSBuild can locate VS 2017 and set up a build environment, we don't need to do anything.
             // MSBuild will take care of itself.
-            if (MSBuildHelpers.TryGetVisualStudioBuildEnvironment())
+            if (MSBuildHelpers.CanInitializeVisualStudioBuildEnvironment())
             {
                 logger.LogInformation("MSBuild will use local Visual Studio installation.");
                 s_usingVisualStudio = true;

--- a/src/OmniSharp.MSBuild/OmniSharp.MSBuild.csproj
+++ b/src/OmniSharp.MSBuild/OmniSharp.MSBuild.csproj
@@ -16,10 +16,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Build" Version="15.3.0-preview-000117-01" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.0-preview-000117-01" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.0-preview-000117-01" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.0-preview-000117-01" />
+    <PackageReference Include="Microsoft.Build" Version="15.3.0-preview-000388-01" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.0-preview-000388-01" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.0-preview-000388-01" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.0-preview-000388-01" />
     <PackageReference Include="NuGet.Packaging.Core" Version="4.0.0" />
     <PackageReference Include="NuGet.ProjectModel" Version="4.0.0" />
     <PackageReference Include="NuGet.Versioning" Version="4.0.0" />

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
@@ -20,10 +20,12 @@
             public const string OutputPath = nameof(OutputPath);
             public const string Platform = nameof(Platform);
             public const string ProjectAssetsFile = nameof(ProjectAssetsFile);
+            public const string ProvideCommandLineInvocation = nameof(ProvideCommandLineInvocation);
             public const string ProjectGuid = nameof(ProjectGuid);
             public const string ProjectName = nameof(ProjectName);
             public const string _ResolveReferenceDependencies = nameof(_ResolveReferenceDependencies);
             public const string SignAssembly = nameof(SignAssembly);
+            public const string SkipCompilerExecution = nameof(SkipCompilerExecution);
             public const string SolutionDir = nameof(SolutionDir);
             public const string TargetFramework = nameof(TargetFramework);
             public const string TargetFrameworkMoniker = nameof(TargetFrameworkMoniker);

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.TargetNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.TargetNames.cs
@@ -4,6 +4,7 @@
     {
         private static class TargetNames
         {
+            public const string Compile = nameof(Compile);
             public const string ResolveReferences = nameof(ResolveReferences);
         }
     }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -133,7 +133,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 }
 
                 var projectInstance = project.CreateProjectInstance();
-                var buildResult = projectInstance.Build(TargetNames.ResolveReferences,
+                var buildResult = projectInstance.Build(TargetNames.Compile,
                     new[] { new MSBuildLogForwarder(logger, diagnostics) });
 
                 return buildResult
@@ -214,7 +214,12 @@ namespace OmniSharp.MSBuild.ProjectFile
                 { PropertyNames.DesignTimeBuild, "true" },
                 { PropertyNames.BuildProjectReferences, "false" },
                 { PropertyNames._ResolveReferenceDependencies, "true" },
-                { PropertyNames.SolutionDir, solutionDirectory + Path.DirectorySeparatorChar }
+                { PropertyNames.SolutionDir, solutionDirectory + Path.DirectorySeparatorChar },
+
+                // This properties allow the design-time build to handle the Compile target without actually invoking the compiler.
+                // See https://github.com/dotnet/roslyn/pull/4604 for details.
+                { PropertyNames.ProvideCommandLineInvocation, "true" },
+                { PropertyNames.SkipCompilerExecution, "true" }
             };
 
             globalProperties.AddPropertyIfNeeded(

--- a/src/OmniSharp/app.config
+++ b/src/OmniSharp/app.config
@@ -1,22 +1,40 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
-  </startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
+            </dependentAssembly>
+
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="2.0.0.0-99.0.0.0" newVersion="15.1.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Build" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="2.0.0.0-99.0.0.0" newVersion="15.1.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Build.Tasks.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="2.0.0.0-99.0.0.0" newVersion="15.1.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="2.0.0.0-99.0.0.0" newVersion="15.1.0.0"/>
+            </dependentAssembly>
+
+        </assemblyBinding>
+    </runtime>
 </configuration>

--- a/test-assets/test-projects/HelloWorld/HelloWorld.csproj
+++ b/test-assets/test-projects/HelloWorld/HelloWorld.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test-assets/test-projects/NetStandardAndNetCoreApp/NetStandardAndNetCoreApp.csproj
+++ b/test-assets/test-projects/NetStandardAndNetCoreApp/NetStandardAndNetCoreApp.csproj
@@ -6,6 +6,7 @@
     <OutputType>exe</OutputType>
     <DefineConstants>NETCOREAPP;$(DefineConstants)</DefineConstants>
     <PackageTargetFallback>dnxcore50</PackageTargetFallback>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />

--- a/test-assets/test-projects/ProjectWithGeneratedFile/Program.cs
+++ b/test-assets/test-projects/ProjectWithGeneratedFile/Program.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace TestConsole
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+			var t = new TestNs.TestClass();
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/test-assets/test-projects/ProjectWithGeneratedFile/ProjectWithGeneratedFile.csproj
+++ b/test-assets/test-projects/ProjectWithGeneratedFile/ProjectWithGeneratedFile.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <XsdFile Include="**\*.xsd">
+      <Generator>MSBuild:CompileGeneratedFiles</Generator>
+    </XsdFile>
+  </ItemGroup> 
+  
+  <Target Name="CompileGeneratedFiles" 
+    BeforeTargets="CoreCompile"
+    DependsOnTargets="UpdateGeneratedFiles" 
+    Condition="'@(XsdFile)' != ''" >
+    <ItemGroup>
+      <Compile Include="$(IntermediateOutputPath)%(XsdFile.Filename).g.cs" />
+      <FileWrites Include="$(IntermediateOutputPath)%(XsdFile.Filename).g.cs" />
+    </ItemGroup>
+  </Target>
+  
+  <Target Name="UpdateGeneratedFiles"
+    Inputs="$(MSBuildProjectFile);@(XsdFile)"
+    Outputs="$(IntermediateOutputPath)%(XsdFile.Filename).g.cs">
+    <Message Text="Generating code from @(XsdFile)..."/>
+    <Copy
+      SourceFiles="@(XsdFile)"  
+      DestinationFiles="$(IntermediateOutputPath)%(XsdFile.Filename).g.cs"/>
+  </Target>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test-assets/test-projects/ProjectWithGeneratedFile/test.xsd
+++ b/test-assets/test-projects/ProjectWithGeneratedFile/test.xsd
@@ -1,0 +1,1 @@
+namespace TestNs { public class TestClass { } }

--- a/test-assets/test-projects/ProjectWithSdkProperty/Program.cs
+++ b/test-assets/test-projects/ProjectWithSdkProperty/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ProjectWithSdkProperty
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/test-assets/test-projects/ProjectWithSdkProperty/ProjectWithSdkProperty.csproj
+++ b/test-assets/test-projects/ProjectWithSdkProperty/ProjectWithSdkProperty.csproj
@@ -1,0 +1,7 @@
+<Project>
+  <Sdk Name="Microsoft.NET.Sdk" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/tests/OmniSharp.DotNetTest.Tests/AbstractGetTestStartInfoFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/AbstractGetTestStartInfoFacts.cs
@@ -29,12 +29,12 @@ namespace OmniSharp.DotNetTest.Tests
         }
 
 
-        public abstract bool UseLegacyDotNetCli { get; }
+        public abstract DotNetCliVersion DotNetCliVersion { get; }
 
         protected async Task GetDotNetTestStartInfoAsync(string projectName, string methodName, string testFramework)
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync(projectName))
-            using (var host = CreateOmniSharpHost(testProject.Directory, useLegacyDotNetCli: UseLegacyDotNetCli))
+            using (var host = CreateOmniSharpHost(testProject.Directory, dotNetCliVersion: DotNetCliVersion))
             {
                 var service = GetRequestHandler(host);
 

--- a/tests/OmniSharp.DotNetTest.Tests/AbstractRunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/AbstractRunTestFacts.cs
@@ -27,12 +27,12 @@ namespace OmniSharp.DotNetTest.Tests
             return host.GetRequestHandler<RunTestService>(OmniSharpEndpoints.V2.RunTest);
         }
 
-        public abstract bool UseLegacyDotNetCli { get; }
+        public abstract DotNetCliVersion DotNetCliVersion { get; }
 
         protected async Task<RunTestResponse> RunDotNetTestAsync(string projectName, string methodName, string testFramework, bool shouldPass, bool expectResults = true)
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync(projectName))
-            using (var host = CreateOmniSharpHost(testProject.Directory, useLegacyDotNetCli: UseLegacyDotNetCli))
+            using (var host = CreateOmniSharpHost(testProject.Directory, dotNetCliVersion: DotNetCliVersion))
             {
                 var service = GetRequestHandler(host);
 

--- a/tests/OmniSharp.DotNetTest.Tests/GetTestStartInfoFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/GetTestStartInfoFacts.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -10,7 +11,7 @@ namespace OmniSharp.DotNetTest.Tests
         {
         }
 
-        public override bool UseLegacyDotNetCli { get; } = false;
+        public override DotNetCliVersion DotNetCliVersion { get; } = DotNetCliVersion.Current;
 
         [Fact]
         public async Task RunXunitTest()

--- a/tests/OmniSharp.DotNetTest.Tests/LegacyGetTestStartInfoFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/LegacyGetTestStartInfoFacts.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -10,7 +11,7 @@ namespace OmniSharp.DotNetTest.Tests
         {
         }
 
-        public override bool UseLegacyDotNetCli { get; } = true;
+        public override DotNetCliVersion DotNetCliVersion { get; } = DotNetCliVersion.Legacy;
 
         [Fact]
         public async Task RunXunitTest()

--- a/tests/OmniSharp.DotNetTest.Tests/LegacyRunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/LegacyRunTestFacts.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
+using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
-
 
 namespace OmniSharp.DotNetTest.Tests
 {
@@ -15,7 +15,7 @@ namespace OmniSharp.DotNetTest.Tests
         {
         }
 
-        public override bool UseLegacyDotNetCli { get; } = true;
+        public override DotNetCliVersion DotNetCliVersion { get; } = DotNetCliVersion.Legacy;
 
         [Fact]
         public async Task RunXunitTest()

--- a/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -11,7 +12,7 @@ namespace OmniSharp.DotNetTest.Tests
         {
         }
 
-        public override bool UseLegacyDotNetCli { get; } = false;
+        public override DotNetCliVersion DotNetCliVersion { get; } = DotNetCliVersion.Current;
 
         [Fact]
         public async Task RunXunitTest()

--- a/tests/OmniSharp.DotNetTest.Tests/TestDiscoveryFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/TestDiscoveryFacts.cs
@@ -33,7 +33,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task FoundFactsBasedTest(string projectName, string fileName, int line, int column, bool found, string expectedFeatureName)
         {
             using (var testProject = await this._testAssets.GetTestProjectAsync(projectName))
-            using (var host = CreateOmniSharpHost(testProject.Directory, useLegacyDotNetCli: true))
+            using (var host = CreateOmniSharpHost(testProject.Directory, dotNetCliVersion: DotNetCliVersion.Legacy))
             {
                 var filePath = Path.Combine(testProject.Directory, fileName);
                 var solution = host.Workspace.CurrentSolution;

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -49,7 +49,7 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.Equal(1, projectFileInfo.TargetFrameworks.Length);
                 Assert.Equal("netcoreapp1.0", projectFileInfo.TargetFrameworks[0]);
                 Assert.Equal("bin/Debug/netcoreapp1.0/", projectFileInfo.OutputPath.Replace('\\', '/'));
-                Assert.Equal(1, projectFileInfo.SourceFiles.Length);
+                Assert.Equal(3, projectFileInfo.SourceFiles.Length); // Program.cs, AssemblyInfo.cs, AssemblyAttributes.cs
             }
         }
 
@@ -68,7 +68,7 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.Equal(1, projectFileInfo.TargetFrameworks.Length);
                 Assert.Equal("netcoreapp1.0", projectFileInfo.TargetFrameworks[0]);
                 Assert.Equal("bin/Debug/netcoreapp1.0/", projectFileInfo.OutputPath.Replace('\\', '/'));
-                Assert.Equal(1, projectFileInfo.SourceFiles.Length);
+                Assert.Equal(3, projectFileInfo.SourceFiles.Length); // Program.cs, AssemblyInfo.cs, AssemblyAttributes.cs
             }
         }
 
@@ -88,7 +88,7 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.Equal("netcoreapp1.0", projectFileInfo.TargetFrameworks[0]);
                 Assert.Equal("netstandard1.5", projectFileInfo.TargetFrameworks[1]);
                 Assert.Equal(@"bin/Debug/netcoreapp1.0/", projectFileInfo.OutputPath.Replace('\\', '/'));
-                Assert.Equal(1, projectFileInfo.SourceFiles.Length);
+                Assert.Equal(3, projectFileInfo.SourceFiles.Length); // Program.cs, AssemblyInfo.cs, AssemblyAttributes.cs
             }
         }
     }

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -70,6 +70,7 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.Equal("netstandard1.3", secondProject.TargetFrameworks[0].ShortName);
             }
         }
+
         [Fact]
         public async Task TwoProjectWithGeneratedFile()
         {
@@ -84,6 +85,23 @@ namespace OmniSharp.MSBuild.Tests
                 var project = workspaceInfo.Projects[0];
                 Assert.Equal("ProjectWithGeneratedFile.csproj", Path.GetFileName(project.Path));
                 Assert.Equal(4, project.SourceFiles.Count);
+            }
+        }
+
+        [Fact]
+        public async Task ProjectWithSdkProperty()
+        {
+            using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectWithSdkProperty"))
+            using (var host = CreateOmniSharpHost(testProject.Directory, dotNetCliVersion: DotNetCliVersion.Future))
+            {
+                var workspaceInfo = await GetWorkspaceInfoAsync(host);
+
+                Assert.NotNull(workspaceInfo.Projects);
+                Assert.Equal(1, workspaceInfo.Projects.Count);
+
+                var project = workspaceInfo.Projects[0];
+                Assert.Equal("ProjectWithSdkProperty.csproj", Path.GetFileName(project.Path));
+                Assert.Equal(3, project.SourceFiles.Count);
             }
         }
 

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -68,7 +68,23 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.Equal("Lib.csproj", Path.GetFileName(secondProject.Path));
                 Assert.Equal(".NETStandard,Version=v1.3", secondProject.TargetFramework);
                 Assert.Equal("netstandard1.3", secondProject.TargetFrameworks[0].ShortName);
-          }
+            }
+        }
+        [Fact]
+        public async Task TwoProjectWithGeneratedFile()
+        {
+            using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectWithGeneratedFile"))
+            using (var host = CreateOmniSharpHost(testProject.Directory))
+            {
+                var workspaceInfo = await GetWorkspaceInfoAsync(host);
+
+                Assert.NotNull(workspaceInfo.Projects);
+                Assert.Equal(1, workspaceInfo.Projects.Count);
+
+                var project = workspaceInfo.Projects[0];
+                Assert.Equal("ProjectWithGeneratedFile.csproj", Path.GetFileName(project.Path));
+                Assert.Equal(4, project.SourceFiles.Count);
+            }
         }
 
         private static async Task<MSBuildWorkspaceInfo> GetWorkspaceInfoAsync(OmniSharpTestHost host)

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -88,7 +88,7 @@ namespace OmniSharp.MSBuild.Tests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "We're mot ready to run .NET Core SDK tests yet.")]
         public async Task ProjectWithSdkProperty()
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectWithSdkProperty"))

--- a/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
+++ b/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
@@ -55,7 +55,7 @@ namespace OmniSharp.Tests
 
                 Assert.Equal(1, version.Major);
                 Assert.Equal(0, version.Minor);
-                Assert.Equal(1, version.Patch);
+                Assert.Equal(4, version.Patch);
                 Assert.Equal("", version.Release);
             }
         }
@@ -71,7 +71,7 @@ namespace OmniSharp.Tests
 
                 Assert.Equal(1, info.Version.Major);
                 Assert.Equal(0, info.Version.Minor);
-                Assert.Equal(1, info.Version.Patch);
+                Assert.Equal(4, info.Version.Patch);
                 Assert.Equal("", info.Version.Release);
             }
         }

--- a/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
+++ b/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
@@ -75,37 +75,5 @@ namespace OmniSharp.Tests
                 Assert.Equal("", info.Version.Release);
             }
         }
-
-        [Fact]
-        public void FutureGetVersion()
-        {
-            using (var host = CreateOmniSharpHost(dotNetCliVersion: DotNetCliVersion.Future))
-            {
-                var dotNetCli = host.GetExport<DotNetCliService>();
-
-                var version = dotNetCli.GetVersion();
-
-                Assert.Equal(2, version.Major);
-                Assert.Equal(0, version.Minor);
-                Assert.Equal(0, version.Patch);
-                Assert.Equal("preview2-006497", version.Release);
-            }
-        }
-
-        [Fact]
-        public void FutureGetInfo()
-        {
-            using (var host = CreateOmniSharpHost(dotNetCliVersion: DotNetCliVersion.Future))
-            {
-                var dotNetCli = host.GetExport<DotNetCliService>();
-
-                var info = dotNetCli.GetInfo();
-
-                Assert.Equal(2, info.Version.Major);
-                Assert.Equal(0, info.Version.Minor);
-                Assert.Equal(0, info.Version.Patch);
-                Assert.Equal("preview2-006497", info.Version.Release);
-            }
-        }
     }
 }

--- a/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
+++ b/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
@@ -15,7 +15,7 @@ namespace OmniSharp.Tests
         [Fact]
         public void LegacyGetVersion()
         {
-            using (var host = CreateOmniSharpHost(useLegacyDotNetCli: true))
+            using (var host = CreateOmniSharpHost(dotNetCliVersion: DotNetCliVersion.Legacy))
             {
                 var dotNetCli = host.GetExport<DotNetCliService>();
 
@@ -31,7 +31,7 @@ namespace OmniSharp.Tests
         [Fact]
         public void LegacyGetInfo()
         {
-            using (var host = CreateOmniSharpHost(useLegacyDotNetCli: true))
+            using (var host = CreateOmniSharpHost(dotNetCliVersion: DotNetCliVersion.Legacy))
             {
                 var dotNetCli = host.GetExport<DotNetCliService>();
 
@@ -47,7 +47,7 @@ namespace OmniSharp.Tests
         [Fact]
         public void GetVersion()
         {
-            using (var host = CreateOmniSharpHost(useLegacyDotNetCli: false))
+            using (var host = CreateOmniSharpHost(dotNetCliVersion: DotNetCliVersion.Current))
             {
                 var dotNetCli = host.GetExport<DotNetCliService>();
 
@@ -63,7 +63,7 @@ namespace OmniSharp.Tests
         [Fact]
         public void GetInfo()
         {
-            using (var host = CreateOmniSharpHost(useLegacyDotNetCli: false))
+            using (var host = CreateOmniSharpHost(dotNetCliVersion: DotNetCliVersion.Current))
             {
                 var dotNetCli = host.GetExport<DotNetCliService>();
 
@@ -73,6 +73,38 @@ namespace OmniSharp.Tests
                 Assert.Equal(0, info.Version.Minor);
                 Assert.Equal(4, info.Version.Patch);
                 Assert.Equal("", info.Version.Release);
+            }
+        }
+
+        [Fact]
+        public void FutureGetVersion()
+        {
+            using (var host = CreateOmniSharpHost(dotNetCliVersion: DotNetCliVersion.Future))
+            {
+                var dotNetCli = host.GetExport<DotNetCliService>();
+
+                var version = dotNetCli.GetVersion();
+
+                Assert.Equal(2, version.Major);
+                Assert.Equal(0, version.Minor);
+                Assert.Equal(0, version.Patch);
+                Assert.Equal("preview2-006497", version.Release);
+            }
+        }
+
+        [Fact]
+        public void FutureGetInfo()
+        {
+            using (var host = CreateOmniSharpHost(dotNetCliVersion: DotNetCliVersion.Future))
+            {
+                var dotNetCli = host.GetExport<DotNetCliService>();
+
+                var info = dotNetCli.GetInfo();
+
+                Assert.Equal(2, info.Version.Major);
+                Assert.Equal(0, info.Version.Minor);
+                Assert.Equal(0, info.Version.Patch);
+                Assert.Equal("preview2-006497", info.Version.Release);
             }
         }
     }

--- a/tests/TestUtility/AbstractTestFixture.cs
+++ b/tests/TestUtility/AbstractTestFixture.cs
@@ -24,8 +24,8 @@ namespace TestUtility
             return host;
         }
 
-        protected OmniSharpTestHost CreateOmniSharpHost(string path = null, IEnumerable<KeyValuePair<string, string>> configurationData = null, bool useLegacyDotNetCli = false) =>
-            OmniSharpTestHost.Create(path, this.TestOutput, configurationData, useLegacyDotNetCli);
+        protected OmniSharpTestHost CreateOmniSharpHost(string path = null, IEnumerable<KeyValuePair<string, string>> configurationData = null, DotNetCliVersion dotNetCliVersion = DotNetCliVersion.Current) =>
+            OmniSharpTestHost.Create(path, this.TestOutput, configurationData, dotNetCliVersion);
 
         protected OmniSharpTestHost CreateOmniSharpHost(params TestFile[] testFiles) => 
             CreateOmniSharpHost(testFiles, null);

--- a/tests/TestUtility/DotNetCliVersion.cs
+++ b/tests/TestUtility/DotNetCliVersion.cs
@@ -1,0 +1,9 @@
+﻿namespace TestUtility
+{
+    public enum DotNetCliVersion
+    {
+        Current,
+        Legacy,
+        Future
+    }
+}

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -74,8 +74,8 @@ namespace TestUtility
             switch (dotNetCliVersion)
             {
                 case DotNetCliVersion.Current: return ".dotnet";
-                case DotNetCliVersion.Future: return ".dotnet-future";
                 case DotNetCliVersion.Legacy: return ".dotnet-legacy";
+                case DotNetCliVersion.Future: throw new InvalidOperationException("Test infrastructure does not support a future .NET Core SDK yet.");
                 default: throw new ArgumentException($"Unknown {nameof(dotNetCliVersion)}: {dotNetCliVersion}", nameof(dotNetCliVersion));
             }
         }

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -69,11 +69,22 @@ namespace TestUtility
             this.Workspace.Dispose();
         }
 
-        public static OmniSharpTestHost Create(string path = null, ITestOutputHelper testOutput = null, IEnumerable<KeyValuePair<string, string>> configurationData = null, bool useLegacyDotNetCli = false)
+        private static string GetDotNetCliFolderName(DotNetCliVersion dotNetCliVersion)
+        {
+            switch (dotNetCliVersion)
+            {
+                case DotNetCliVersion.Current: return ".dotnet";
+                case DotNetCliVersion.Future: return ".dotnet-future";
+                case DotNetCliVersion.Legacy: return ".dotnet-legacy";
+                default: throw new ArgumentException($"Unknown {nameof(dotNetCliVersion)}: {dotNetCliVersion}", nameof(dotNetCliVersion));
+            }
+        }
+
+        public static OmniSharpTestHost Create(string path = null, ITestOutputHelper testOutput = null, IEnumerable<KeyValuePair<string, string>> configurationData = null, DotNetCliVersion dotNetCliVersion = DotNetCliVersion.Current)
         {
             var dotNetPath = Path.Combine(
                 TestAssets.Instance.RootFolder,
-                useLegacyDotNetCli ? ".dotnet-legacy" : ".dotnet",
+                GetDotNetCliFolderName(dotNetCliVersion),
                 "dotnet");
 
             if (!File.Exists(dotNetPath))

--- a/tests/app.config
+++ b/tests/app.config
@@ -3,76 +3,95 @@
 <!-- binding redirects for tests -->
 
 <configuration>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="NuGet.Packaging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="NuGet.Packaging.Core.Types" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="NuGet.RuntimeModel" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Composition.AttributedModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Composition.Hosting" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Composition.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Composition.TypedParts" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
+            </dependentAssembly>
+
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="2.0.0.0-99.0.0.0" newVersion="15.1.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Build" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="2.0.0.0-99.0.0.0" newVersion="15.1.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Build.Tasks.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="2.0.0.0-99.0.0.0" newVersion="15.1.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="2.0.0.0-99.0.0.0" newVersion="15.1.0.0"/>
+            </dependentAssembly>
+
+            <dependentAssembly>
+                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="NuGet.Packaging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="NuGet.Packaging.Core.Types" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="NuGet.RuntimeModel" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
+            </dependentAssembly>
+
+            <dependentAssembly>
+                <assemblyIdentity name="System.Composition.AttributedModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Composition.Hosting" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Composition.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Composition.TypedParts" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
 </configuration>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Cake" version="0.19.5" />
-    <package id="Microsoft.Build.Runtime" version="15.3.0-preview-000117-01" />
-    <package id="Microsoft.Net.Compilers" version="2.1.0" />
+    <package id="Microsoft.Build.Runtime" version="15.3.0-preview-000388-01" />
+    <package id="Microsoft.Net.Compilers" version="2.3.0-beta2" />
     <package id="xunit.runner.console" version="2.2.0" />
 </packages>


### PR DESCRIPTION
This represents several updates for the OmniSharp MSBuild projects system:

1. Use the "Compile" target rather than the "ResolveReferences" target. This allows MSBuild to run more stuff while evaluating the project file, such as generated files (fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1531). Note that this requires copying the C# build tasks into OmniSharp.
2. Update MSBuild to latest bits (fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/904).
3. Binding redirects added for MSBuild (fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/903).
4. ~~Support for testing projects with the latest .NET Core SDK.~~