### PR TITLE
Adds LoadFrom to IAssemblyLoader

### DIFF
--- a/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
+++ b/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
@@ -9,6 +9,8 @@ namespace OmniSharp.Services
         Assembly Load(AssemblyName name);
 
         IReadOnlyList<Assembly> LoadAllFrom(string folderPath);
+
+        Assembly LoadFrom(string assemblyPath);
     }
 
     public static class IAssemblyLoaderExtensions

--- a/src/OmniSharp.Host/Services/AssemblyLoader.cs
+++ b/src/OmniSharp.Host/Services/AssemblyLoader.cs
@@ -44,7 +44,7 @@ namespace OmniSharp.Host.Loader
 
                 foreach (var filePath in Directory.EnumerateFiles(folderPath, "*.dll"))
                 {
-                    var assembly = LoadFromPath(filePath);
+                    var assembly = LoadFrom(filePath);
                     if (assembly != null)
                     {
                         assemblies.Add(assembly);
@@ -60,8 +60,10 @@ namespace OmniSharp.Host.Loader
             }
         }
 
-        private Assembly LoadFromPath(string assemblyPath)
+        public Assembly LoadFrom(string assemblyPath)
         {
+            if (string.IsNullOrWhiteSpace(assemblyPath)) return null;
+
             Assembly assembly = null;
 
             try


### PR DESCRIPTION
- Makes it possible to load single assembly from path.
- Make private method in `AssemblyLoader` public.
- Rename to `LoadFrom` to align with `LoadAllFrom`