### PR TITLE
regression fix - revert cd7b3c369b7c77540aee5d8eec7924a8c59d414d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All changes to the project will be documented in this file.
 
 ## [Unreleased]
 
-* None
+* Fixed a Script project system regression introduced as part of [#898](https://github.com/OmniSharp/omnisharp-roslyn/pull/898), that caused CSX support to break for Desktop CLR scripts on Windows (PR: [913](https://github.com/OmniSharp/omnisharp-roslyn/pull/913))
 
 ## [1.22.0] - 2017-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All changes to the project will be documented in this file.
 
 ## [Unreleased]
 
-* Fixed a Script project system regression introduced as part of [#898](https://github.com/OmniSharp/omnisharp-roslyn/pull/898), that caused CSX support to break for Desktop CLR scripts on Windows (PR: [913](https://github.com/OmniSharp/omnisharp-roslyn/pull/913))
+* Fixed a Script project system regression introduced as part of [#898](https://github.com/OmniSharp/omnisharp-roslyn/pull/898), that caused CSX support to break for Desktop CLR scripts on Windows (PR: [#913](https://github.com/OmniSharp/omnisharp-roslyn/pull/913))
 
 ## [1.22.0] - 2017-07-07
 

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -30,19 +30,17 @@ namespace OmniSharp.Script
         private readonly OmniSharpWorkspace _workspace;
         private readonly IOmniSharpEnvironment _env;
         private readonly ILogger _logger;
-        private readonly IAssemblyLoader _assemblyLoader;
 
         private readonly IScriptProjectProvider _scriptProjectProvider;        
         private static readonly Lazy<string> _targetFrameWork = new Lazy<string>(ResolveTargetFramework);
 
         [ImportingConstructor]
         public ScriptProjectSystem(OmniSharpWorkspace workspace, IOmniSharpEnvironment env, ILoggerFactory loggerFactory, 
-            MetadataFileReferenceCache metadataFileReferenceCache, IAssemblyLoader assemblyLoader)
+            MetadataFileReferenceCache metadataFileReferenceCache)
         {
             _metadataFileReferenceCache = metadataFileReferenceCache;
             _workspace = workspace;
             _env = env;
-            _assemblyLoader = assemblyLoader;
             _logger = loggerFactory.CreateLogger<ScriptProjectSystem>();
             _projects = new Dictionary<string, ProjectInfo>();
             _scriptProjectProvider = ScriptProjectProvider.Create(loggerFactory);
@@ -156,8 +154,8 @@ namespace OmniSharp.Script
                     typeof(Enumerable).GetTypeInfo().Assembly,
                     typeof(Stack<>).GetTypeInfo().Assembly,
                     typeof(Lazy<,>).GetTypeInfo().Assembly,
-                    _assemblyLoader.Load("System.Runtime"),
-                    _assemblyLoader.Load("mscorlib")
+                    FromName("System.Runtime"),
+                    FromName("mscorlib")
                 };
 
                 var references = assemblies
@@ -169,6 +167,18 @@ namespace OmniSharp.Script
                 foreach (var reference in references)
                 {
                     commonReferences.Add(reference);
+                }
+            }
+
+            Assembly FromName(string assemblyName)
+            {
+                try
+                {
+                    return Assembly.Load(new AssemblyName(assemblyName));
+                }
+                catch
+                {
+                    return null;
                 }
             }
         }


### PR DESCRIPTION
This PR reverts the change introduced in https://github.com/OmniSharp/omnisharp-roslyn/commit/cd7b3c369b7c77540aee5d8eec7924a8c59d414d 
Functionally everything is the same.

The problem is when we switched to using `IAssemblyLoader`, we would now throw (since `IAssemblyLoader` rethrows the exceptions it encounters) when i.e. `System.Runtime` is not found and we'd like to avoid that. For simplicity, it makes sense for us to always try to load `System.Runtime` if we can. 
The alternative wold be to make `IAssemblyLoader` not rethrow anymore, but it would still log errors into the command line which is not good. 

Due to this issue the scripting project system for desktop is broken on Windows at the moment.