### PR TITLE
Clean up build log

### DIFF
--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -29,12 +29,17 @@ public class Folders
     public string ArtifactsPackage { get; }
     public string ArtifactsScripts { get; }
 
+    public string MonoMSBuildLib { get; }
+    public string MonoMSBuildRuntime { get; }
+    public string MSBuildBase { get; }
+
     public Folders(string workingDirectory)
     {
         this.DotNetSdk = PathHelper.Combine(workingDirectory, ".dotnet");
         this.LegacyDotNetSdk = PathHelper.Combine(workingDirectory, ".dotnet-legacy");
         this.Tools = PathHelper.Combine(workingDirectory, "tools");
 
+        this.MSBuildBase = PathHelper.Combine(workingDirectory, ".msbuild");
         this.MSBuild = PathHelper.Combine(workingDirectory, "msbuild");
         this.Source = PathHelper.Combine(workingDirectory, "src");
         this.Tests = PathHelper.Combine(workingDirectory, "tests");
@@ -45,6 +50,9 @@ public class Folders
         this.ArtifactsLogs = PathHelper.Combine(this.Artifacts, "logs");
         this.ArtifactsPackage = PathHelper.Combine(this.Artifacts, "package");
         this.ArtifactsScripts = PathHelper.Combine(this.Artifacts, "scripts");
+
+        this.MonoMSBuildLib = PathHelper.Combine(this.Tools, "Microsoft.Build.Lib.Mono");
+        this.MonoMSBuildRuntime = PathHelper.Combine(this.Tools, "Microsoft.Build.Runtime.Mono");
     }
 }
 

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -1,7 +1,95 @@
+#addin "Newtonsoft.Json"
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+public static class Log
+{
+    public static ICakeContext Context { get; set; }
+
+    public static void Write(Verbosity verbosity, LogLevel logLevel, string message, params object[] args) =>
+        Context.Log.Write(verbosity, logLevel, message, args);
+
+    public static void Debug(Verbosity verbosity, string message, params object[] args) =>
+        Write(verbosity, LogLevel.Debug, message, args);
+}
+
+public static class FileHelper
+{
+    public static void Copy(string source, string destination, bool overwrite = false)
+    {
+        Log.Debug(Verbosity.Diagnostic, "Copy file: {0} to {1}.", source, destination);
+        System.IO.File.Copy(source, destination, overwrite);
+    }
+
+    public static void Delete(string path)
+    {
+        Log.Debug(Verbosity.Diagnostic, "Delete file: {0}.", path);
+        System.IO.File.Delete(path);
+    }
+}
+
+public static class DirectoryHelper
+{
+    public static void Copy(string source, string destination)
+    {
+        var files = System.IO.Directory.GetFiles(source);
+        var subDirectories = System.IO.Directory.GetDirectories(source);
+
+        if (!Exists(destination))
+        {
+            Create(destination);
+        }
+
+        foreach (var file in files)
+        {
+            var newFile = PathHelper.Combine(destination, PathHelper.GetFileName(file));
+            FileHelper.Copy(file, newFile);
+        }
+
+        foreach (var subDirectory in subDirectories)
+        {
+            var newSubDirectory = PathHelper.Combine(destination, PathHelper.GetFileName(subDirectory));
+            Copy(subDirectory, newSubDirectory);
+        }
+    }
+
+    public static void Create(string path)
+    {
+        Log.Debug(Verbosity.Diagnostic, "Create directory: {0}.", path);
+        System.IO.Directory.CreateDirectory(path);
+    }
+
+    public static void Delete(string path, bool recursive)
+    {
+        Log.Debug(Verbosity.Diagnostic, "Delete directory: {0}.", path);
+        System.IO.Directory.Delete(path, recursive);
+    }
+
+    public static bool Exists(string path) =>
+        System.IO.Directory.Exists(path);
+
+    public static void ForceCreate(string path)
+    {
+        if (Exists(path))
+        {
+            Delete(path, recursive: true);
+        }
+
+        Create(path);
+    }
+}
+
 public static class PathHelper
 {
     public static string Combine(params string[] paths) =>
         System.IO.Path.Combine(paths);
+
+    public static string GetDirectoryName(string path) =>
+        System.IO.Path.GetDirectoryName(path);
+
+    public static string GetFileName(string path) =>
+        System.IO.Path.GetFileName(path);
 
     public static string GetFullPath(string path) =>
         System.IO.Path.Combine(path);
@@ -83,6 +171,60 @@ public class BuildEnvironment
         this.ShellCommand = isWindows ? "powershell" : "bash";
         this.ShellArgument = isWindows ? "-NoProfile /Command" : "-C";
         this.ShellScriptFileExtension = isWindows ? "ps1" : "sh";
+    }
+}
+
+/// <summary>
+///  Class representing build.json
+/// </summary>
+public class BuildPlan
+{
+    public string DotNetInstallScriptURL { get; set; }
+    public string DotNetChannel { get; set; }
+    public string DotNetVersion { get; set; }
+    public string LegacyDotNetVersion { get; set; }
+    public string DownloadURL { get; set; }
+    public string MSBuildRuntimeForMono { get; set; }
+    public string MSBuildLibForMono { get; set; }
+    public string[] Frameworks { get; set; }
+    public string MainProject { get; set; }
+    public string[] TestProjects { get; set; }
+    public string[] TestAssets { get; set; }
+    public string[] LegacyTestAssets { get; set; }
+
+    private string currentRid;
+    private string[] targetRids;
+
+    public void SetCurrentRid(string currentRid)
+    {
+        this.currentRid = currentRid;
+    }
+
+    public string CurrentRid => currentRid;
+    public string[] TargetRids => targetRids;
+
+    public void SetTargetRids(params string[] targetRids)
+    {
+        this.targetRids = targetRids;
+    }
+
+    public string GetDefaultRid()
+    {
+        if (currentRid.StartsWith("win"))
+        {
+            return currentRid.EndsWith("-x86")
+                ? "win7-x86"
+                : "win7-x64";
+        }
+
+        return currentRid;
+    }
+
+    public static BuildPlan Load(BuildEnvironment env)
+    {
+        var buildJsonPath = PathHelper.Combine(env.WorkingDirectory, "build.json");
+        return JsonConvert.DeserializeObject<BuildPlan>(
+            System.IO.File.ReadAllText(buildJsonPath));
     }
 }
 

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -44,7 +44,7 @@ public static class DirectoryHelper
         foreach (var file in files)
         {
             var newFile = PathHelper.Combine(destination, PathHelper.GetFileName(file));
-            FileHelper.Copy(file, newFile);
+            FileHelper.Copy(file, newFile, overwrite: true);
         }
 
         foreach (var subDirectory in subDirectories)

--- a/scripts/msbuild.cake
+++ b/scripts/msbuild.cake
@@ -1,0 +1,92 @@
+#load "common.cake"
+
+using System.Net;
+
+void SetupMSBuild(BuildEnvironment env)
+{
+    var msbuildNet46Folder = env.Folders.MSBuildBase + "-net46";
+    var msbuildNetCoreAppFolder = env.Folders.MSBuildBase + "-netcoreapp1.1";
+
+    if (!IsRunningOnWindows())
+    {
+        if (DirectoryExists(env.Folders.MonoMSBuildRuntime))
+        {
+            DeleteDirectory(env.Folders.MonoMSBuildRuntime, recursive: true);
+        }
+
+        if (DirectoryExists(env.Folders.MonoMSBuildLib))
+        {
+            DeleteDirectory(env.Folders.MonoMSBuildLib, recursive: true);
+        }
+
+        CreateDirectory(env.Folders.MonoMSBuildRuntime);
+        CreateDirectory(env.Folders.MonoMSBuildLib);
+
+        var msbuildMonoRuntimeZip = CombinePaths(env.Folders.MonoMSBuildRuntime, buildPlan.MSBuildRuntimeForMono);
+        var msbuildMonoLibZip = CombinePaths(env.Folders.MonoMSBuildLib, buildPlan.MSBuildLibForMono);
+
+        using (var client = new WebClient())
+        {
+            client.DownloadFile($"{buildPlan.DownloadURL}/{buildPlan.MSBuildRuntimeForMono}", msbuildMonoRuntimeZip);
+            client.DownloadFile($"{buildPlan.DownloadURL}/{buildPlan.MSBuildLibForMono}", msbuildMonoLibZip);
+        }
+
+        Unzip(msbuildMonoRuntimeZip, env.Folders.MonoMSBuildRuntime);
+        Unzip(msbuildMonoLibZip, env.Folders.MonoMSBuildLib);
+
+        DeleteFile(msbuildMonoRuntimeZip);
+        DeleteFile(msbuildMonoLibZip);
+    }
+
+    if (DirectoryExists(msbuildNet46Folder))
+    {
+        DeleteDirectory(msbuildNet46Folder, recursive: true);
+    }
+
+    if (DirectoryExists(msbuildNetCoreAppFolder))
+    {
+        DeleteDirectory(msbuildNetCoreAppFolder, recursive: true);
+    }
+
+    CreateDirectory(msbuildNet46Folder);
+    CreateDirectory(msbuildNetCoreAppFolder);
+
+    // Copy MSBuild runtime to appropriate locations
+    var msbuildInstallFolder = CombinePaths(env.Folders.Tools, "Microsoft.Build.Runtime", "contentFiles", "any");
+    var msbuildNet46InstallFolder = CombinePaths(msbuildInstallFolder, "net46");
+    var msbuildNetCoreAppInstallFolder = CombinePaths(msbuildInstallFolder, "netcoreapp1.0");
+
+    if (IsRunningOnWindows())
+    {
+        CopyDirectory(msbuildNet46InstallFolder, msbuildNet46Folder);
+    }
+    else
+    {
+        CopyDirectory(env.Folders.MonoMSBuildRuntime, msbuildNet46Folder);
+    }
+
+    CopyDirectory(msbuildNetCoreAppInstallFolder, msbuildNetCoreAppFolder);
+
+    // Finally, copy Microsoft.Net.Compilers
+    var roslynFolder = CombinePaths(env.Folders.Tools, "Microsoft.Net.Compilers", "tools");
+    var roslynNet46Folder = CombinePaths(msbuildNet46Folder, "Roslyn");
+    var roslynNetCoreAppFolder = CombinePaths(msbuildNetCoreAppFolder, "Roslyn");
+
+    CreateDirectory(roslynNet46Folder);
+    CreateDirectory(roslynNetCoreAppFolder);
+
+    CopyDirectory(roslynFolder, roslynNet46Folder);
+    CopyDirectory(roslynFolder, roslynNetCoreAppFolder);
+
+    // Delete unnecessary files
+    foreach (var folder in new[] { roslynNet46Folder, roslynNetCoreAppFolder })
+    {
+        DeleteFile(CombinePaths(folder, "Microsoft.CodeAnalysis.VisualBasic.dll"));
+        DeleteFile(CombinePaths(folder, "Microsoft.VisualBasic.Core.targets"));
+        DeleteFile(CombinePaths(folder, "VBCSCompiler.exe"));
+        DeleteFile(CombinePaths(folder, "VBCSCompiler.exe.config"));
+        DeleteFile(CombinePaths(folder, "vbc.exe"));
+        DeleteFile(CombinePaths(folder, "vbc.exe.config"));
+        DeleteFile(CombinePaths(folder, "vbc.rsp"));
+    }
+}

--- a/scripts/msbuild.cake
+++ b/scripts/msbuild.cake
@@ -5,16 +5,13 @@ using System.Net;
 
 void SetupMSBuild(BuildEnvironment env, BuildPlan plan)
 {
-    var msbuildNet46Folder = env.Folders.MSBuildBase + "-net46";
-    var msbuildNetCoreAppFolder = env.Folders.MSBuildBase + "-netcoreapp1.1";
-
     if (!IsRunningOnWindows())
     {
         AcquireMonoMSBuild(env, plan);
     }
 
-    SetupMSBuildForFramework("net46");
-    SetupMSBuildForFramework("netcoreapp1.1");
+    SetupMSBuildForFramework(env, "net46");
+    SetupMSBuildForFramework(env, "netcoreapp1.1");
 }
 
 private void AcquireMonoMSBuild(BuildEnvironment env, BuildPlan plan)
@@ -40,13 +37,14 @@ private void AcquireMonoMSBuild(BuildEnvironment env, BuildPlan plan)
     FileHelper.Delete(msbuildMonoLibZip);
 }
 
-private void SetupMSBuildForFramework(string framework)
+private void SetupMSBuildForFramework(BuildEnvironment env, string framework)
 {
     var msbuildFolder = $"{env.Folders.MSBuildBase}-{framework}";
 
-    // Delete the install folder if it already exists and create it again.
-    Information("Creating {0} directory...", msbuildFolder);
-    DirectoryHelper.ForceCreate(msbuildFolder);
+    if (DirectoryHelper.Exists(msbuildFolder))
+    {
+        DirectoryHelper.Delete(msbuildFolder, recursive: true);
+    }
 
     if (!IsRunningOnWindows() && framework == "net46")
     {
@@ -69,8 +67,6 @@ private void SetupMSBuildForFramework(string framework)
     Information("Copying Microsoft.Net.Compilers for {0}...", framework);
     var compilersFolder = CombinePaths(env.Folders.Tools, "Microsoft.Net.Compilers", "tools");
     var msbuildRoslynFolder = CombinePaths(msbuildFolder, "Roslyn");
-
-    DirectoryHelper.Create(msbuildRoslynFolder);
 
     DirectoryHelper.Copy(compilersFolder, msbuildRoslynFolder);
 


### PR DESCRIPTION
Big changes:
* Don't produce so much build output by using custom IO helpers. You can still get all of the "copy file blah to baz" by passing the `--verbosity Diagnostic` flag.
* Refactor the MSBuild setup logic to be sensible and reduce the overall size of build.cake.