### PR TITLE
Use MSBuild SDK Resolvers

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,6 +4,6 @@
         <clear />
         <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
         <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-        <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
+        <add key="dotnet-cli" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     </packageSources>
 </configuration>

--- a/build.cake
+++ b/build.cake
@@ -218,7 +218,7 @@ Task("InstallMonoAssets")
     Run("chmod", $"+x '{CombinePaths(env.Folders.Mono, "run")}'");
 });
 
-void CopyDotNetHostResolver(string os, string arch, string hostFileName, string targetFolderBase)
+void CopyDotNetHostResolver(BuildEnvironment env, string os, string arch, string hostFileName, string targetFolderBase)
 {
     var source = CombinePaths(
         env.Folders.Tools,
@@ -271,16 +271,16 @@ Task("CreateMSBuildFolder")
 
     if (Platform.Current.IsWindows)
     {
-        CopyDotNetHostResolver("win", "x86", "hostfxr.dll", msbuildSdkResolverFolder);
-        CopyDotNetHostResolver("win", "x64", "hostfxr.dll", msbuildSdkResolverFolder);
+        CopyDotNetHostResolver(env, "win", "x86", "hostfxr.dll", msbuildSdkResolverFolder);
+        CopyDotNetHostResolver(env, "win", "x64", "hostfxr.dll", msbuildSdkResolverFolder);
     }
     else if (Platform.Current.IsMacOS)
     {
-        CopyDotNetHostResolver("osx", "x64", "libhostfxr.dylib", msbuildSdkResolverFolder);
+        CopyDotNetHostResolver(env, "osx", "x64", "libhostfxr.dylib", msbuildSdkResolverFolder);
     }
     else if (Platform.Current.IsLinux)
     {
-        CopyDotNetHostResolver("linux", "x64", "libhostfxr.so", msbuildSdkResolverFolder);
+        CopyDotNetHostResolver(env, "linux", "x64", "libhostfxr.so", msbuildSdkResolverFolder);
     }
 
     // Copy content of Microsoft.Net.Compilers

--- a/build.cake
+++ b/build.cake
@@ -218,7 +218,7 @@ Task("InstallMonoAssets")
     Run("chmod", $"+x '{CombinePaths(env.Folders.Mono, "run")}'");
 });
 
-void CopyDotNetHostResolver(BuildEnvironment env, string os, string arch, string hostFileName, string targetFolderBase)
+void CopyDotNetHostResolver(BuildEnvironment env, string os, string arch, string hostFileName, string targetFolderBase, bool copyToArchSpecificFolder)
 {
     var source = CombinePaths(
         env.Folders.Tools,
@@ -228,9 +228,13 @@ void CopyDotNetHostResolver(BuildEnvironment env, string os, string arch, string
         "native",
         hostFileName);
 
-    var targetFolder = CombinePaths(targetFolderBase, arch);
+    var targetFolder = targetFolderBase;
 
-    DirectoryHelper.ForceCreate(targetFolder);
+    if (copyToArchSpecificFolder)
+    {
+        targetFolder = CombinePaths(targetFolderBase, arch);
+        DirectoryHelper.ForceCreate(targetFolder);
+    }
 
     FileHelper.Copy(source, CombinePaths(targetFolder, hostFileName));
 }
@@ -271,16 +275,16 @@ Task("CreateMSBuildFolder")
 
     if (Platform.Current.IsWindows)
     {
-        CopyDotNetHostResolver(env, "win", "x86", "hostfxr.dll", msbuildSdkResolverFolder);
-        CopyDotNetHostResolver(env, "win", "x64", "hostfxr.dll", msbuildSdkResolverFolder);
+        CopyDotNetHostResolver(env, "win", "x86", "hostfxr.dll", msbuildSdkResolverFolder, copyToArchSpecificFolder: true);
+        CopyDotNetHostResolver(env, "win", "x64", "hostfxr.dll", msbuildSdkResolverFolder, copyToArchSpecificFolder: true);
     }
     else if (Platform.Current.IsMacOS)
     {
-        CopyDotNetHostResolver(env, "osx", "x64", "libhostfxr.dylib", msbuildSdkResolverFolder);
+        CopyDotNetHostResolver(env, "osx", "x64", "libhostfxr.dylib", msbuildSdkResolverFolder, copyToArchSpecificFolder: false);
     }
     else if (Platform.Current.IsLinux)
     {
-        CopyDotNetHostResolver(env, "linux", "x64", "libhostfxr.so", msbuildSdkResolverFolder);
+        CopyDotNetHostResolver(env, "linux", "x64", "libhostfxr.so", msbuildSdkResolverFolder, copyToArchSpecificFolder: false);
     }
 
     // Copy content of Microsoft.Net.Compilers

--- a/build.json
+++ b/build.json
@@ -5,12 +5,12 @@
   "LegacyDotNetVersion": "1.0.0-preview2-1-003177",
   "RequiredMonoVersion": "5.2.0.196",
   "DownloadURL": "https://omnisharpdownload.blob.core.windows.net/ext",
-  "MonoRuntimeMacOS": "mono.osx-5.2.0.213.zip",
-  "MonoRuntimeLinux32": "mono.linux-x86-5.2.0.213.zip",
-  "MonoRuntimeLinux64": "mono.linux-x86_64-5.2.0.213.zip",
-  "MonoFramework": "framework-5.2.0.213.zip",
-  "MonoMSBuildRuntime": "Microsoft.Build.Runtime.Mono-alpha5.zip",
-  "MonoMSBuildLib": "Microsoft.Build.Lib.Mono-alpha5.zip",
+  "MonoRuntimeMacOS": "mono.osx-5.2.0.215.zip",
+  "MonoRuntimeLinux32": "mono.linux-x86-5.2.0.215.zip",
+  "MonoRuntimeLinux64": "mono.linux-x86_64-5.2.0.215.zip",
+  "MonoFramework": "framework-5.2.0.215.zip",
+  "MonoMSBuildRuntime": "Microsoft.Build.Runtime.Mono-alpha6.zip",
+  "MonoMSBuildLib": "Microsoft.Build.Lib.Mono-alpha6.zip",
   "HostProjects": [
     "OmniSharp.Stdio",
     "OmniSharp.Http"

--- a/src/OmniSharp.MSBuild/AssemblyInfo.cs
+++ b/src/OmniSharp.MSBuild/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("OmniSharp.MSBuild.Tests")]
+[assembly: InternalsVisibleTo("TestUtility")]

--- a/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
+++ b/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
@@ -149,7 +149,7 @@ namespace OmniSharp.MSBuild
                 throw new InvalidOperationException("MSBuild environment is already initialized.");
             }
 
-            if (TryWithLocalMSBuild())
+            if (TryWithLocalMSBuild(allowMonoPaths: false))
             {
                 s_kind = MSBuildEnvironmentKind.StandAlone;
                 s_isInitialized = true;
@@ -329,7 +329,7 @@ namespace OmniSharp.MSBuild
             return false;
         }
 
-        private static bool TryWithLocalMSBuild()
+        private static bool TryWithLocalMSBuild(bool allowMonoPaths = true)
         {
             var msbuildDirectory = FindMSBuildDirectory();
             if (msbuildDirectory == null)
@@ -346,12 +346,14 @@ namespace OmniSharp.MSBuild
 
             SetMSBuildExePath(msbuildExePath);
 
-            if (!TrySetMSBuildExtensionsPathToXBuild())
+            s_msbuildExtensionsPath = msbuildDirectory;
+
+            if (allowMonoPaths)
             {
-                s_msbuildExtensionsPath = msbuildDirectory;
+                TrySetMSBuildExtensionsPathToXBuild();
+                TrySetTargetFrameworkRootPathToXBuildFrameworks();
             }
 
-            TrySetTargetFrameworkRootPathToXBuildFrameworks();
             TrySetRoslynTargetsPathAndCscTool();
 
             return true;

--- a/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
+++ b/src/OmniSharp.MSBuild/MSBuildEnvironment.cs
@@ -137,6 +137,40 @@ namespace OmniSharp.MSBuild
                 return;
             }
 
+            LogSummary(logger);
+        }
+
+        internal static void InitializeForTest(ILogger logger)
+        {
+            // For tests, we only initialize in standalone mode.
+
+            if (s_isInitialized)
+            {
+                throw new InvalidOperationException("MSBuild environment is already initialized.");
+            }
+
+            if (TryWithLocalMSBuild())
+            {
+                s_kind = MSBuildEnvironmentKind.StandAlone;
+                s_isInitialized = true;
+            }
+            else
+            {
+                s_kind = MSBuildEnvironmentKind.Unknown;
+                logger.LogError("MSBuild environment could not be initialized.");
+                s_isInitialized = false;
+            }
+
+            if (!s_isInitialized)
+            {
+                return;
+            }
+
+            LogSummary(logger);
+        }
+
+        private static void LogSummary(ILogger logger)
+        {
             var summary = new StringBuilder();
             switch (s_kind)
             {

--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -306,22 +306,6 @@ namespace OmniSharp.MSBuild
             return result.FilePath;
         }
 
-        private string GetSdksPath(string projectFilePath)
-        {
-            var info = _dotNetCli.GetInfo(Path.GetDirectoryName(projectFilePath));
-
-            if (info.IsEmpty || string.IsNullOrWhiteSpace(info.BasePath))
-            {
-                return null;
-            }
-
-            var result = Path.Combine(info.BasePath, "Sdks");
-
-            return Directory.Exists(result)
-                ? result
-                : null;
-        }
-
         private ProjectFileInfo LoadProject(string projectFilePath)
         {
             _logger.LogInformation($"Loading project: {projectFilePath}");
@@ -331,7 +315,7 @@ namespace OmniSharp.MSBuild
 
             try
             {
-                project = ProjectFileInfo.Create(projectFilePath, _environment.TargetDirectory, GetSdksPath(projectFilePath), _loggerFactory.CreateLogger<ProjectFileInfo>(), _options, diagnostics);
+                project = ProjectFileInfo.Create(projectFilePath, _environment.TargetDirectory, _loggerFactory.CreateLogger<ProjectFileInfo>(), _options, diagnostics);
 
                 if (project == null)
                 {
@@ -357,7 +341,7 @@ namespace OmniSharp.MSBuild
                 if (_projects.TryGetValue(projectFilePath, out var oldProjectFileInfo))
                 {
                     var diagnostics = new List<MSBuildDiagnosticsMessage>();
-                    var newProjectFileInfo = oldProjectFileInfo.Reload(_environment.TargetDirectory, GetSdksPath(projectFilePath), _loggerFactory.CreateLogger<ProjectFileInfo>(), _options, diagnostics);
+                    var newProjectFileInfo = oldProjectFileInfo.Reload(_environment.TargetDirectory, _loggerFactory.CreateLogger<ProjectFileInfo>(), _options, diagnostics);
 
                     if (newProjectFileInfo != null)
                     {

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -20,19 +20,6 @@ namespace OmniSharp.MSBuild.Tests
         {
             this._testAssets = TestAssets.Instance;
             this._logger = this.LoggerFactory.CreateLogger<ProjectFileInfoTests>();
-
-            if (!MSBuildEnvironment.IsInitialized)
-            {
-                MSBuildEnvironment.Initialize(this._logger);
-            }
-        }
-
-        private static string GetSdksPath(OmniSharpTestHost host)
-        {
-            var dotNetCli = host.GetExport<DotNetCliService>();
-            var info = dotNetCli.GetInfo();
-
-            return Path.Combine(info.BasePath, "Sdks");
         }
 
         [Fact]
@@ -43,7 +30,7 @@ namespace OmniSharp.MSBuild.Tests
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "HelloWorld.csproj");
 
-                var projectFileInfo = ProjectFileInfo.Create(projectFilePath, testProject.Directory, GetSdksPath(host), this._logger);
+                var projectFileInfo = ProjectFileInfo.Create(projectFilePath, testProject.Directory, this._logger);
 
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
@@ -63,7 +50,7 @@ namespace OmniSharp.MSBuild.Tests
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "HelloWorldSlim.csproj");
 
-                var projectFileInfo = ProjectFileInfo.Create(projectFilePath, testProject.Directory, GetSdksPath(host), this._logger);
+                var projectFileInfo = ProjectFileInfo.Create(projectFilePath, testProject.Directory, this._logger);
 
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
@@ -82,7 +69,7 @@ namespace OmniSharp.MSBuild.Tests
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "NetStandardAndNetCoreApp.csproj");
 
-                var projectFileInfo = ProjectFileInfo.Create(projectFilePath, testProject.Directory, GetSdksPath(host), this._logger);
+                var projectFileInfo = ProjectFileInfo.Create(projectFilePath, testProject.Directory, this._logger);
 
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -7,14 +7,12 @@ using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using OmniSharp;
 using OmniSharp.DotNet;
 using OmniSharp.DotNetTest.Models;
 using OmniSharp.Eventing;
 using OmniSharp.Mef;
 using OmniSharp.MSBuild;
-using OmniSharp.Options;
 using OmniSharp.Roslyn.CSharp.Services;
 using OmniSharp.Services;
 using OmniSharp.Utilities;
@@ -25,10 +23,12 @@ namespace TestUtility
 {
     public class OmniSharpTestHost : DisposableObject
     {
+        private const string MSBuildSDKsPath = "MSBuildSDKsPath";
+
         private static Lazy<Assembly[]> s_lazyAssemblies = new Lazy<Assembly[]>(() => new[]
         {
             typeof(OmniSharpEndpoints).GetTypeInfo().Assembly, // OmniSharp.Abstractions
-            typeof(OmniSharp.HostHelpers).GetTypeInfo().Assembly, // OmniSharp.Host
+            typeof(HostHelpers).GetTypeInfo().Assembly, // OmniSharp.Host
             typeof(DotNetProjectSystem).GetTypeInfo().Assembly, // OmniSharp.DotNet
             typeof(RunTestRequest).GetTypeInfo().Assembly, // OmniSharp.DotNetTest
             typeof(MSBuildProjectSystem).GetTypeInfo().Assembly, // OmniSharp.MSBuild
@@ -38,6 +38,7 @@ namespace TestUtility
 
         private readonly TestServiceProvider _serviceProvider;
         private readonly CompositionHost _compositionHost;
+        private readonly string _oldMSBuildSdksPath;
 
         private Dictionary<(string name, string language), Lazy<IRequestHandler, OmniSharpRequestHandlerMetadata>> _handlers;
 
@@ -55,6 +56,21 @@ namespace TestUtility
 
             this.LoggerFactory = loggerFactory;
             this.Workspace = workspace;
+
+            _oldMSBuildSdksPath = Environment.GetEnvironmentVariable(MSBuildSDKsPath);
+            SetMSBuildSdksPath(compositionHost);
+        }
+
+        private static void SetMSBuildSdksPath(CompositionHost compositionHost)
+        {
+            var dotNetCli = compositionHost.GetExport<DotNetCliService>();
+            var info = dotNetCli.GetInfo();
+            var msbuildSdksPath = Path.Combine(info.BasePath, "Sdks");
+
+            if (Directory.Exists(msbuildSdksPath))
+            {
+                Environment.SetEnvironmentVariable(MSBuildSDKsPath, msbuildSdksPath);
+            }
         }
 
         ~OmniSharpTestHost()
@@ -64,6 +80,8 @@ namespace TestUtility
 
         protected override void DisposeCore(bool disposing)
         {
+            Environment.SetEnvironmentVariable(MSBuildSDKsPath, _oldMSBuildSdksPath);
+
             this._serviceProvider.Dispose();
             this._compositionHost.Dispose();
 
@@ -99,7 +117,7 @@ namespace TestUtility
                 throw new InvalidOperationException($"Local .NET CLI path does not exist. Did you run build.(ps1|sh) from the command line?");
             }
 
-             var builder = new Microsoft.Extensions.Configuration.ConfigurationBuilder();
+            var builder = new Microsoft.Extensions.Configuration.ConfigurationBuilder();
             builder.AddInMemoryCollection(configurationData);
             var configuration = builder.Build();
 
@@ -108,6 +126,11 @@ namespace TestUtility
             var sharedTextWriter = new TestSharedTextWriter(testOutput);
 
             var serviceProvider = new TestServiceProvider(environment, loggerFactory, sharedTextWriter, configuration);
+
+            if (!MSBuildEnvironment.IsInitialized)
+            {
+                MSBuildEnvironment.InitializeForTest(loggerFactory.CreateLogger<OmniSharpTestHost>());
+            }
 
             var compositionHost = new CompositionHostBuilder(serviceProvider, environment, sharedTextWriter, NullEventEmitter.Instance)
                 .WithAssemblies(s_lazyAssemblies.Value)

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -3,5 +3,10 @@
     <package id="Cake" version="0.19.5" />
     <package id="Microsoft.Build.Runtime" version="15.3.0-preview-000388-01" />
     <package id="Microsoft.Net.Compilers" version="2.3.1" />
+    <package id="Microsoft.DotNet.MSBuildSdkResolver" version="15.5.0-preview-007006" />
+    <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="2.0.0" />
+    <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="2.0.0" />
+    <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="2.0.0" />
+    <package id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" version="2.0.0" />
     <package id="xunit.runner.console" version="2.3.0-rc1-build3809" />
 </packages>


### PR DESCRIPTION
Currently, we launch `dotnet --info` for every MSBuild project. This allows us to detect the .NET Core SDK that is used for that project without having to replicate a lot of code to search for a `global.json`, or look in various places. Once we've have the output of `dotnet --info`, we look for the "Base Path" property and use that to decide where the location of the "Sdks" are within the relevant .NET Core SDK's directory. Once we've got that, we set the `MSBuildSDKsPath` environment variable to tell MSBuild where the SDKs are before we load the project.

This approach has several problems:

1. Setting an environment variable is fragile! It means that we can't load MSBuild projects in parallel because the projects might target a different .NET Core SDK. Also, another process (even another OmniSharp process) could change or unset it.
2. Parsing `dotnet --info` is fragile! The .NET Core SDK's informational output is subject to change, and there are proposals to do it.

To avoid this problem, OmniSharp will deploy the same "SDK Resolvers" that are deployed with Visual Studio. This is a bit of code that knows how to resolve a project to the correct .NET Core SDK. In fact, it uses the same native binary that "dotnet" does to find the SDK. Once present, MSBuild uses the resolver to locate the .NET Core SDK for any project that contains an `Sdk` attribute.

For tests, we still set the `MSBuildSDKsPath` environment variable so that we can use the .NET Core SDKs that the OmniSharp build scripts install locally during our test runs. We *could* write our own SDK Resolver to resolve our local .NET Core SDKs during testing, but that's probably overkill. If it becomes an issue, we can look into that.