### PR TITLE
Force LF EOL for sh scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -49,3 +49,5 @@
 *.dbproj text=auto
 *.xproj text=auto
 *.sln text=auto eol=crlf
+
+*.sh text eol=lf


### PR DESCRIPTION
Related to #989, this forces `LF` to be used as the EOL character on `.sh` scripts, if the contributor was using `autocrlf = true` in his `.gitconfig` when cloning the project, it would cause the errors mentioned in the issue.

Having this info in `.gitattributes` will force the correct EOL character on checkin and checkout.