### PR TITLE
Use latest Mono rather than beta in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 env:
   global:
     secure: m2PtYwYOhaK0uFMZ19ZxApZwWZeAIq1dS//jx/5I3txpIWD+TfycQMAWYxycFJ/GJkeVF29P4Zz1uyS2XKKjPJpp2Pds98FNQyDv3OftpLAVa0drsjfhurVlBmSdrV7GH6ncKfvhd+h7KVK5vbZc+NeR4dH7eNvN/jraS//AMJg=
-mono: beta
+mono: latest
 dotnet: 1.0.4
 os:
   - linux


### PR DESCRIPTION
It's not necessary to use the Mono beta channel in Travis any longer since the latest stable release has all of the changes we depend on.