### PR TITLE
added System.Composition binding redirects to omnisharp.exe

### DIFF
--- a/src/OmniSharp/app.config
+++ b/src/OmniSharp/app.config
@@ -34,7 +34,23 @@
                 <assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
                 <bindingRedirect oldVersion="2.0.0.0-99.0.0.0" newVersion="15.1.0.0"/>
             </dependentAssembly>
-
+          
+            <dependentAssembly>
+                <assemblyIdentity name="System.Composition.AttributedModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.0.31.0" newVersion="1.0.31.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Composition.Hosting" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.0.31.0" newVersion="1.0.31.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Composition.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.0.31.0" newVersion="1.0.31.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Composition.TypedParts" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.0.31.0" newVersion="1.0.31.0"/>
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
 </configuration>


### PR DESCRIPTION
Follow up to #930 
At the moment if you start Omnisharp, and you have a folder with external code actions configured, it will fail to start:

```
C:\code\omnisharp-roslyn>"C:\code\omnisharp-roslyn\artifacts\publish\OmniSharp\default\net46\OmniSharp.exe" -s C:\code\omnisharp-roslyn\src\OmniSharp --stdio
OmniSharp: -s C:\code\omnisharp-roslyn\src\OmniSharp --stdio
System.IO.FileNotFoundException: Could not load file or assembly 'System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
File name: 'System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   at System.ModuleHandle.ResolveType(RuntimeModule module, Int32 typeToken, IntPtr* typeInstArgs, Int32 typeInstCount, IntPtr* methodInstArgs, Int32 methodInstCount, ObjectHandleOnStack type)
   at System.ModuleHandle.ResolveTypeHandleInternal(RuntimeModule module, Int32 typeToken, RuntimeTypeHandle[] typeInstantiationContext, RuntimeTypeHandle[] methodInstantiationContext)
   at System.Reflection.RuntimeModule.ResolveType(Int32 metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
   at System.Reflection.CustomAttribute.FilterCustomAttributeRecord(CustomAttributeRecord caRecord, MetadataImport scope, Assembly& lastAptcaOkAssembly, RuntimeModule decoratedModule, MetadataToken decoratedToken, RuntimeType attributeFilterType, Boolean mustBeInheritable, Object[] attributes, IList derivedAttributes, RuntimeType& attributeType, IRuntimeMethodInfo& ctor, Boolean& ctorHasParameters, Boolean& isVarArg)
   at System.Reflection.CustomAttribute.GetCustomAttributes(RuntimeModule decoratedModule, Int32 decoratedMetadataToken, Int32 pcaCount, RuntimeType attributeFilterType, Boolean mustBeInheritable, IList derivedAttributes, Boolean isDecoratedTargetSecurityTransparent)
```

There is a unit test for this https://github.com/OmniSharp/omnisharp-roslyn/blob/master/tests/OmniSharp.Roslyn.CSharp.Tests/CodeActionsV2Facts.cs#L39 but it didn't catch this because the test project has the necessary binding redirects 🙂 