### PR TITLE
Update to latest 2.3.1 Roslyn packages

### DIFF
--- a/src/OmniSharp.Abstractions/OmniSharp.Abstractions.csproj
+++ b/src/OmniSharp.Abstractions/OmniSharp.Abstractions.csproj
@@ -4,15 +4,11 @@
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
-
-    <!-- Needed for Microsoft.Composition -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
     <RootNamespace>OmniSharp</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.30" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.1.0" />
@@ -20,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="NuGet.Versioning" Version="4.0.0" />
+    <PackageReference Include="System.Composition" Version="1.0.31" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/OmniSharp.DotNet/OmniSharp.DotNet.csproj
+++ b/src/OmniSharp.DotNet/OmniSharp.DotNet.csproj
@@ -4,9 +4,6 @@
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
-
-    <!-- Needed for Microsoft.Composition -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.0-beta2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.1" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel" Version="1.0.0-rc3-1-003177" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />

--- a/src/OmniSharp.DotNetTest/OmniSharp.DotNetTest.csproj
+++ b/src/OmniSharp.DotNetTest/OmniSharp.DotNetTest.csproj
@@ -4,9 +4,6 @@
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-
-    <!-- Needed for Microsoft.Composition -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.0-beta2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.1" />
   </ItemGroup>
 
   <!-- Legacy 'dotnet test' support -->

--- a/src/OmniSharp.Host/OmniSharp.Host.csproj
+++ b/src/OmniSharp.Host/OmniSharp.Host.csproj
@@ -4,9 +4,6 @@
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    
-    <!-- Needed for Microsoft.Composition -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OmniSharp.MSBuild/OmniSharp.MSBuild.csproj
+++ b/src/OmniSharp.MSBuild/OmniSharp.MSBuild.csproj
@@ -4,9 +4,6 @@
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
-
-    <!-- Needed for Microsoft.Composition -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OmniSharp.Nuget/OmniSharp.Nuget.csproj
+++ b/src/OmniSharp.Nuget/OmniSharp.Nuget.csproj
@@ -4,9 +4,6 @@
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    
-    <!-- Needed for Microsoft.Composition -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OmniSharp.Plugins/OmniSharp.Plugins.csproj
+++ b/src/OmniSharp.Plugins/OmniSharp.Plugins.csproj
@@ -4,9 +4,6 @@
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    
-    <!-- Needed for Microsoft.Composition -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
+++ b/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
@@ -4,9 +4,6 @@
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
-
-    <!-- Needed for Microsoft.Composition -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.0-beta2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.3.0-beta2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.0-beta2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">

--- a/src/OmniSharp.Roslyn/OmniSharp.Roslyn.csproj
+++ b/src/OmniSharp.Roslyn/OmniSharp.Roslyn.csproj
@@ -4,9 +4,6 @@
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
-
-    <!-- Needed for Microsoft.Composition -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.3.0-beta2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.3.0-beta2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.3.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.0" />
   </ItemGroup>
 

--- a/src/OmniSharp.Script/OmniSharp.Script.csproj
+++ b/src/OmniSharp.Script/OmniSharp.Script.csproj
@@ -5,8 +5,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
 
-    <!-- Needed for Microsoft.Composition -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dotnet.Script.NuGetMetadataResolver" Version="2.0.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.3.0-beta2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.3.1" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel" Version="1.0.0-rc3-1-003177" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>

--- a/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj
+++ b/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj
@@ -4,9 +4,6 @@
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
-
-    <!-- Needed for Microsoft.Composition -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OmniSharp/OmniSharp.csproj
+++ b/src/OmniSharp/OmniSharp.csproj
@@ -6,7 +6,6 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;fedora.24-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/OmniSharp.DotNet.Tests/OmniSharp.DotNet.Tests.csproj
+++ b/tests/OmniSharp.DotNet.Tests/OmniSharp.DotNet.Tests.csproj
@@ -5,7 +5,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/OmniSharp.DotNetTest.Tests/OmniSharp.DotNetTest.Tests.csproj
+++ b/tests/OmniSharp.DotNetTest.Tests/OmniSharp.DotNetTest.Tests.csproj
@@ -5,7 +5,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/OmniSharp.MSBuild.Tests/OmniSharp.MSBuild.Tests.csproj
+++ b/tests/OmniSharp.MSBuild.Tests/OmniSharp.MSBuild.Tests.csproj
@@ -5,7 +5,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/OmniSharp.Roslyn.CSharp.Tests.csproj
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/OmniSharp.Roslyn.CSharp.Tests.csproj
@@ -5,7 +5,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/OmniSharp.Stdio.Tests/OmniSharp.Stdio.Tests.csproj
+++ b/tests/OmniSharp.Stdio.Tests/OmniSharp.Stdio.Tests.csproj
@@ -5,7 +5,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.3.0-beta2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3722" />
     <PackageReference Include="xunit" Version="2.3.0-beta4-build3722" />

--- a/tests/OmniSharp.Tests/OmniSharp.Tests.csproj
+++ b/tests/OmniSharp.Tests/OmniSharp.Tests.csproj
@@ -5,7 +5,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/TestUtility/TestUtility.csproj
+++ b/tests/TestUtility/TestUtility.csproj
@@ -4,9 +4,6 @@
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
-
-    <!-- Needed for Microsoft.Composition -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.0-beta2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.3.0-beta2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.3.1" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel" Version="1.0.0-rc3-1-003177" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel.Workspaces" Version="1.0.0-preview2-1-003177" />
     <PackageReference Include="xunit" Version="2.3.0-beta4-build3722" />

--- a/tests/app.config
+++ b/tests/app.config
@@ -67,19 +67,19 @@
 
             <dependentAssembly>
                 <assemblyIdentity name="System.Composition.AttributedModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.0.31.0" newVersion="1.0.31.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Composition.Hosting" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.0.31.0" newVersion="1.0.31.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Composition.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.0.31.0" newVersion="1.0.31.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Composition.TypedParts" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.0.31.0" newVersion="1.0.31.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral"/>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -2,6 +2,6 @@
 <packages>
     <package id="Cake" version="0.19.5" />
     <package id="Microsoft.Build.Runtime" version="15.3.0-preview-000388-01" />
-    <package id="Microsoft.Net.Compilers" version="2.3.0-beta2" />
+    <package id="Microsoft.Net.Compilers" version="2.3.1" />
     <package id="xunit.runner.console" version="2.3.0-beta4-build3722" />
 </packages>


### PR DESCRIPTION
This PR also includes an update to System.Composition, 1.0.31, since Roslyn now targets that instead of Microsoft.Composition, 1.0.30. That also allows us to remove our PackageTargetFallback.