### PR TITLE
Update xUnit to fix test runner in VS 2017

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,5 +5,6 @@
         <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
         <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
         <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
+        <add key="xunit" value="https://www.myget.org/F/xunit/api/v3/index.json" />
     </packageSources>
 </configuration>

--- a/tests/OmniSharp.DotNet.Tests/OmniSharp.DotNet.Tests.csproj
+++ b/tests/OmniSharp.DotNet.Tests/OmniSharp.DotNet.Tests.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3722" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3722" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/tests/OmniSharp.DotNetTest.Tests/AbstractGetTestStartInfoFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/AbstractGetTestStartInfoFacts.cs
@@ -15,7 +15,7 @@ namespace OmniSharp.DotNetTest.Tests
         protected const string LegacyNunitTestProject = "LegacyNunitTestProject";
         protected const string LegacyMSTestProject = "LegacyMSTestProject";
         protected const string XunitTestProject = "XunitTestProject";
-        protected const string NunitTestProject = "NunitTestProject";
+        protected const string NunitTestProject = "NUnitTestProject";
         protected const string MSTestProject = "MSTestProject";
 
         protected AbstractGetTestStartInfoFacts(ITestOutputHelper output)

--- a/tests/OmniSharp.DotNetTest.Tests/GetTestStartInfoFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/GetTestStartInfoFacts.cs
@@ -25,7 +25,7 @@ namespace OmniSharp.DotNetTest.Tests
         // NUnit does not work with .NET CLI RTM yet. https://github.com/nunit/dotnet-test-nunit/issues/108
         // When it does, the NUnitTestProject should be updated and the tests below re-enabled.
 
-        //[Fact]
+        [Fact]
         public async Task RunNunitTest()
         {
             await GetDotNetTestStartInfoAsync(

--- a/tests/OmniSharp.DotNetTest.Tests/OmniSharp.DotNetTest.Tests.csproj
+++ b/tests/OmniSharp.DotNetTest.Tests/OmniSharp.DotNetTest.Tests.csproj
@@ -20,8 +20,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3722" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3722" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />
   </ItemGroup>
 

--- a/tests/OmniSharp.MSBuild.Tests/GlobalSuppressions.cs
+++ b/tests/OmniSharp.MSBuild.Tests/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped", Justification = "<Pending>", Scope = "member", Target = "~M:OmniSharp.MSBuild.Tests.WorkspaceInformationTests.ProjectWithSdkProperty~System.Threading.Tasks.Task")]
+

--- a/tests/OmniSharp.MSBuild.Tests/OmniSharp.MSBuild.Tests.csproj
+++ b/tests/OmniSharp.MSBuild.Tests/OmniSharp.MSBuild.Tests.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3722" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3722" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -88,7 +88,7 @@ namespace OmniSharp.MSBuild.Tests
             }
         }
 
-        [Fact(Skip = "We're mot ready to run .NET Core SDK tests yet.")]
+        [Fact(Skip = "We're not ready to run .NET Core SDK tests yet.")]
         public async Task ProjectWithSdkProperty()
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectWithSdkProperty"))

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsV2Facts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsV2Facts.cs
@@ -99,7 +99,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 var controller = new DiagnosticsService(host.Workspace, forwarder, service);
                 var response = await controller.Handle(new DiagnosticsRequest());
 
-                Assert.Equal(true, forwarder.IsEnabled);
+                Assert.True(forwarder.IsEnabled);
             }
         }
     }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/OmniSharp.Roslyn.CSharp.Tests.csproj
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/OmniSharp.Roslyn.CSharp.Tests.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3722" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3722" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -259,7 +259,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 }";
             var actual = await GetSignatureHelp(source);
             Assert.Equal(3, actual.Signatures.Count());
-            Assert.True(actual.Signatures.ElementAt(actual.ActiveSignature).Documentation.Contains("foo2"));
+            Assert.Contains("foo2", actual.Signatures.ElementAt(actual.ActiveSignature).Documentation);
         }
 
         [Fact]
@@ -289,7 +289,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 }";
             var actual = await GetSignatureHelp(source);
             Assert.Equal(3, actual.Signatures.Count());
-            Assert.True(actual.Signatures.ElementAt(actual.ActiveSignature).Documentation.Contains("foo3"));
+            Assert.Contains("foo3", actual.Signatures.ElementAt(actual.ActiveSignature).Documentation);
         }
 
         [Fact]
@@ -319,7 +319,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 }";
             var actual = await GetSignatureHelp(source);
             Assert.Equal(3, actual.Signatures.Count());
-            Assert.True(actual.Signatures.ElementAt(actual.ActiveSignature).Documentation.Contains("foo1"));
+            Assert.Contains("foo1", actual.Signatures.ElementAt(actual.ActiveSignature).Documentation);
         }
 
         [Fact]
@@ -372,7 +372,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             var actual = await GetSignatureHelp(source);
             Assert.Equal(3, actual.Signatures.Count());
             Assert.Equal(1, actual.ActiveParameter);
-            Assert.True(actual.Signatures.ElementAt(actual.ActiveSignature).Documentation.Contains("ctor2"));
+            Assert.Contains("ctor2", actual.Signatures.ElementAt(actual.ActiveSignature).Documentation);
         }
 
         [Fact]

--- a/tests/OmniSharp.Stdio.Tests/OmniSharp.Stdio.Tests.csproj
+++ b/tests/OmniSharp.Stdio.Tests/OmniSharp.Stdio.Tests.csproj
@@ -19,8 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.3.0-beta2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3722" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3722" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/tests/OmniSharp.Stdio.Tests/StdioServerFacts.cs
+++ b/tests/OmniSharp.Stdio.Tests/StdioServerFacts.cs
@@ -106,8 +106,8 @@ namespace OmniSharp.Stdio.Tests
                     var packet = JsonConvert.DeserializeObject<ResponsePacket>(value);
                     Assert.Equal(request.Seq, packet.Request_seq);
                     Assert.Equal(request.Command, packet.Command);
-                    Assert.Equal(true, packet.Success);
-                    Assert.Equal(true, packet.Running);
+                    Assert.True(packet.Success);
+                    Assert.True(packet.Running);
                     Assert.Null(packet.Message);
                 }
             );
@@ -134,14 +134,14 @@ namespace OmniSharp.Stdio.Tests
                 },
                 value =>
                 {
-                    Assert.True(value.Contains("\"Body\":null"));
+                    Assert.Contains("\"Body\":null", value);
 
                     // Deserialize is too relaxed...
                     var packet = JsonConvert.DeserializeObject<ResponsePacket>(value);
                     Assert.Equal(request.Seq, packet.Request_seq);
                     Assert.Equal(request.Command, packet.Command);
-                    Assert.Equal(true, packet.Success);
-                    Assert.Equal(true, packet.Running);
+                    Assert.True(packet.Success);
+                    Assert.True(packet.Running);
                     Assert.Null(packet.Message);
                     Assert.Null(packet.Body);
                 }
@@ -172,8 +172,8 @@ namespace OmniSharp.Stdio.Tests
                     var packet = JsonConvert.DeserializeObject<ResponsePacket>(value);
                     Assert.Equal(request.Seq, packet.Request_seq);
                     Assert.Equal(request.Command, packet.Command);
-                    Assert.Equal(false, packet.Success);
-                    Assert.Equal(true, packet.Running);
+                    Assert.False(packet.Success);
+                    Assert.True(packet.Running);
                     Assert.NotNull(packet.Message);
                 }
             );

--- a/tests/OmniSharp.Tests/GlobalSuppressions.cs
+++ b/tests/OmniSharp.Tests/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped", Justification = "<Pending>", Scope = "member", Target = "~M:OmniSharp.Tests.UpdateBufferFilterFacts.UpdateBuffer_TransientDocumentsDisappearWhenProjectAddsThem~System.Threading.Tasks.Task")]
+

--- a/tests/OmniSharp.Tests/MarkupCodeFacts.cs
+++ b/tests/OmniSharp.Tests/MarkupCodeFacts.cs
@@ -14,7 +14,7 @@ namespace OmniSharp.Tests
             var markupCode = TestContent.Parse(code);
 
             Assert.Equal("class C { }", markupCode.Code);
-            Assert.Equal(false, markupCode.HasPosition);
+            Assert.False(markupCode.HasPosition);
             Assert.Throws<InvalidOperationException>(() => { var _ = markupCode.Position; });
 
             var spans = markupCode.GetSpans();
@@ -28,7 +28,7 @@ namespace OmniSharp.Tests
             var markupCode = TestContent.Parse(code);
 
             Assert.Equal("class C { }", markupCode.Code);
-            Assert.Equal(true, markupCode.HasPosition);
+            Assert.True(markupCode.HasPosition);
             Assert.Equal(0, markupCode.Position);
         }
 
@@ -39,7 +39,7 @@ namespace OmniSharp.Tests
             var markupCode = TestContent.Parse(code);
 
             Assert.Equal("class C { }", markupCode.Code);
-            Assert.Equal(true, markupCode.HasPosition);
+            Assert.True(markupCode.HasPosition);
             Assert.Equal(markupCode.Code.Length, markupCode.Position);
         }
 
@@ -50,7 +50,7 @@ namespace OmniSharp.Tests
             var markupCode = TestContent.Parse(code);
 
             Assert.Equal(@"class C { string s = $""Hello""; }", markupCode.Code);
-            Assert.Equal(true, markupCode.HasPosition);
+            Assert.True(markupCode.HasPosition);
             Assert.Equal(21, markupCode.Position);
         }
 

--- a/tests/OmniSharp.Tests/OmniSharp.Tests.csproj
+++ b/tests/OmniSharp.Tests/OmniSharp.Tests.csproj
@@ -20,8 +20,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3722" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3722" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/tests/OmniSharp.Tests/ZeroBasedIndexConverterFacts.cs
+++ b/tests/OmniSharp.Tests/ZeroBasedIndexConverterFacts.cs
@@ -24,8 +24,8 @@ namespace OmniSharp.Tests
 
             var input = JsonConvert.DeserializeObject<Request>(output);
 
-            Assert.Equal(input.Line, 0);
-            Assert.Equal(input.Column, 0);
+            Assert.Equal(0, input.Line);
+            Assert.Equal(0, input.Column);
         }
 
         [Fact]

--- a/tests/TestUtility/TestUtility.csproj
+++ b/tests/TestUtility/TestUtility.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.3.0-beta2" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel" Version="1.0.0-rc3-1-003177" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel.Workspaces" Version="1.0.0-preview2-1-003177" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3722" />
   </ItemGroup>
 
 </Project>

--- a/tests/app.config
+++ b/tests/app.config
@@ -36,6 +36,11 @@
             </dependentAssembly>
 
             <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0"/>
+            </dependentAssembly>
+
+            <dependentAssembly>
                 <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
                 <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
             </dependentAssembly>


### PR DESCRIPTION
This PR updates xUnit to fix running tests in VS 2017 per https://github.com/Microsoft/vstest/issues/811. Because we're updating to the latest xUnit 2.3.0, this change also includes fixes for errors introduced by the new xUnit Roslyn analyzers. The suggested fixes all looked to be righteous to me, so I went ahead and made them.

Note that this change also requires a new binding redirect for the tests to run properly. This is because our test fixtures pull in Microsoft.Extensions.Logging.Abstractions, 1.1.0, but NuGet is pulling in 1.1.1 due to the `Dotnet.Script.NuGetMetadataResolver` dependency.