### PR TITLE
Fix build on CentOS 7

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -18,7 +18,7 @@ brew install caskroom/cask/mono-mdk
 
 Because OmniSharp uses the .NET Core SDK as part of the build, not all Linux distros are supported. A good rule of thumb is to check the list [here](https://www.microsoft.com/net/download/linux) to see if your particular distro is supported.
 
-**Mono 5.2.0** or greater is required. Each distro or derivative has it's own set of instructions for installing Mono which you can find [here](http://www.mono-project.com/download/#download-lin).
+**Mono 5.2.0** or greater is required. Each distro or derivative has it's own set of instructions for installing Mono which you can find [here](http://www.mono-project.com/download/#download-lin). Be sure to install `msbuild` as well, which may be a separate package.
 
 # Usage
 

--- a/build.cake
+++ b/build.cake
@@ -54,11 +54,11 @@ bool AllowLegacyTests()
         switch (platform.DistroName)
         {
             case "alpine":   return version == "3.4.3";
-            case "centos":   return version == "7";
-            case "debian":   return version == "8";
+            case "centos":   return version == "7.0";
+            case "debian":   return version == "8.0";
             case "fedora":   return version == "23" || version == "24";
             case "opensuse": return version == "13.2" || version == "42.1";
-            case "rhel":     return version == "7";
+            case "rhel":     return version == "7.0";
             case "ubuntu":   return version == "14.4" || version == "16.4" || version == "16.10";
         }
     }

--- a/scripts/platform.cake
+++ b/scripts/platform.cake
@@ -114,6 +114,11 @@ public sealed class Platform
                 }
                 else if (key == "VERSION_ID")
                 {
+                    // Normalize any versions to include a Major and Minor version
+                    if (!value.Contains("."))
+                    {
+                        value = value + ".0";
+                    }
                     version = new Version(value);
                 }
                 


### PR DESCRIPTION
This fixes two issues building Omnisharp on CentOS 7:

System.Version needs a major and minor version or it refuses to parse it. For Linux distributions with a single major-only version in /etc/os-release, add a ".0" suffix to the version.

Add a documentation note about `msbuild` being a dependency as well since it is sometimes not included with the default mono installation.