### PR TITLE
Don't crash when encountering external code action DLL with missing dependencies 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.24.0] - Not released
+
+* Fixed a bug where an external code action DLL with missing dependencies would crash OmniSharp.
+
 ## [1.23.2] - 2017-08-14
 
 * Set CscToolExe to 'csc.exe' to address issues with older Mono installations where the MSBuild targets have set it to 'mcs.exe'.

--- a/src/OmniSharp.Roslyn/HostServicesAggregator.cs
+++ b/src/OmniSharp.Roslyn/HostServicesAggregator.cs
@@ -43,11 +43,11 @@ namespace OmniSharp
                         builder.Add(assembly);
                         logger.LogTrace("Successfully added {assembly} to host service assemblies.", assembly.FullName);
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
                         // if we can't see exported types, it means that the assembly cannot participate
-                        // in MefHostServices as one or more of its dependencies (typically a Visual Studio or GACed DLL) is missing
-                        logger.LogWarning("Expected to use {assembly} in host services but the assembly cannot be used due to missing dependencies.", assembly.FullName);
+                        // in MefHostServices. Most likely cause is that one or more of its dependencies (typically a Visual Studio or GACed DLL) are missing
+                        logger.LogWarning("Expected to use {assembly} in host services but the assembly cannot be loaded due to an exception: {exceptionMessage}.", assembly.FullName, ex.Message);
                     }
                 }
             }

--- a/src/OmniSharp.Roslyn/HostServicesAggregator.cs
+++ b/src/OmniSharp.Roslyn/HostServicesAggregator.cs
@@ -1,13 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Reflection;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
-using OmniSharp.Services;
-using System.Linq;
-using System;
 using Microsoft.Extensions.Logging;
+using OmniSharp.Services;
 
 namespace OmniSharp
 {

--- a/src/OmniSharp.Roslyn/HostServicesAggregator.cs
+++ b/src/OmniSharp.Roslyn/HostServicesAggregator.cs
@@ -5,18 +5,22 @@ using System.Reflection;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using OmniSharp.Services;
+using System.Linq;
+using System;
+using Microsoft.Extensions.Logging;
 
 namespace OmniSharp
 {
     [Export]
     public class HostServicesAggregator
     {
-        private readonly ImmutableArray<Assembly> _assemblies;
+        private ImmutableArray<Assembly> _assemblies;
 
         [ImportingConstructor]
         public HostServicesAggregator(
-            [ImportMany] IEnumerable<IHostServicesProvider> hostServicesProviders)
+            [ImportMany] IEnumerable<IHostServicesProvider> hostServicesProviders, ILoggerFactory loggerFactory)
         {
+            var logger = loggerFactory.CreateLogger<HostServicesAggregator>();
             var builder = ImmutableHashSet.CreateBuilder<Assembly>();
 
             // We always include the default Roslyn assemblies, which includes:
@@ -34,7 +38,18 @@ namespace OmniSharp
             {
                 foreach (var assembly in provider.Assemblies)
                 {
-                    builder.Add(assembly);
+                    try
+                    {
+                        var exportedTypes = assembly.ExportedTypes;
+                        builder.Add(assembly);
+                        logger.LogTrace("Successfully added {assembly} to host service assemblies.", assembly.FullName);
+                    }
+                    catch (Exception)
+                    {
+                        // if we can't see exported types, it means that the assembly cannot participate
+                        // in MefHostServices as one or more of its dependencies (typically a Visual Studio or GACed DLL) is missing
+                        logger.LogWarning("Expected to use {assembly} in host services but the assembly cannot be used due to missing dependencies.", assembly.FullName);
+                    }
                 }
             }
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/BufferFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/BufferFacts.cs
@@ -2,11 +2,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Models.ChangeBuffer;
 using OmniSharp.Roslyn.CSharp.Services.Buffer;
 using OmniSharp.Services;
 using Xunit;
-using Microsoft.Extensions.Logging;
 
 namespace OmniSharp.Roslyn.CSharp.Tests
 {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/BufferFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/BufferFacts.cs
@@ -6,6 +6,7 @@ using OmniSharp.Models.ChangeBuffer;
 using OmniSharp.Roslyn.CSharp.Services.Buffer;
 using OmniSharp.Services;
 using Xunit;
+using Microsoft.Extensions.Logging;
 
 namespace OmniSharp.Roslyn.CSharp.Tests
 {
@@ -15,7 +16,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         {
             var workspace = new OmniSharpWorkspace(
                 new HostServicesAggregator(
-                    Enumerable.Empty<IHostServicesProvider>()));
+                    Enumerable.Empty<IHostServicesProvider>(), new LoggerFactory()));
 
             var service = new ChangeBufferService(workspace);
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/BufferManagerFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/BufferManagerFacts.cs
@@ -8,6 +8,7 @@ using OmniSharp.Services;
 using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace OmniSharp.Tests
 {
@@ -95,7 +96,7 @@ namespace OmniSharp.Tests
         {
             var workspace = new OmniSharpWorkspace(
                 new HostServicesAggregator(
-                    Enumerable.Empty<IHostServicesProvider>()));
+                    Enumerable.Empty<IHostServicesProvider>(), new LoggerFactory()));
 
             TestHelpers.AddProjectToWorkspace(workspace,
                 filePath: Path.Combine("src", "root", "foo.csproj"),
@@ -161,7 +162,7 @@ namespace OmniSharp.Tests
         {
             var workspace = new OmniSharpWorkspace(
                 new HostServicesAggregator(
-                    Enumerable.Empty<IHostServicesProvider>()));
+                    Enumerable.Empty<IHostServicesProvider>(), new LoggerFactory()));
 
             TestHelpers.AddProjectToWorkspace(workspace,
                 filePath: Path.Combine("src", "project.json"),

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/BufferManagerFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/BufferManagerFacts.cs
@@ -2,13 +2,13 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Models;
 using OmniSharp.Models.UpdateBuffer;
 using OmniSharp.Services;
 using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
-using Microsoft.Extensions.Logging;
 
 namespace OmniSharp.Tests
 {

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Microsoft.Extensions.Logging;
 using OmniSharp;
 using OmniSharp.Script;
 using OmniSharp.Services;
@@ -14,7 +15,7 @@ namespace TestUtility
     {
         public static OmniSharpWorkspace CreateCsxWorkspace(TestFile testFile)
         {
-            var workspace = new OmniSharpWorkspace(new HostServicesAggregator(Enumerable.Empty<IHostServicesProvider>()));
+            var workspace = new OmniSharpWorkspace(new HostServicesAggregator(Enumerable.Empty<IHostServicesProvider>(), new LoggerFactory()));
             AddCsxProjectToWorkspace(workspace, testFile);
             return workspace;
         }


### PR DESCRIPTION
Fixed a bug where an external code action DLL with missing dependencies would crash OmniSharp. This can happen when - for example - the refactoring DLL is built in a way that it takes dependency on Visual Studio DLLs or GAC DLLs that don't exist on the machine where OmniSharp runs.

If that happens, we will now just log a warning and continue, rather than crashing OmniSharp.