### PR TITLE
disable VisualStudioInstanceProvider on mono

### DIFF
--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/VisualStudioInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/VisualStudioInstanceProvider.cs
@@ -17,7 +17,7 @@ namespace OmniSharp.MSBuild.Discovery.Providers
 
         public override ImmutableArray<MSBuildInstance> GetInstances()
         {
-            if (!PlatformHelper.IsWindows)
+            if (PlatformHelper.IsMono)
             {
                 return NoInstances;
             }


### PR DESCRIPTION
Since #998 I've been getting:

```
System.PlatformNotSupportedException: Operation is not supported on this platform.
  at OmniSharp.MSBuild.Discovery.Interop.GetSetupConfiguration () [0x0000a] in <fc86425b83fa4820a94c3447774fdb30>:0
  at OmniSharp.MSBuild.Discovery.Providers.VisualStudioInstanceProvider.GetInstances () [0x0000e] in <fc86425b83fa4820a94c3447774fdb30>:0
  at OmniSharp.MSBuild.Discovery.MSBuildLocator.GetInstances () [0x0001e] in <fc86425b83fa4820a94c3447774fdb30>:0
  at OmniSharp.CompositionHostBuilder.Build () [0x00053] in <fc86425b83fa4820a94c3447774fdb30>:0
  at OmniSharp.Stdio.Host..ctor (System.IO.TextReader input, OmniSharp.Stdio.Services.ISharedTextWriter writer, OmniSharp.IOmniSharpEnvironment environment, Microsoft.Extensions.Configuration.IConfiguration configuration, System.IServiceProvider serviceProvider, OmniSharp.CompositionHostBuilder compositionHostBuilder, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, System.Threading.CancellationTokenSource cancellationTokenSource) [0x00052] in <6ba7b54f3edf42509e7ecb6c40595f1f>:0
  at OmniSharp.Stdio.Program+<>c__DisplayClass0_0.<Main>b__1 () [0x00087] in <6ba7b54f3edf42509e7ecb6c40595f1f>:0
  at OmniSharp.CommandLineApplication+<>c__DisplayClass11_0.<OnExecute>b__0 () [0x0000b] in <fc86425b83fa4820a94c3447774fdb30>:0
  at Microsoft.Extensions.CommandLineUtils.CommandLineApplication.Execute (System.String[] args) [0x0035b] in <e56ebbc3ed87488b8e26736bbadaa5d3>:0
  at OmniSharp.CommandLineApplication.Execute (System.Collections.Generic.IEnumerable`1[T] args) [0x00042] in <fc86425b83fa4820a94c3447774fdb30>:0
  at OmniSharp.Stdio.Program+<>c__DisplayClass0_1.<Main>b__0 () [0x00028] in <6ba7b54f3edf42509e7ecb6c40595f1f>:0
  at OmniSharp.HostHelpers.Start (System.Func`1[TResult] action) [0x0001c] in <fc86425b83fa4820a94c3447774fdb30>:0
```

I've worked around this by disabling the VS instance provider on mono, but I'm still not exactly sure why it's failing.  I've tried x64 and x86 mono, and according to http://www.mono-project.com/docs/advanced/com-interop/, COM interop is supposed to work.