### PR TITLE
Add any installed SDKs to PATH

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -161,6 +161,12 @@ Task("InstallDotNetCoreSdk")
                 installFolder: env.Folders.DotNetSdk,
                 sharedRuntime: true);
         }
+
+        // Add non-legacy .NET SDK to PATH
+        var oldPath = Environment.GetEnvironmentVariable("PATH");
+        var newPath = env.Folders.DotNetSdk + (string.IsNullOrEmpty(oldPath) ? "" : System.IO.Path.PathSeparator + oldPath);
+        Environment.SetEnvironmentVariable("PATH", newPath);
+        Information("PATH: {0}", Environment.GetEnvironmentVariable("PATH"));
     }
 
     if (AllowLegacyTests())


### PR DESCRIPTION
Without this, we get warnings about msbuild not finding the desired SDK that we just installed because `dotnet` was not added to PATH.

See https://github.com/OmniSharp/omnisharp-roslyn/issues/984