### PR TITLE
A couple of fixes to test support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All changes to the project will be documented in this file.
 ## [1.24.0] - Not released
 
 * Fixed a bug where an external code action DLL with missing dependencies would crash OmniSharp.
+* When running a test via 'dotnet vstest' support, pass "--no-restore" when building with the .NET CLI to ensure that implicit restore does not run, making build a bit faster. ([#942](https://github.com/OmniSharp/omnisharp-roslyn/issues/942))
+* Add support for specifying the 'TargetFrameworkVersion' to the 'dotnet vstest' endpoints. ([#944](https://github.com/OmniSharp/omnisharp-roslyn/issues/944))
 
 ## [1.23.2] - 2017-08-14
 

--- a/src/OmniSharp.Abstractions/Services/DotNetCliService.cs
+++ b/src/OmniSharp.Abstractions/Services/DotNetCliService.cs
@@ -174,6 +174,15 @@ namespace OmniSharp.Services
         {
             var version = GetVersion(workingDirectory);
 
+            return IsLegacy(version);
+        }
+
+        /// <summary>
+        /// Determines whether the specified version is from a "legacy" .NET CLI.
+        /// If true, this .NET CLI supports project.json development; otherwise, it supports .csproj development.
+        /// </summary>
+        public bool IsLegacy(SemanticVersion version)
+        {
             if (version.Major < 1)
             {
                 return true;

--- a/src/OmniSharp.DotNetTest/DebugSessionManager.cs
+++ b/src/OmniSharp.DotNetTest/DebugSessionManager.cs
@@ -77,11 +77,11 @@ namespace OmniSharp.DotNetTest
             }
         }
 
-        public Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string testFrameworkName, CancellationToken cancellationToken)
+        public Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken)
         {
             VerifySession(isStarted: true);
 
-            return _testManager.DebugGetStartInfoAsync(methodName, testFrameworkName, cancellationToken);
+            return _testManager.DebugGetStartInfoAsync(methodName, testFrameworkName, targetFrameworkVersion, cancellationToken);
         }
 
         public async Task<DebugTestLaunchResponse> DebugLaunchAsync(int targetProcessId)

--- a/src/OmniSharp.DotNetTest/Legacy/LegacyTestManager.cs
+++ b/src/OmniSharp.DotNetTest/Legacy/LegacyTestManager.cs
@@ -52,7 +52,7 @@ namespace OmniSharp.DotNetTest.Legacy
             }
         }
 
-        public override RunTestResponse RunTest(string methodName, string testFrameworkName)
+        public override RunTestResponse RunTest(string methodName, string testFrameworkName, string targetFrameworkVersion)
         {
             var testFramework = TestFramework.GetFramework(testFrameworkName);
             if (testFramework == null)
@@ -143,7 +143,7 @@ namespace OmniSharp.DotNetTest.Legacy
             };
         }
 
-        public override GetTestStartInfoResponse GetTestStartInfo(string methodName, string testFrameworkName)
+        public override GetTestStartInfoResponse GetTestStartInfo(string methodName, string testFrameworkName, string targetFrameworkVersion)
         {
             var testFramework = TestFramework.GetFramework(testFrameworkName);
             if (testFramework == null)
@@ -178,7 +178,7 @@ namespace OmniSharp.DotNetTest.Legacy
             };
         }
 
-        public override Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string testFrameworkName, CancellationToken cancellationToken)
+        public override Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken)
         {
             throw new NotSupportedException();
         }

--- a/src/OmniSharp.DotNetTest/Legacy/LegacyTestManager.cs
+++ b/src/OmniSharp.DotNetTest/Legacy/LegacyTestManager.cs
@@ -9,8 +9,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using NuGet.Versioning;
 using OmniSharp.DotNetTest.Models;
-using OmniSharp.DotNetTest.Models.Events;
 using OmniSharp.DotNetTest.TestFrameworks;
 using OmniSharp.Eventing;
 using OmniSharp.Services;
@@ -29,8 +29,8 @@ namespace OmniSharp.DotNetTest.Legacy
         private const string TestExecution_GetTestRunnerProcessStartInfo = "TestExecution.GetTestRunnerProcessStartInfo";
         private const string TestExecution_TestResult = "TestExecution.TestResult";
 
-        public LegacyTestManager(Project project, string workingDirectory, DotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
-            : base(project, workingDirectory, dotNetCli, eventEmitter, loggerFactory.CreateLogger<LegacyTestManager>())
+        public LegacyTestManager(Project project, string workingDirectory, DotNetCliService dotNetCli, SemanticVersion dotNetCliVersion, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
+            : base(project, workingDirectory, dotNetCli, dotNetCliVersion, eventEmitter, loggerFactory.CreateLogger<LegacyTestManager>())
         {
         }
 

--- a/src/OmniSharp.DotNetTest/Models/DebugTestGetStartInfoRequest.cs
+++ b/src/OmniSharp.DotNetTest/Models/DebugTestGetStartInfoRequest.cs
@@ -8,5 +8,9 @@ namespace OmniSharp.DotNetTest.Models
     {
         public string MethodName { get; set; }
         public string TestFrameworkName { get; set; }
+        /// <summary>
+        /// e.g. .NETCoreApp, Version=2.0
+        /// </summary>
+        public string TargetFrameworkVersion { get; set; }
     }
 }

--- a/src/OmniSharp.DotNetTest/Models/GetTestStartInfoRequest.cs
+++ b/src/OmniSharp.DotNetTest/Models/GetTestStartInfoRequest.cs
@@ -8,5 +8,9 @@ namespace OmniSharp.DotNetTest.Models
     {
         public string MethodName { get; set; }
         public string TestFrameworkName { get; set; }
+        /// <summary>
+        /// e.g. .NETCoreApp, Version=2.0
+        /// </summary>
+        public string TargetFrameworkVersion { get; set; }
     }
 }

--- a/src/OmniSharp.DotNetTest/Models/RunTestRequest.cs
+++ b/src/OmniSharp.DotNetTest/Models/RunTestRequest.cs
@@ -8,5 +8,9 @@ namespace OmniSharp.DotNetTest.Models
     {
         public string MethodName { get; set; }
         public string TestFrameworkName { get; set; }
+        /// <summary>
+        /// e.g. .NETCoreApp, Version=2.0
+        /// </summary>
+        public string TargetFrameworkVersion { get; set; }
     }
 }

--- a/src/OmniSharp.DotNetTest/OmniSharp.DotNetTest.csproj
+++ b/src/OmniSharp.DotNetTest/OmniSharp.DotNetTest.csproj
@@ -22,7 +22,7 @@
 
   <!-- New VSTest 'dotnet test' support -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="15.0.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="15.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/OmniSharp.DotNetTest/Services/DebugTestService.cs
+++ b/src/OmniSharp.DotNetTest/Services/DebugTestService.cs
@@ -33,7 +33,7 @@ namespace OmniSharp.DotNetTest.Services
             var testManager = CreateTestManager(request.FileName);
             _debugSessionManager.StartSession(testManager);
 
-            return _debugSessionManager.DebugGetStartInfoAsync(request.MethodName, request.TestFrameworkName, CancellationToken.None);
+            return _debugSessionManager.DebugGetStartInfoAsync(request.MethodName, request.TestFrameworkName, request.TargetFrameworkVersion, CancellationToken.None);
         }
 
         public Task<DebugTestLaunchResponse> Handle(DebugTestLaunchRequest request)

--- a/src/OmniSharp.DotNetTest/Services/GetTestStartInfoService.cs
+++ b/src/OmniSharp.DotNetTest/Services/GetTestStartInfoService.cs
@@ -19,7 +19,7 @@ namespace OmniSharp.DotNetTest.Services
 
         protected override GetTestStartInfoResponse HandleRequest(GetTestStartInfoRequest request, TestManager testManager)
         {
-            return testManager.GetTestStartInfo(request.MethodName, request.TestFrameworkName);
+            return testManager.GetTestStartInfo(request.MethodName, request.TestFrameworkName, request.TargetFrameworkVersion);
         }
     }
 }

--- a/src/OmniSharp.DotNetTest/Services/RunTestService.cs
+++ b/src/OmniSharp.DotNetTest/Services/RunTestService.cs
@@ -21,7 +21,7 @@ namespace OmniSharp.DotNetTest.Services
         {
             if (testManager.IsConnected)
             {
-                return testManager.RunTest(request.MethodName, request.TestFrameworkName);
+                return testManager.RunTest(request.MethodName, request.TestFrameworkName, request.TargetFrameworkVersion);
             }
 
             var response = new RunTestResponse

--- a/src/OmniSharp.DotNetTest/TestManager.cs
+++ b/src/OmniSharp.DotNetTest/TestManager.cs
@@ -67,10 +67,10 @@ namespace OmniSharp.DotNetTest
         protected abstract string GetCliTestArguments(int port, int parentProcessId);
         protected abstract void VersionCheck();
 
-        public abstract RunTestResponse RunTest(string methodName, string testFrameworkName);
-        public abstract GetTestStartInfoResponse GetTestStartInfo(string methodName, string testFrameworkName);
+        public abstract RunTestResponse RunTest(string methodName, string testFrameworkName, string targetFrameworkVersion);
+        public abstract GetTestStartInfoResponse GetTestStartInfo(string methodName, string testFrameworkName, string targetFrameworkVersion);
 
-        public abstract Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string testFrameworkName, CancellationToken cancellationToken);
+        public abstract Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken);
         public abstract Task DebugLaunchAsync(CancellationToken cancellationToken);
 
         protected virtual bool PrepareToConnect()

--- a/src/OmniSharp.DotNetTest/TestManager.cs
+++ b/src/OmniSharp.DotNetTest/TestManager.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using NuGet.Versioning;
 using OmniSharp.DotNetTest.Legacy;
 using OmniSharp.DotNetTest.Models;
 using OmniSharp.DotNetTest.Models.Events;
@@ -24,6 +25,7 @@ namespace OmniSharp.DotNetTest
     {
         protected readonly Project Project;
         protected readonly DotNetCliService DotNetCli;
+        protected readonly SemanticVersion DotNetCliVersion;
         protected readonly IEventEmitter EventEmitter;
         protected readonly ILogger Logger;
         protected readonly string WorkingDirectory;
@@ -39,11 +41,12 @@ namespace OmniSharp.DotNetTest
 
         public bool IsConnected => _isConnected;
 
-        protected TestManager(Project project, string workingDirectory, DotNetCliService dotNetCli, IEventEmitter eventEmitter, ILogger logger)
+        protected TestManager(Project project, string workingDirectory, DotNetCliService dotNetCli, SemanticVersion dotNetCliVersion, IEventEmitter eventEmitter, ILogger logger)
         {
             Project = project ?? throw new ArgumentNullException(nameof(project));
             WorkingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
             DotNetCli = dotNetCli ?? throw new ArgumentNullException(nameof(dotNetCli));
+            DotNetCliVersion = dotNetCliVersion ?? throw new ArgumentNullException(nameof(dotNetCliVersion));
             EventEmitter = eventEmitter ?? throw new ArgumentNullException(nameof(eventEmitter));
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
@@ -59,9 +62,11 @@ namespace OmniSharp.DotNetTest
         {
             var workingDirectory = Path.GetDirectoryName(project.FilePath);
 
-            return dotNetCli.IsLegacy(workingDirectory)
-                ? new LegacyTestManager(project, workingDirectory, dotNetCli, eventEmitter, loggerFactory)
-                : (TestManager)new VSTestManager(project, workingDirectory, dotNetCli, eventEmitter, loggerFactory);
+            var version = dotNetCli.GetVersion(workingDirectory);
+
+            return dotNetCli.IsLegacy(version)
+                ? new LegacyTestManager(project, workingDirectory, dotNetCli, version, eventEmitter, loggerFactory)
+                : (TestManager)new VSTestManager(project, workingDirectory, dotNetCli, version, eventEmitter, loggerFactory);
         }
 
         protected abstract string GetCliTestArguments(int port, int parentProcessId);

--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -43,7 +43,7 @@ namespace OmniSharp.DotNetTest
 
         protected override string GetCliTestArguments(int port, int parentProcessId)
         {
-            return $"vstest --Port:{port} --ParentProcessId:{parentProcessId} --Diag:Foo.txt";
+            return $"vstest --Port:{port} --ParentProcessId:{parentProcessId}";
         }
 
         protected override void VersionCheck()

--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -229,13 +229,13 @@ namespace OmniSharp.DotNetTest
             }
 
             var results = testResults.Select(testResult =>
-                    new DotNetTestResult
-                    {
-                        MethodName = testResult.TestCase.FullyQualifiedName,
-                        Outcome = testResult.Outcome.ToString().ToLowerInvariant(),
-                        ErrorMessage = testResult.ErrorMessage,
-                        ErrorStackTrace = testResult.ErrorStackTrace
-                    });
+                new DotNetTestResult
+                {
+                    MethodName = testResult.TestCase.FullyQualifiedName,
+                    Outcome = testResult.Outcome.ToString().ToLowerInvariant(),
+                    ErrorMessage = testResult.ErrorMessage,
+                    ErrorStackTrace = testResult.ErrorStackTrace
+                });
 
             return new RunTestResponse
             {

--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -34,7 +34,7 @@ namespace OmniSharp.DotNetTest
 <RunSettings>
     <RunConfiguration>
         <TargetFrameworkVersion>.NETCoreApp, Version=2.0</TargetFrameworkVersion>
-    <RunConfiguration>
+    </RunConfiguration>
 </RunSettings>";
             }
 

--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -33,7 +33,7 @@ namespace OmniSharp.DotNetTest
                 return $@"
 <RunSettings>
     <RunConfiguration>
-        <TargetFrameworkVersion>.NETCoreApp, Version=2.0</TargetFrameworkVersion>
+        <TargetFrameworkVersion>{targetFrameworkVersion}</TargetFrameworkVersion>
     </RunConfiguration>
 </RunSettings>";
             }


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/942 and https://github.com/OmniSharp/omnisharp-roslyn/issues/944

* When running a test via 'dotnet vstest' support, pass "--no-restore" when building with the .NET CLI to ensure that implicit restore does not run, making build a bit faster.
* Add support for specifying the 'TargetFrameworkVersion' to the 'dotnet vstest' endpoints.