### PR TITLE
Restore request/response logging in STDIO

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Helpers/DiagnosticExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/DiagnosticExtensions.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.CodeAnalysis;
+using OmniSharp.Models.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace OmniSharp.Helpers
+{
+    internal static class DiagnosticExtensions
+    {
+        internal static DiagnosticLocation ToDiagnosticLocation(this Diagnostic diagnostic)
+        {
+            var span = diagnostic.Location.GetMappedLineSpan();
+            return new DiagnosticLocation
+            {
+                FileName = span.Path,
+                Line = span.StartLinePosition.Line,
+                Column = span.StartLinePosition.Character,
+                EndLine = span.EndLinePosition.Line,
+                EndColumn = span.EndLinePosition.Character,
+                Text = diagnostic.GetMessage(),
+                LogLevel = diagnostic.Severity.ToString()
+            };
+        }
+
+        internal static async Task<IEnumerable<DiagnosticLocation>> FindDiagnosticLocationsAsync(this IEnumerable<Document> documents)
+        {
+            var items = new List<DiagnosticLocation>();
+
+            if (documents.Any())
+            {
+                foreach (var document in documents)
+                {
+                    var semanticModel = await document.GetSemanticModelAsync();
+                    IEnumerable<Diagnostic> diagnostics = semanticModel.GetDiagnostics();
+
+                    foreach (var quickFix in diagnostics.Select(d => d.ToDiagnosticLocation()))
+                    {
+                        var existingQuickFix = items.FirstOrDefault(q => q.Equals(quickFix));
+                        if (existingQuickFix == null)
+                        {
+                            quickFix.Projects.Add(document.Project.Name);
+                            items.Add(quickFix);
+                        }
+                        else
+                        {
+                            existingQuickFix.Projects.Add(document.Project.Name);
+                        }
+                    }
+                }
+            }
+
+            return items;
+        }
+    }
+}

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/DiagnosticExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/DiagnosticExtensions.cs
@@ -25,27 +25,25 @@ namespace OmniSharp.Helpers
 
         internal static async Task<IEnumerable<DiagnosticLocation>> FindDiagnosticLocationsAsync(this IEnumerable<Document> documents)
         {
+            if (documents == null || !documents.Any()) return Enumerable.Empty<DiagnosticLocation>();
+
             var items = new List<DiagnosticLocation>();
-
-            if (documents.Any())
+            foreach (var document in documents)
             {
-                foreach (var document in documents)
-                {
-                    var semanticModel = await document.GetSemanticModelAsync();
-                    IEnumerable<Diagnostic> diagnostics = semanticModel.GetDiagnostics();
+                var semanticModel = await document.GetSemanticModelAsync();
+                IEnumerable<Diagnostic> diagnostics = semanticModel.GetDiagnostics();
 
-                    foreach (var quickFix in diagnostics.Select(d => d.ToDiagnosticLocation()))
+                foreach (var quickFix in diagnostics.Select(d => d.ToDiagnosticLocation()))
+                {
+                    var existingQuickFix = items.FirstOrDefault(q => q.Equals(quickFix));
+                    if (existingQuickFix == null)
                     {
-                        var existingQuickFix = items.FirstOrDefault(q => q.Equals(quickFix));
-                        if (existingQuickFix == null)
-                        {
-                            quickFix.Projects.Add(document.Project.Name);
-                            items.Add(quickFix);
-                        }
-                        else
-                        {
-                            existingQuickFix.Projects.Add(document.Project.Name);
-                        }
+                        quickFix.Projects.Add(document.Project.Name);
+                        items.Add(quickFix);
+                    }
+                    else
+                    {
+                        existingQuickFix.Projects.Add(document.Project.Name);
                     }
                 }
             }

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/QuickFixExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/QuickFixExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using OmniSharp.Models;
 

--- a/src/OmniSharp.Roslyn.CSharp/Services/Diagnostics/CodeCheckService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Diagnostics/CodeCheckService.cs
@@ -3,10 +3,10 @@ using System.Composition;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using OmniSharp.Helpers;
 using OmniSharp.Mef;
 using OmniSharp.Models;
 using OmniSharp.Models.CodeCheck;
-using OmniSharp.Models.Diagnostics;
 
 namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
 {
@@ -23,48 +23,12 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
 
         public async Task<QuickFixResponse> Handle(CodeCheckRequest request)
         {
-            var quickFixes = new List<QuickFix>();
-
             var documents = request.FileName != null
                 ? _workspace.GetDocuments(request.FileName)
                 : _workspace.CurrentSolution.Projects.SelectMany(project => project.Documents);
 
-            foreach (var document in documents)
-            {
-                var semanticModel = await document.GetSemanticModelAsync();
-                IEnumerable<Diagnostic> diagnostics = semanticModel.GetDiagnostics();
-
-                foreach (var quickFix in diagnostics.Select(MakeQuickFix))
-                {
-                    var existingQuickFix = quickFixes.FirstOrDefault(q => q.Equals(quickFix));
-                    if (existingQuickFix == null)
-                    {
-                        quickFix.Projects.Add(document.Project.Name);
-                        quickFixes.Add(quickFix);
-                    }
-                    else
-                    {
-                        existingQuickFix.Projects.Add(document.Project.Name);
-                    }
-                }
-            }
-
+            var quickFixes = await documents.FindDiagnosticLocationsAsync();
             return new QuickFixResponse(quickFixes);
-        }
-
-        private static QuickFix MakeQuickFix(Diagnostic diagnostic)
-        {
-            var span = diagnostic.Location.GetMappedLineSpan();
-            return new DiagnosticLocation
-            {
-                FileName = span.Path,
-                Line = span.StartLinePosition.Line,
-                Column = span.StartLinePosition.Character,
-                EndLine = span.EndLinePosition.Line,
-                EndColumn = span.EndLinePosition.Character,
-                Text = diagnostic.GetMessage(),
-                LogLevel = diagnostic.Severity.ToString()
-            };
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
+using OmniSharp.Helpers;
 using OmniSharp.Models.Diagnostics;
 using OmniSharp.Roslyn;
 
@@ -139,50 +140,12 @@ namespace OmniSharp.Workers.Diagnostics
         private async Task<DiagnosticResult> ProcessNextItem(string filePath)
         {
             var documents = _workspace.GetDocuments(filePath);
-            var items = new List<DiagnosticLocation>();
-
-            if (documents.Any())
-            {
-                foreach (var document in documents)
-                {
-                    var semanticModel = await document.GetSemanticModelAsync();
-                    IEnumerable<Diagnostic> diagnostics = semanticModel.GetDiagnostics();
-
-                    foreach (var quickFix in diagnostics.Select(MakeQuickFix))
-                    {
-                        var existingQuickFix = items.FirstOrDefault(q => q.Equals(quickFix));
-                        if (existingQuickFix == null)
-                        {
-                            quickFix.Projects.Add(document.Project.Name);
-                            items.Add(quickFix);
-                        }
-                        else
-                        {
-                            existingQuickFix.Projects.Add(document.Project.Name);
-                        }
-                    }
-                }
-            }
+            var items = await documents.FindDiagnosticLocationsAsync();
 
             return new DiagnosticResult()
             {
                 FileName = filePath,
                 QuickFixes = items
-            };
-        }
-
-        private static DiagnosticLocation MakeQuickFix(Diagnostic diagnostic)
-        {
-            var span = diagnostic.Location.GetMappedLineSpan();
-            return new DiagnosticLocation
-            {
-                FileName = span.Path,
-                Line = span.StartLinePosition.Line,
-                Column = span.StartLinePosition.Character,
-                EndLine = span.EndLinePosition.Line,
-                EndColumn = span.EndLinePosition.Character,
-                Text = diagnostic.GetMessage(),
-                LogLevel = diagnostic.Severity.ToString()
             };
         }
     }


### PR DESCRIPTION
With the merge of #854 we overlooked the fact that we lost request/response logging when running over STDIO. That logic was handled by `LoggingMiddleware` which is now part of the HTTP host. This PR restores the old functionality of logging of request/response packets for log levels debug and lower (this is what shows up i.e. in "omnisharp log" panel in VS Code). This is quite useful for debugging what is going on.

As a bonus, I removed some code duplication between `CodeCheckService` and `CSharpDiagnosticService`