### PR TITLE
C# 7.1

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
@@ -37,6 +37,7 @@ namespace OmniSharp.MSBuild.ProjectFile
             // ISO-1, ISO-2, 3, 4, 5, 6, 7 or Default
             switch (propertyValue.ToLower())
             {
+                case "latest": return LanguageVersion.Latest;
                 case "iso-1": return LanguageVersion.CSharp1;
                 case "iso-2": return LanguageVersion.CSharp2;
                 case "3": return LanguageVersion.CSharp3;
@@ -44,6 +45,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 case "5": return LanguageVersion.CSharp5;
                 case "6": return LanguageVersion.CSharp6;
                 case "7": return LanguageVersion.CSharp7;
+                case "7.1": return LanguageVersion.CSharp7_1;
                 default: return LanguageVersion.Default;
             }
         }

--- a/src/OmniSharp.Script/ScriptHelper.cs
+++ b/src/OmniSharp.Script/ScriptHelper.cs
@@ -30,7 +30,7 @@ namespace OmniSharp.Script
             "System.Threading.Tasks"
         };
 
-        private static readonly CSharpParseOptions ParseOptions = new CSharpParseOptions(LanguageVersion.Default, DocumentationMode.Parse, SourceCodeKind.Script);
+        private static readonly CSharpParseOptions ParseOptions = new CSharpParseOptions(LanguageVersion.Latest, DocumentationMode.Parse, SourceCodeKind.Script);
 
         private readonly Lazy<CSharpCompilationOptions> _compilationOptions;
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -412,6 +412,21 @@ class C
             Assert.True(completions.All(c => !c.IsSuggestionMode));
         }
 
+        [Fact]
+        public async Task Scripting_by_default_returns_completions_for_CSharp7_1()
+        {
+            const string source =
+                @"
+                  var number1 = 1;
+                  var number2 = 2;
+                  var tuple = (number1, number2);
+                  tuple.n$$
+                ";
+
+            var completions = await FindCompletionsAsync("dummy.csx", source);
+            ContainsCompletions(completions.Select(c => c.CompletionText), new[] { "number1", "number2" });
+        }
+
         private void ContainsCompletions(IEnumerable<string> completions, params string[] expected)
         {
             if (!completions.SequenceEqual(expected))


### PR DESCRIPTION
 - added C# `7.1` and `Latest` to the MSBuild property converter
 - updated CSX from `LanguageVersion.Default` (which is C# 7) to `LanguageVersion.Latest` because we should be cutting edge there 😃 Jokes aside, there is no way in scripting to specify language version (since there is no project file) so it makes sense to be on the latest-greatest version