### PR TITLE
Do not throw NullReferenceException when trying to "go to definition" on a namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All changes to the project will be documented in this file.
 * Fixed a bug where an external code action DLL with missing dependencies would crash OmniSharp.
 * When running a test via 'dotnet vstest' support, pass "--no-restore" when building with the .NET CLI to ensure that implicit restore does not run, making build a bit faster. ([#942](https://github.com/OmniSharp/omnisharp-roslyn/issues/942))
 * Add support for specifying the 'TargetFrameworkVersion' to the 'dotnet vstest' endpoints. ([#944](https://github.com/OmniSharp/omnisharp-roslyn/issues/944))
+* Do not throw an exception when attempting to "go to definition" on a namespace
 
 ## [1.23.2] - 2017-08-14
 

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionService.cs
@@ -44,7 +44,8 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                 var position = sourceText.Lines.GetPosition(new LinePosition(request.Line, request.Column));
                 var symbol = await SymbolFinder.FindSymbolAtPositionAsync(semanticModel, position, _workspace);
 
-                if (symbol != null)
+                // go to definition for namespaces is not supported
+                if (symbol != null && !(symbol is INamespaceSymbol))
                 {
                     // for partial methods, pick the one with body
                     if (symbol is IMethodSymbol method)

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
@@ -232,6 +232,14 @@ class Bar {
             }
         }
 
+        [Fact]
+        public async Task ReturnsNoResultsButDoesNotThrowForNamespaces()
+        {
+            var testFile = new TestFile("foo.cs", "namespace F$$oo {}");
+            var response = await GetResponseAsync(new[] { testFile }, wantMetadata: false);
+            Assert.Null(response.FileName);
+        }
+
         private async Task TestGoToSourceAsync(params TestFile[] testFiles)
         {
             var response = await GetResponseAsync(testFiles, wantMetadata: false);


### PR DESCRIPTION
At the moment, when you try to go to definition on a namespace, we throw a NullReferenceException. 
OmniSharp doesn't crash but a nasty exception shows up in the logs.