### PR TITLE
Add logic to set MSBuildExtensionsPath to Mono's xbuild directory

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -392,13 +392,13 @@ Task("Test")
         var instanceFolder = CombinePaths(env.Folders.Tests, testProject, "bin", testConfiguration, "net46");
 
         // Copy xunit executable to test folder to solve path errors
-        var xunitToolsFolder = CombinePaths(env.Folders.Tools, "xunit.runner.console", "tools");
+        var xunitToolsFolder = CombinePaths(env.Folders.Tools, "xunit.runner.console", "tools", "net452");
         var xunitInstancePath = CombinePaths(instanceFolder, "xunit.console.exe");
         FileHelper.Copy(CombinePaths(xunitToolsFolder, "xunit.console.exe"), xunitInstancePath, overwrite: true);
         FileHelper.Copy(CombinePaths(xunitToolsFolder, "xunit.runner.utility.net452.dll"), CombinePaths(instanceFolder, "xunit.runner.utility.net452.dll"), overwrite: true);
         var targetPath = CombinePaths(instanceFolder, $"{testProject}.dll");
         var logFile = CombinePaths(env.Folders.ArtifactsLogs, $"{testProject}-desktop-result.xml");
-        var arguments = $"\"{targetPath}\" -parallel none -xml \"{logFile}\" -notrait category=failing";
+        var arguments = $"\"{targetPath}\" -parallel none -noshadow -xml \"{logFile}\" -notrait category=failing";
 
         if (Platform.Current.IsWindows)
         {
@@ -511,9 +511,12 @@ Task("OnlyPublish")
             DirectoryHelper.Copy($"{env.Folders.MSBuildBase}-{framework}", CombinePaths(outputFolder, "msbuild"));
 
             // For OSX/Linux net46 builds, copy the MSBuild libraries built for Mono.
+            // In addition, delete System.Runtime.InteropServices.RuntimeInformation, which is Windows-specific.
             if (!Platform.Current.IsWindows && framework == "net46")
             {
                 DirectoryHelper.Copy($"{env.Folders.MonoMSBuildLib}", outputFolder);
+
+                FileHelper.Delete(CombinePaths(outputFolder, "System.Runtime.InteropServices.RuntimeInformation.dll"));
             }
 
             if (requireArchive)

--- a/build.json
+++ b/build.json
@@ -5,8 +5,8 @@
   "LegacyDotNetVersion": "1.0.0-preview2-1-003177",
   "RequiredMonoVersion": "5.2.0.196",
   "DownloadURL": "https://omnisharpdownload.blob.core.windows.net/ext",
-  "MSBuildRuntimeForMono": "Microsoft.Build.Runtime.Mono-alpha4.zip",
-  "MSBuildLibForMono": "Microsoft.Build.Lib.Mono-alpha4.zip",
+  "MSBuildRuntimeForMono": "Microsoft.Build.Runtime.Mono-alpha5.zip",
+  "MSBuildLibForMono": "Microsoft.Build.Lib.Mono-alpha5.zip",
   "Frameworks": [
     "net46",
     "netcoreapp1.1"

--- a/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
+++ b/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Utilities;
 
@@ -7,6 +8,7 @@ namespace OmniSharp.MSBuild
 {
     public enum MSBuildEnvironmentKind
     {
+        Unknown,
         VisualStudio,
         Mono,
         StandAlone
@@ -15,13 +17,14 @@ namespace OmniSharp.MSBuild
     public static class MSBuildEnvironment
     {
         public const string MSBuildExePathName = "MSBUILD_EXE_PATH";
-        public const string MSBuildExtensionsPathName = "MSBuildExtensionsPath";
 
         private static bool s_isInitialized;
         private static MSBuildEnvironmentKind s_kind;
 
         private static string s_msbuildExePath;
         private static string s_msbuildExtensionsPath;
+        private static string s_targetFrameworkRootPath;
+        private static string s_roslynTargetsPath;
 
         public static bool IsInitialized => s_isInitialized;
 
@@ -52,6 +55,24 @@ namespace OmniSharp.MSBuild
             }
         }
 
+        public static string TargetFrameworkRootPath
+        {
+            get
+            {
+                ThrowIfNotInitialized();
+                return s_targetFrameworkRootPath;
+            }
+        }
+
+        public static string RoslynTargetsPath
+        {
+            get
+            {
+                ThrowIfNotInitialized();
+                return s_roslynTargetsPath;
+            }
+        }
+
         private static void ThrowIfNotInitialized()
         {
             if (!s_isInitialized)
@@ -71,56 +92,77 @@ namespace OmniSharp.MSBuild
             // MSBuild will take care of itself.
             if (MSBuildHelpers.CanInitializeVisualStudioBuildEnvironment())
             {
-                logger.LogInformation("MSBuild will use local Visual Studio installation.");
                 s_kind = MSBuildEnvironmentKind.VisualStudio;
                 s_isInitialized = true;
             }
-#if NET46
-            else if (TryWithMonoMSBuild(logger, out var monoMSBuildPath, out var monoMSBuildExtensionsPath))
+            else if (TryWithMonoMSBuild())
             {
-                logger.LogInformation("MSBuild will use Mono installation.");
                 s_kind = MSBuildEnvironmentKind.Mono;
-                s_msbuildExePath = monoMSBuildPath;
-                s_msbuildExtensionsPath = monoMSBuildExtensionsPath;
                 s_isInitialized = true;
             }
-#endif
-            else if (TryWithLocalMSBuild(logger, out var localMSBuildPath, out var localMSBuildExtensionsPath))
+            else if (TryWithLocalMSBuild())
             {
-                logger.LogInformation("MSBuild will use local OmniSharp installation.");
                 s_kind = MSBuildEnvironmentKind.StandAlone;
-                s_msbuildExePath = localMSBuildPath;
-                s_msbuildExtensionsPath = localMSBuildExtensionsPath;
                 s_isInitialized = true;
+            }
+            else
+            {
+                s_kind = MSBuildEnvironmentKind.Unknown;
+                logger.LogError("MSBuild environment could not be initialized.");
+                s_isInitialized = false;
             }
 
             if (!s_isInitialized)
             {
-                logger.LogError("MSBuild environment could not be initialized.");
+                return;
             }
+
+            var summary = new StringBuilder();
+            switch (s_kind)
+            {
+                case MSBuildEnvironmentKind.VisualStudio:
+                    summary.AppendLine("OmniSharp initialized with Visual Studio MSBuild.");
+                    break;
+                case MSBuildEnvironmentKind.Mono:
+                    summary.AppendLine("OmniSharp initialized with Mono MSBuild.");
+                    break;
+                case MSBuildEnvironmentKind.StandAlone:
+                    summary.AppendLine("Omnisharp will use local MSBuild.");
+                    break;
+            }
+
+            if (s_msbuildExePath != null)
+            {
+                summary.AppendLine($"    MSBUILD_EXE_PATH: {s_msbuildExePath}");
+            }
+
+            if (s_msbuildExtensionsPath != null)
+            {
+                summary.AppendLine($"    MSBuildExtensionsPath: {s_msbuildExtensionsPath}");
+            }
+
+            if (s_targetFrameworkRootPath != null)
+            {
+                summary.AppendLine($"    TargetFrameworkRootPath: {s_targetFrameworkRootPath}");
+            }
+
+            if (s_roslynTargetsPath != null)
+            {
+                summary.AppendLine($"    RoslynTargetsPath: {s_roslynTargetsPath}");
+            }
+
+            logger.LogInformation(summary.ToString());
         }
 
-        private static void SetEnvionmentVariables(ILogger logger, string msbuildExePath, string msbuildExtensionsPath)
+        private static void SetMSBuildExePath(string msbuildExePath)
         {
-            if (msbuildExePath != null)
-            {
-                Environment.SetEnvironmentVariable(MSBuildExePathName, msbuildExePath);
-                logger.LogInformation($"{MSBuildExePathName} environment variable set to {msbuildExePath}");
-            }
-
-            if (msbuildExtensionsPath != null)
-            {
-                Environment.SetEnvironmentVariable(MSBuildExtensionsPathName, msbuildExtensionsPath);
-                logger.LogInformation($"{MSBuildExtensionsPathName} environment variable set to {msbuildExtensionsPath}");
-            }
+            s_msbuildExePath = msbuildExePath;
+            Environment.SetEnvironmentVariable(MSBuildExePathName, msbuildExePath);
         }
 
-        private static bool TryWithMonoMSBuild(ILogger logger, out string msbuildExePath, out string msbuildExtensionsPath)
+        private static bool TryWithMonoMSBuild()
         {
-            msbuildExePath = null;
-            msbuildExtensionsPath = null;
-
-            if (PlatformHelper.IsWindows)
+            if (!PlatformHelper.IsMono)
             {
                 return false;
             }
@@ -134,49 +176,83 @@ namespace OmniSharp.MSBuild
 
             var monoMSBuildBinDirPath = Path.Combine(monoMSBuildDirPath, "15.0", "bin");
 
-            msbuildExePath = Path.Combine(monoMSBuildBinDirPath, "MSBuild.dll");
+            var msbuildExePath = Path.Combine(monoMSBuildBinDirPath, "MSBuild.dll");
             if (!File.Exists(msbuildExePath))
             {
                 // Could not locate Mono MSBuild.
                 return false;
             }
 
-            // Note: we intentionally don't set msbuildExtensionsPath. This will be set through MSBuild targets.
+            SetMSBuildExePath(msbuildExePath);
 
-            SetEnvionmentVariables(logger, msbuildExePath, msbuildExtensionsPath);
+            if (!TrySetMonoVariables())
+            {
+                s_msbuildExtensionsPath = monoMSBuildDirPath;
+            }
+
+            // Use our version of the Roslyn compiler and targets.
+            var msbuildDirectory = FindMSBuildDirectory();
+            if (msbuildDirectory != null)
+            {
+                var roslynTargetsPath = Path.Combine(msbuildDirectory, "Roslyn");
+                if (Directory.Exists(roslynTargetsPath))
+                {
+                    s_roslynTargetsPath = roslynTargetsPath;
+                }
+            }
 
             return true;
         }
 
-        private static bool TryWithLocalMSBuild(ILogger logger, out string msbuildExePath, out string msbuildExtensionsPath)
+        private static bool TrySetMonoVariables()
         {
-            msbuildExePath = null;
-            msbuildExtensionsPath = null;
+            if (!PlatformHelper.IsMono)
+            {
+                return false;
+            }
 
-            var msbuildDirectory = FindMSBuildDirectory(logger);
+            var monoMSBuildXBuildDirPath = PlatformHelper.GetMonoXBuildDirPath();
+            var monoMSBuildXBuildFrameworksDirPath = PlatformHelper.GetMonoXBuildFrameworksDirPath();
+
+            if (monoMSBuildXBuildDirPath == null &&
+                monoMSBuildXBuildFrameworksDirPath == null)
+            {
+                // No Mono xbuild or xbuild-frameworks folders?.
+                return false;
+            }
+
+            s_msbuildExtensionsPath = monoMSBuildXBuildDirPath;
+            s_targetFrameworkRootPath = monoMSBuildXBuildFrameworksDirPath;
+
+            return true;
+        }
+
+        private static bool TryWithLocalMSBuild()
+        {
+            var msbuildDirectory = FindMSBuildDirectory();
             if (msbuildDirectory == null)
             {
-                logger.LogError("Could not locate MSBuild directory.");
                 return false;
             }
 
             // Set the MSBUILD_EXE_PATH environment variable to the location of MSBuild.exe or MSBuild.dll.
-            msbuildExePath = FindMSBuildExe(msbuildDirectory);
+            var msbuildExePath = FindMSBuildExe(msbuildDirectory);
             if (msbuildExePath == null)
             {
-                logger.LogError("Could not locate MSBuild executable");
                 return false;
             }
 
-            // Set the MSBuildExtensionsPath environment variable to the local msbuild directory.
-            msbuildExtensionsPath = msbuildDirectory;
+            SetMSBuildExePath(msbuildExePath);
 
-            SetEnvionmentVariables(logger, msbuildExePath, msbuildExtensionsPath);
+            if (!TrySetMonoVariables())
+            {
+                s_msbuildExtensionsPath = msbuildDirectory;
+            }
 
             return true;
         }
 
-        private static string FindMSBuildDirectory(ILogger logger)
+        private static string FindMSBuildDirectory()
         {
             // If OmniSharp is running normally, MSBuild is located in an 'msbuild' folder beneath OmniSharp.exe.
             var msbuildDirectory = Path.Combine(AppContext.BaseDirectory, "msbuild");
@@ -186,18 +262,16 @@ namespace OmniSharp.MSBuild
                 // If the 'msbuild' folder does not exist beneath OmniSharp.exe, this is likely a development scenario,
                 // such as debugging or running unit tests. In that case, we use one of the .msbuild-* folders at the
                 // solution level.
-                msbuildDirectory = FindLocalMSBuildFromSolution(logger);
+                msbuildDirectory = FindLocalMSBuildFromSolution();
             }
 
             return msbuildDirectory;
         }
 
-        private static string FindLocalMSBuildFromSolution(ILogger logger)
+        private static string FindLocalMSBuildFromSolution()
         {
             // Try to locate the appropriate build-time msbuild folder by searching for
             // the OmniSharp solution relative to the current folder.
-
-            logger.LogInformation("Searching for solution OmniSharp.sln to locate MSBuild tools...");
 
             var current = AppContext.BaseDirectory;
             while (!File.Exists(Path.Combine(current, "OmniSharp.sln")))

--- a/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
+++ b/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
@@ -9,7 +9,9 @@ namespace OmniSharp.Options
         public bool EnablePackageAutoRestore { get; set; }
 
         public string MSBuildExtensionsPath { get; set; }
+        public string TargetFrameworkRootPath { get; set; }
         public string MSBuildSDKsPath { get; set; }
+        public string RoslynTargetsPath { get; set; }
 
         // TODO: Allow loose properties
         // public IConfiguration Properties { get; set; }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
@@ -24,6 +24,7 @@
             public const string ProjectGuid = nameof(ProjectGuid);
             public const string ProjectName = nameof(ProjectName);
             public const string _ResolveReferenceDependencies = nameof(_ResolveReferenceDependencies);
+            public const string RoslynTargetsPath = nameof(RoslynTargetsPath);
             public const string SignAssembly = nameof(SignAssembly);
             public const string SkipCompilerExecution = nameof(SkipCompilerExecution);
             public const string SolutionDir = nameof(SolutionDir);

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -252,9 +252,18 @@ namespace OmniSharp.MSBuild.ProjectFile
                 userOptionValue: options.Platform,
                 environmentValue: null);
 
-            if (PlatformHelper.IsMono)
+            // If we're running on Mono and couldn't set up Mono MSBuild, try to
+            // set MSBuildExtensionsPath and TargetFrameworkRootPath to xbuild and xbuild-frameworks.
+            if (PlatformHelper.IsMono && MSBuildEnvironment.Kind == MSBuildEnvironmentKind.StandAlone)
             {
-                var monoXBuildFrameworksDirPath = PlatformHelper.MonoXBuildFrameworksDirPath;
+                var monoXBuildDirPath = PlatformHelper.GetMonoXBuildDirPath();
+                if (monoXBuildDirPath != null && !globalProperties.ContainsKey(PropertyNames.MSBuildExtensionsPath))
+                {
+                    logger.LogDebug($"Using MSBuildExtensionsPath: {monoXBuildDirPath}");
+                    globalProperties[PropertyNames.MSBuildExtensionsPath] = monoXBuildDirPath;
+                }
+
+                var monoXBuildFrameworksDirPath = PlatformHelper.GetMonoXBuildFrameworksDirPath();
                 if (monoXBuildFrameworksDirPath != null)
                 {
                     logger.LogDebug($"Using TargetFrameworkRootPath: {monoXBuildFrameworksDirPath}");

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -236,6 +236,18 @@ namespace OmniSharp.MSBuild.ProjectFile
 
             globalProperties.AddPropertyIfNeeded(
                 logger,
+                PropertyNames.TargetFrameworkRootPath,
+                userOptionValue: options.TargetFrameworkRootPath,
+                environmentValue: MSBuildEnvironment.TargetFrameworkRootPath);
+
+            globalProperties.AddPropertyIfNeeded(
+                logger,
+                PropertyNames.RoslynTargetsPath,
+                userOptionValue: options.RoslynTargetsPath,
+                environmentValue: MSBuildEnvironment.RoslynTargetsPath);
+
+            globalProperties.AddPropertyIfNeeded(
+                logger,
                 PropertyNames.VisualStudioVersion,
                 userOptionValue: options.VisualStudioVersion,
                 environmentValue: null);
@@ -251,25 +263,6 @@ namespace OmniSharp.MSBuild.ProjectFile
                 PropertyNames.Platform,
                 userOptionValue: options.Platform,
                 environmentValue: null);
-
-            // If we're running on Mono and couldn't set up Mono MSBuild, try to
-            // set MSBuildExtensionsPath and TargetFrameworkRootPath to xbuild and xbuild-frameworks.
-            if (PlatformHelper.IsMono && MSBuildEnvironment.Kind == MSBuildEnvironmentKind.StandAlone)
-            {
-                var monoXBuildDirPath = PlatformHelper.GetMonoXBuildDirPath();
-                if (monoXBuildDirPath != null && !globalProperties.ContainsKey(PropertyNames.MSBuildExtensionsPath))
-                {
-                    logger.LogDebug($"Using MSBuildExtensionsPath: {monoXBuildDirPath}");
-                    globalProperties[PropertyNames.MSBuildExtensionsPath] = monoXBuildDirPath;
-                }
-
-                var monoXBuildFrameworksDirPath = PlatformHelper.GetMonoXBuildFrameworksDirPath();
-                if (monoXBuildFrameworksDirPath != null)
-                {
-                    logger.LogDebug($"Using TargetFrameworkRootPath: {monoXBuildFrameworksDirPath}");
-                    globalProperties.Add(PropertyNames.TargetFrameworkRootPath, monoXBuildFrameworksDirPath);
-                }
-            }
 
             return globalProperties;
         }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -3,5 +3,5 @@
     <package id="Cake" version="0.19.5" />
     <package id="Microsoft.Build.Runtime" version="15.3.0-preview-000388-01" />
     <package id="Microsoft.Net.Compilers" version="2.3.0-beta2" />
-    <package id="xunit.runner.console" version="2.2.0" />
+    <package id="xunit.runner.console" version="2.3.0-beta4-build3722" />
 </packages>


### PR DESCRIPTION
I'm cherry-picking this change from https://github.com/OmniSharp/omnisharp-roslyn/pull/915, since it's unrelated to that PR.

Fixes #892 
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1597
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1624
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1396

Related PR: https://github.com/mono/msbuild/pull/22