### PR TITLE
Fix design-time build for Antlr-generated files

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -378,9 +378,27 @@ Task("PrepareTestAssets")
             .ExceptionOnError($"Failed to build '{folder}'.");
     }
 
+    var platform = Platform.Current;
+
+    // Restore and build Windows-only test assets
+    if (platform.IsWindows)
+    {
+        foreach (var project in buildPlan.WindowsOnlyTestAssets)
+        {
+            Information("Restoring and building: {0} (windows-only)...", project);
+
+            var folder = CombinePaths(env.Folders.TestAssets, "test-projects", project);
+
+            RunTool(env.DotNetCommand, "restore", folder)
+                .ExceptionOnError($"Failed to restore '{folder}'.");
+
+            RunTool(env.DotNetCommand, "build", folder)
+                .ExceptionOnError($"Failed to build '{folder}'.");
+        }
+    }
+
     if (AllowLegacyTests())
     {
-        var platform = Platform.Current;
         if (platform.IsMacOS && platform.Version.Major == 10 && platform.Version.Minor == 12)
         {
             // Trick to allow older .NET Core SDK to run on Sierra.

--- a/build.json
+++ b/build.json
@@ -35,8 +35,8 @@
     "ProjectAndSolution",
     "ProjectAndSolutionWithProjectSection",
     "TwoProjectsWithSolution",
-    "ProjectWithGeneratedFile"
-
+    "ProjectWithGeneratedFile",
+    "AntlrGeneratedFiles"
   ],
   "LegacyTestAssets": [
     "LegacyNUnitTestProject",

--- a/build.json
+++ b/build.json
@@ -35,8 +35,7 @@
     "ProjectAndSolution",
     "ProjectAndSolutionWithProjectSection",
     "TwoProjectsWithSolution",
-    "ProjectWithGeneratedFile",
-    "AntlrGeneratedFiles"
+    "ProjectWithGeneratedFile"
   ],
   "LegacyTestAssets": [
     "LegacyNUnitTestProject",
@@ -46,5 +45,8 @@
   ],
   "CakeTestAssets": [
     "CakeProject"
+  ],
+  "WindowsOnlyTestAssets": [
+    "AntlrGeneratedFiles"
   ]
 }

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -272,6 +272,7 @@ public class BuildPlan
     public string[] TestAssets { get; set; }
     public string[] LegacyTestAssets { get; set; }
     public string[] CakeTestAssets { get; set; }
+    public string[] WindowsOnlyTestAssets { get; set; }
 
     public static BuildPlan Load(BuildEnvironment env)
     {

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.PropertyNames.cs
@@ -8,6 +8,7 @@
             public const string AssemblyName = nameof(AssemblyName);
             public const string AssemblyOriginatorKeyFile = nameof(AssemblyOriginatorKeyFile);
             public const string BuildProjectReferences = nameof(BuildProjectReferences);
+            public const string BuildingInsideVisualStudio = nameof(BuildingInsideVisualStudio);
             public const string Configuration = nameof(Configuration);
             public const string CscToolExe = nameof(CscToolExe);
             public const string CscToolPath = nameof(CscToolPath);
@@ -22,7 +23,7 @@
             public const string OutputPath = nameof(OutputPath);
             public const string Platform = nameof(Platform);
             public const string ProjectAssetsFile = nameof(ProjectAssetsFile);
-            public const string ProvideCommandLineInvocation = nameof(ProvideCommandLineInvocation);
+            public const string ProvideCommandLineArgs = nameof(ProvideCommandLineArgs);
             public const string ProjectGuid = nameof(ProjectGuid);
             public const string ProjectName = nameof(ProjectName);
             public const string _ResolveReferenceDependencies = nameof(_ResolveReferenceDependencies);

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.TargetNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.TargetNames.cs
@@ -5,6 +5,7 @@
         private static class TargetNames
         {
             public const string Compile = nameof(Compile);
+            public const string CoreCompile = nameof(CoreCompile);
             public const string ResolveReferences = nameof(ResolveReferences);
         }
     }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -130,7 +130,7 @@ namespace OmniSharp.MSBuild.ProjectFile
             }
 
             var projectInstance = project.CreateProjectInstance();
-            var buildResult = projectInstance.Build(TargetNames.Compile,
+            var buildResult = projectInstance.Build(new string[] { TargetNames.Compile, TargetNames.CoreCompile },
                 new[] { new MSBuildLogForwarder(logger, diagnostics) });
 
             return buildResult
@@ -249,13 +249,14 @@ namespace OmniSharp.MSBuild.ProjectFile
             var globalProperties = new Dictionary<string, string>
             {
                 { PropertyNames.DesignTimeBuild, "true" },
+                { PropertyNames.BuildingInsideVisualStudio, "true" },
                 { PropertyNames.BuildProjectReferences, "false" },
                 { PropertyNames._ResolveReferenceDependencies, "true" },
                 { PropertyNames.SolutionDir, solutionDirectory + Path.DirectorySeparatorChar },
 
                 // This properties allow the design-time build to handle the Compile target without actually invoking the compiler.
                 // See https://github.com/dotnet/roslyn/pull/4604 for details.
-                { PropertyNames.ProvideCommandLineInvocation, "true" },
+                { PropertyNames.ProvideCommandLineArgs, "true" },
                 { PropertyNames.SkipCompilerExecution, "true" }
             };
 

--- a/test-assets/test-projects/AntlrGeneratedFiles/Grammar.g4
+++ b/test-assets/test-projects/AntlrGeneratedFiles/Grammar.g4
@@ -1,0 +1,3 @@
+grammar Grammar;
+
+main : ;

--- a/test-assets/test-projects/AntlrGeneratedFiles/Program.cs
+++ b/test-assets/test-projects/AntlrGeneratedFiles/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Test
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            new GrammarParser(null);
+        }
+    }
+}

--- a/test-assets/test-projects/AntlrGeneratedFiles/Test.csproj
+++ b/test-assets/test-projects/AntlrGeneratedFiles/Test.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Antlr4.CodeGenerator" Version="4.6.4" />
+    <PackageReference Include="Antlr4.Runtime" Version="4.6.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <Antlr4 Include="Grammar.g4">
+      <Generator>MSBuild:Compile</Generator>
+      <CustomToolNamespace>Test</CustomToolNamespace>
+      <Listener>False</Listener>
+      <Visitor>True</Visitor>
+    </Antlr4>
+
+  </ItemGroup>
+</Project>

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -105,6 +105,23 @@ namespace OmniSharp.MSBuild.Tests
             }
         }
 
+        [Fact]
+        public async Task AntlrGeneratedFiles()
+        {
+            using (var testProject = await TestAssets.Instance.GetTestProjectAsync("AntlrGeneratedFiles"))
+            using (var host = CreateOmniSharpHost(testProject.Directory))
+            {
+                var workspaceInfo = await GetWorkspaceInfoAsync(host);
+
+                Assert.NotNull(workspaceInfo.Projects);
+                Assert.Equal(1, workspaceInfo.Projects.Count);
+
+                var project = workspaceInfo.Projects[0];
+                Assert.Equal(6, project.SourceFiles.Count);
+                Assert.Contains(project.SourceFiles, fileName => fileName.EndsWith("GrammarParser.cs"));
+            }
+        }
+
         private static async Task<MSBuildWorkspaceInfo> GetWorkspaceInfoAsync(OmniSharpTestHost host)
         {
             var service = host.GetWorkspaceInformationService();

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -105,7 +105,7 @@ namespace OmniSharp.MSBuild.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly))]
         public async Task AntlrGeneratedFiles()
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("AntlrGeneratedFiles"))

--- a/tests/TestUtility/ConditionalFactAttribute.cs
+++ b/tests/TestUtility/ConditionalFactAttribute.cs
@@ -48,6 +48,12 @@ namespace TestUtility
         public override string SkipReason => "Can't run on AppVeyor";
     }
 
+    public class WindowsOnly : SkipCondition
+    {
+        public override bool ShouldSkip => !PlatformHelper.IsWindows;
+        public override string SkipReason => "Can only be run on Windows";
+    }
+
     public class IsLegacyTest : SkipCondition
     {
         public override bool ShouldSkip


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1822

This change may fix several issues, but it particular it fixes files not appearing in the OmniSharpWorkspace that were generated through Antlr. Essentially, we had failed to set the `BuildingInsideVisualStudio` property when running a design-time build in OmniSharp. Antlr uses this property to determine whether the antlr design-time grammar compilation target runs ([link](https://github.com/tunnelvisionlabs/antlr4cs/blob/f62010862bd1e38b3c6e3940931dcde949bdaa91/runtime/CSharp/Antlr4BuildTasks/Antlr4.net40.targets#L95)).

In addition, there a couple of other tweaks in this change that are somewhat unrelated:

1. There was a type in the `ProvideCommandLineArgs` property.
2. We should run two targets: `Compile` and `CoreCompile`. This is needed to produce items from `ProvideCommandLineArgs`.