### PR TITLE
Msbuild project fixes

### DIFF
--- a/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
+++ b/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
@@ -25,6 +25,7 @@ namespace OmniSharp.MSBuild
         private static string s_msbuildExtensionsPath;
         private static string s_targetFrameworkRootPath;
         private static string s_roslynTargetsPath;
+        private static string s_cscToolPath;
 
         public static bool IsInitialized => s_isInitialized;
 
@@ -70,6 +71,15 @@ namespace OmniSharp.MSBuild
             {
                 ThrowIfNotInitialized();
                 return s_roslynTargetsPath;
+            }
+        }
+
+        public static string CscToolPath
+        {
+            get
+            {
+                ThrowIfNotInitialized();
+                return s_cscToolPath;
             }
         }
 
@@ -151,6 +161,11 @@ namespace OmniSharp.MSBuild
                 summary.AppendLine($"    RoslynTargetsPath: {s_roslynTargetsPath}");
             }
 
+            if (s_cscToolPath != null)
+            {
+                summary.AppendLine($"    CscToolPath: {s_cscToolPath}");
+            }
+
             logger.LogInformation(summary.ToString());
         }
 
@@ -186,17 +201,7 @@ namespace OmniSharp.MSBuild
             SetMSBuildExePath(msbuildExePath);
             TrySetMSBuildExtensionsPathToXBuild();
             TrySetTargetFrameworkRootPathToXBuildFrameworks();
-
-            // Use our version of the Roslyn compiler and targets.
-            var msbuildDirectory = FindMSBuildDirectory();
-            if (msbuildDirectory != null)
-            {
-                var roslynTargetsPath = Path.Combine(msbuildDirectory, "Roslyn");
-                if (Directory.Exists(roslynTargetsPath))
-                {
-                    s_roslynTargetsPath = roslynTargetsPath;
-                }
-            }
+            TrySetRoslynTargetsPathAndCscToolPath();
 
             return true;
         }
@@ -225,15 +230,52 @@ namespace OmniSharp.MSBuild
                 return false;
             }
 
-            var monoMSBuildXBuildDirPath = PlatformHelper.GetMonoXBuildDirPath();
-            if (monoMSBuildXBuildDirPath == null)
+            var monoXBuildDirPath = PlatformHelper.GetMonoXBuildDirPath();
+            if (monoXBuildDirPath == null)
             {
                 return false;
             }
 
-            s_msbuildExtensionsPath = monoMSBuildXBuildDirPath;
+            var monoXBuild15DirPath = Path.Combine(monoXBuildDirPath, "15.0");
+            if (!Directory.Exists(monoXBuild15DirPath))
+            {
+                return false;
+            }
+
+            s_msbuildExtensionsPath = monoXBuildDirPath;
 
             return true;
+        }
+
+        private static bool TrySetRoslynTargetsPathAndCscToolPath()
+        {
+            if (!PlatformHelper.IsMono)
+            {
+                return false;
+            }
+
+            // Use our version of the Roslyn compiler and targets.
+            // We do this for a couple of reasons:
+            //
+            // 1. Mono relocates csc.exe to a different location within Mono.
+            // 2. The Mono targets hardcode CscToolPath to that different location.
+            //
+            // In order to use the Compile target during MSBuild execution, csc.exe
+            // needs to be located successfully.
+
+            var msbuildDirectory = FindMSBuildDirectory();
+            if (msbuildDirectory != null)
+            {
+                var roslynTargetsPath = Path.Combine(msbuildDirectory, "Roslyn");
+                if (Directory.Exists(roslynTargetsPath))
+                {
+                    s_roslynTargetsPath = roslynTargetsPath;
+                    s_cscToolPath = roslynTargetsPath;
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool TryWithLocalMSBuild()
@@ -252,8 +294,14 @@ namespace OmniSharp.MSBuild
             }
 
             SetMSBuildExePath(msbuildExePath);
-            s_msbuildExtensionsPath = msbuildDirectory;
+
+            if (!TrySetMSBuildExtensionsPathToXBuild())
+            {
+                s_msbuildExtensionsPath = msbuildDirectory;
+            }
+
             TrySetTargetFrameworkRootPathToXBuildFrameworks();
+            TrySetRoslynTargetsPathAndCscToolPath();
 
             return true;
         }

--- a/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
+++ b/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
@@ -184,11 +184,8 @@ namespace OmniSharp.MSBuild
             }
 
             SetMSBuildExePath(msbuildExePath);
-
-            if (!TrySetMonoVariables())
-            {
-                s_msbuildExtensionsPath = monoMSBuildDirPath;
-            }
+            TrySetMSBuildExtensionsPathToXBuild();
+            TrySetTargetFrameworkRootPathToXBuildFrameworks();
 
             // Use our version of the Roslyn compiler and targets.
             var msbuildDirectory = FindMSBuildDirectory();
@@ -204,7 +201,24 @@ namespace OmniSharp.MSBuild
             return true;
         }
 
-        private static bool TrySetMonoVariables()
+        private static bool TrySetTargetFrameworkRootPathToXBuildFrameworks()
+        {
+            if (!PlatformHelper.IsMono)
+            {
+                return false;
+            }
+
+            var monoMSBuildXBuildFrameworksDirPath = PlatformHelper.GetMonoXBuildFrameworksDirPath();
+            if (monoMSBuildXBuildFrameworksDirPath == null)
+            {
+                return false;
+            }
+
+            s_targetFrameworkRootPath = monoMSBuildXBuildFrameworksDirPath;
+            return true;
+        }
+
+        private static bool TrySetMSBuildExtensionsPathToXBuild()
         {
             if (!PlatformHelper.IsMono)
             {
@@ -212,17 +226,12 @@ namespace OmniSharp.MSBuild
             }
 
             var monoMSBuildXBuildDirPath = PlatformHelper.GetMonoXBuildDirPath();
-            var monoMSBuildXBuildFrameworksDirPath = PlatformHelper.GetMonoXBuildFrameworksDirPath();
-
-            if (monoMSBuildXBuildDirPath == null &&
-                monoMSBuildXBuildFrameworksDirPath == null)
+            if (monoMSBuildXBuildDirPath == null)
             {
-                // No Mono xbuild or xbuild-frameworks folders?.
                 return false;
             }
 
             s_msbuildExtensionsPath = monoMSBuildXBuildDirPath;
-            s_targetFrameworkRootPath = monoMSBuildXBuildFrameworksDirPath;
 
             return true;
         }
@@ -243,11 +252,8 @@ namespace OmniSharp.MSBuild
             }
 
             SetMSBuildExePath(msbuildExePath);
-
-            if (!TrySetMonoVariables())
-            {
-                s_msbuildExtensionsPath = msbuildDirectory;
-            }
+            s_msbuildExtensionsPath = msbuildDirectory;
+            TrySetTargetFrameworkRootPathToXBuildFrameworks();
 
             return true;
         }

--- a/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
+++ b/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
@@ -12,6 +12,7 @@ namespace OmniSharp.Options
         public string TargetFrameworkRootPath { get; set; }
         public string MSBuildSDKsPath { get; set; }
         public string RoslynTargetsPath { get; set; }
+        public string CscToolPath { get; set; }
 
         // TODO: Allow loose properties
         // public IConfiguration Properties { get; set; }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
@@ -9,6 +9,7 @@
             public const string AssemblyOriginatorKeyFile = nameof(AssemblyOriginatorKeyFile);
             public const string BuildProjectReferences = nameof(BuildProjectReferences);
             public const string Configuration = nameof(Configuration);
+            public const string CscToolPath = nameof(CscToolPath);
             public const string DefineConstants = nameof(DefineConstants);
             public const string DesignTimeBuild = nameof(DesignTimeBuild);
             public const string DocumentationFile = nameof(DocumentationFile);

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -298,6 +298,12 @@ namespace OmniSharp.MSBuild.ProjectFile
 
             globalProperties.AddPropertyIfNeeded(
                 logger,
+                PropertyNames.CscToolPath,
+                userOptionValue: options.CscToolPath,
+                environmentValue: MSBuildEnvironment.CscToolPath);
+
+            globalProperties.AddPropertyIfNeeded(
+                logger,
                 PropertyNames.VisualStudioVersion,
                 userOptionValue: options.VisualStudioVersion,
                 environmentValue: null);


### PR DESCRIPTION
Fixes #936
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1676

This PR addresses a few issues with using MSBuild for execution on Mono:

1. There was a bug introduced where we would set `MSBuildExtensionsPath` to `$mono_prefix/xbuild` in situations that caused things to break. OmniSharp will now only do that if `$mono_prefix/msbuild` and `$mono_prefix/xbuild/15.0` exist. If we set it when those paths don't exist, it's likely that we'll lose the targets to properly handle .NET Core projects.
2. The Mono targets have hardcoded a redirect of `CscToolPath` to a different location. Unfortunately, that breaks OmniSharp when we call the `Compile` target, since the `Csc` task requires a correct path to `csc.exe`. So, we override `CscToolsPath` and set it to point to our own copy of `csc.exe` (which is the same value as `RoslynTargetsPath`).
3. I encountered an issue where we would attempt to use an MSBuild Toolset, even if it pointed to a location that didn't exist on disk. We now try to figure out the correct toolset to use, and, if it doesn't exist, use the highest toolset version that *does* exist.