### PR TITLE
Consider subset match valid for symbol lookups and completions

### DIFF
--- a/src/OmniSharp.Roslyn/Extensions/StringExtensions.cs
+++ b/src/OmniSharp.Roslyn/Extensions/StringExtensions.cs
@@ -31,6 +31,11 @@ namespace OmniSharp.Extensions
                 return true;
             }
 
+            if (completion.ToLowerInvariant().Contains(partial.ToLowerInvariant()))
+            {
+                return true;
+            }
+
             // Limit the number of results returned by making sure
             // at least the first characters match.
             // We can get far too many results back otherwise.

--- a/src/OmniSharp.Roslyn/Extensions/StringExtensions.cs
+++ b/src/OmniSharp.Roslyn/Extensions/StringExtensions.cs
@@ -31,7 +31,7 @@ namespace OmniSharp.Extensions
                 return true;
             }
 
-            if (completion.ToLowerInvariant().Contains(partial.ToLowerInvariant()))
+            if (partial.Length > 1 && completion.ToLowerInvariant().Contains(partial.ToLowerInvariant()))
             {
                 return true;
             }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindSymbolsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindSymbolsFacts.cs
@@ -221,11 +221,38 @@ public partial class MyClass
             var expected = new[]
             {
                 "Method()",
-                "Method(string param)"
+                "Method(string param)",
+                "NestedMethod()"
             };
 
             Assert.Equal(expected, symbols);
         }
+
+        [Fact]
+        public async Task Can_find_symbols_using_filter_with_subset_match()
+        {
+            const string code = @"
+                namespace Some.Long.Namespace
+                {
+                    public class Options {}
+                    public class Opossum {}
+                    public interface IConfigurationOptions { }
+                    public class ConfigurationOptions : IConfigurationOptions { }
+                }";
+
+            var usages = await FindSymbolsWithFilterAsync(code, "opti");
+            var symbols = usages.QuickFixes.Select(q => q.Text);
+
+            var expected = new[]
+            {
+                "Options",
+                "IConfigurationOptions",
+                "ConfigurationOptions"
+            };
+
+            Assert.Equal(expected, symbols);
+        }
+
 
         private async Task<QuickFixResponse> FindSymbolsAsync(string code)
         {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -132,6 +132,23 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         [Theory]
         [InlineData("dummy.cs")]
         [InlineData("dummy.csx")]
+        public async Task Returns_sub_sequence_completions_without_matching_firstletter(string filename)
+        {
+            const string input =
+                @"public class Class1 {
+                    public Class1()
+                        {
+                            System.Guid.gu$$
+                        }
+                    }";
+            
+            var completions = await FindCompletionsAsync(filename, input);
+            ContainsCompletions(completions.Select(c => c.CompletionText).Take(1), "NewGuid");
+        }
+
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
         public async Task Returns_method_header(string filename)
         {
             const string input =


### PR DESCRIPTION
Given the following code:

```
    public class Options { }
    public interface IConfigurationOptions { }
    public class ConfigurationOptions : IConfigurationOptions { }
```

When passing `Opt` into symbol lookup or completion service, we will only return `Options`, which is not the optimal user experience.
In fact, this is not in line with the Visual Studio behavior, where in both symbol lookup and completion, `opt` returns all 3 possibilities.

This PR changes a subset match of length longer than 1 to be valid when verifying symbol/completion subsequences, resulting in much better experience.