### PR TITLE
Fix issue with C# projects referencing F# projects

### DIFF
--- a/build.json
+++ b/build.json
@@ -35,7 +35,8 @@
     "ProjectAndSolution",
     "ProjectAndSolutionWithProjectSection",
     "TwoProjectsWithSolution",
-    "ProjectWithGeneratedFile"
+    "ProjectWithGeneratedFile",
+    "CSharpAndFSharp"
   ],
   "LegacyTestAssets": [
     "LegacyNUnitTestProject",

--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -465,7 +465,8 @@ namespace OmniSharp.MSBuild
             {
                 if (!_projects.TryGetValue(projectReferencePath, out var referencedProject))
                 {
-                    if (File.Exists(projectReferencePath))
+                    if (File.Exists(projectReferencePath) &&
+                        projectReferencePath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
                     {
                         _logger.LogInformation($"Found referenced project outside root directory: {projectReferencePath}");
 

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.MetadataNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.MetadataNames.cs
@@ -7,6 +7,7 @@
             public const string FullPath = nameof(FullPath);
             public const string IsImplicitlyDefined = nameof(IsImplicitlyDefined);
             public const string Project = nameof(Project);
+            public const string OriginalItemSpec = nameof(OriginalItemSpec);
             public const string ReferenceSourceTarget = nameof(ReferenceSourceTarget);
             public const string Version = nameof(Version);
         }

--- a/test-assets/test-projects/CSharpAndFSharp/CSharpAndFSharp.sln
+++ b/test-assets/test-projects/CSharpAndFSharp/CSharpAndFSharp.sln
@@ -1,0 +1,48 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "csharp-console", "csharp-console\csharp-console.csproj", "{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "fsharp-lib", "fsharp-lib\fsharp-lib.fsproj", "{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}.Debug|x64.ActiveCfg = Debug|x64
+		{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}.Debug|x64.Build.0 = Debug|x64
+		{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}.Debug|x86.ActiveCfg = Debug|x86
+		{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}.Debug|x86.Build.0 = Debug|x86
+		{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}.Release|x64.ActiveCfg = Release|x64
+		{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}.Release|x64.Build.0 = Release|x64
+		{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}.Release|x86.ActiveCfg = Release|x86
+		{ED247A90-AFBE-4717-8F32-AA8BFC2C8627}.Release|x86.Build.0 = Release|x86
+		{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}.Debug|x64.ActiveCfg = Debug|x64
+		{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}.Debug|x64.Build.0 = Debug|x64
+		{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}.Debug|x86.ActiveCfg = Debug|x86
+		{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}.Debug|x86.Build.0 = Debug|x86
+		{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}.Release|x64.ActiveCfg = Release|x64
+		{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}.Release|x64.Build.0 = Release|x64
+		{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}.Release|x86.ActiveCfg = Release|x86
+		{4FCFD6A3-2860-42C4-B98E-ADAEC268B928}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+EndGlobal

--- a/test-assets/test-projects/CSharpAndFSharp/csharp-console/Program.cs
+++ b/test-assets/test-projects/CSharpAndFSharp/csharp-console/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace csharp_console
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/test-assets/test-projects/CSharpAndFSharp/csharp-console/csharp-console.csproj
+++ b/test-assets/test-projects/CSharpAndFSharp/csharp-console/csharp-console.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\fsharp-lib\fsharp-lib.fsproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test-assets/test-projects/CSharpAndFSharp/fsharp-lib/Library.fs
+++ b/test-assets/test-projects/CSharpAndFSharp/fsharp-lib/Library.fs
@@ -1,0 +1,5 @@
+namespace lib
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/test-assets/test-projects/CSharpAndFSharp/fsharp-lib/fsharp-lib.fsproj
+++ b/test-assets/test-projects/CSharpAndFSharp/fsharp-lib/fsharp-lib.fsproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -105,6 +105,23 @@ namespace OmniSharp.MSBuild.Tests
             }
         }
 
+        [Fact]
+        public async Task CSharpAndFSharp()
+        {
+            using (var testProject = await TestAssets.Instance.GetTestProjectAsync("CSharpAndFSharp"))
+            using (var host = CreateOmniSharpHost(testProject.Directory))
+            {
+                var workspaceInfo = await GetWorkspaceInfoAsync(host);
+
+                Assert.NotNull(workspaceInfo.Projects);
+                Assert.Equal(1, workspaceInfo.Projects.Count);
+
+                var project = workspaceInfo.Projects[0];
+                Assert.Equal("csharp-console.csproj", Path.GetFileName(project.Path));
+                Assert.Equal(3, project.SourceFiles.Count);
+            }
+        }
+
         [ConditionalFact(typeof(WindowsOnly))]
         public async Task AntlrGeneratedFiles()
         {


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/371 and https://github.com/OmniSharp/omnisharp-vscode/issues/1829

This fixes a long-standing problem where C# projects would attempt to load project references
to non-C# projects. This is related to the problem on not adding file references for C# project references
to avoid duplicate references. Now, we're a bit more selective when we decide to throw out a project or file
reference: We check the file path and see if it ends with ".csproj".

I'll be porting this change into https://github.com/OmniSharp/omnisharp-roslyn/pull/1003 as well.