### PR TITLE
Ensure that CscToolExe is set to 'csc.exe'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.23.2] - 2017-08-14
+
+* Set CscToolExe to 'csc.exe' to address issues with older Mono installations where the MSBuild targets have set it to 'mcs.exe'.
+
 ## [1.23.1] - 2017-08-08
 
 * Fixed two regressions with MSBuild projects:

--- a/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
+++ b/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
@@ -26,6 +26,7 @@ namespace OmniSharp.MSBuild
         private static string s_targetFrameworkRootPath;
         private static string s_roslynTargetsPath;
         private static string s_cscToolPath;
+        private static string s_cscToolExe;
 
         public static bool IsInitialized => s_isInitialized;
 
@@ -80,6 +81,15 @@ namespace OmniSharp.MSBuild
             {
                 ThrowIfNotInitialized();
                 return s_cscToolPath;
+            }
+        }
+
+        public static string CscToolExe
+        {
+            get
+            {
+                ThrowIfNotInitialized();
+                return s_cscToolExe;
             }
         }
 
@@ -201,7 +211,7 @@ namespace OmniSharp.MSBuild
             SetMSBuildExePath(msbuildExePath);
             TrySetMSBuildExtensionsPathToXBuild();
             TrySetTargetFrameworkRootPathToXBuildFrameworks();
-            TrySetRoslynTargetsPathAndCscToolPath();
+            TrySetRoslynTargetsPathAndCscTool();
 
             return true;
         }
@@ -247,7 +257,7 @@ namespace OmniSharp.MSBuild
             return true;
         }
 
-        private static bool TrySetRoslynTargetsPathAndCscToolPath()
+        private static bool TrySetRoslynTargetsPathAndCscTool()
         {
             if (!PlatformHelper.IsMono)
             {
@@ -258,7 +268,7 @@ namespace OmniSharp.MSBuild
             // We do this for a couple of reasons:
             //
             // 1. Mono relocates csc.exe to a different location within Mono.
-            // 2. The Mono targets hardcode CscToolPath to that different location.
+            // 2. The latest Mono targets hardcode CscToolPath to that different location.
             //
             // In order to use the Compile target during MSBuild execution, csc.exe
             // needs to be located successfully.
@@ -271,6 +281,13 @@ namespace OmniSharp.MSBuild
                 {
                     s_roslynTargetsPath = roslynTargetsPath;
                     s_cscToolPath = roslynTargetsPath;
+
+                    // Ensure that CscToolExe is set to "csc.exe", since that's what
+                    // is included in OmniSharp. On older versions of Mono, this would
+                    // be mcs.exe, which will not be able to be located in our "Roslyn"
+                    // directory.
+                    s_cscToolExe = "csc.exe";
+
                     return true;
                 }
             }
@@ -301,7 +318,7 @@ namespace OmniSharp.MSBuild
             }
 
             TrySetTargetFrameworkRootPathToXBuildFrameworks();
-            TrySetRoslynTargetsPathAndCscToolPath();
+            TrySetRoslynTargetsPathAndCscTool();
 
             return true;
         }

--- a/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
+++ b/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
@@ -13,6 +13,7 @@ namespace OmniSharp.Options
         public string MSBuildSDKsPath { get; set; }
         public string RoslynTargetsPath { get; set; }
         public string CscToolPath { get; set; }
+        public string CscToolExe { get; set; }
 
         // TODO: Allow loose properties
         // public IConfiguration Properties { get; set; }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
@@ -9,6 +9,7 @@
             public const string AssemblyOriginatorKeyFile = nameof(AssemblyOriginatorKeyFile);
             public const string BuildProjectReferences = nameof(BuildProjectReferences);
             public const string Configuration = nameof(Configuration);
+            public const string CscToolExe = nameof(CscToolExe);
             public const string CscToolPath = nameof(CscToolPath);
             public const string DefineConstants = nameof(DefineConstants);
             public const string DesignTimeBuild = nameof(DesignTimeBuild);

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -304,6 +304,12 @@ namespace OmniSharp.MSBuild.ProjectFile
 
             globalProperties.AddPropertyIfNeeded(
                 logger,
+                PropertyNames.CscToolExe,
+                userOptionValue: options.CscToolExe,
+                environmentValue: MSBuildEnvironment.CscToolExe);
+
+            globalProperties.AddPropertyIfNeeded(
+                logger,
                 PropertyNames.VisualStudioVersion,
                 userOptionValue: options.VisualStudioVersion,
                 environmentValue: null);


### PR DESCRIPTION
We set CscToolPath to the Roslyn directory that we include with OmniSharp to ensure that the Compile task can run. However, we failed to set CscToolExe to "csc.exe". So, if a project or target was using something else (like "mcs.exe"), OmniSharp fails to process the project.

Note: "csc.exe" is never actually called. However, MSBuild tool tasks validate that the tool (in this case, "csc.exe") actually exist on disk. Since _our_ "csc.exe" will always be there, this should be quite safe.