### PR TITLE
Use --zero-based-indices argument in Stdio and Http hosts

### DIFF
--- a/src/OmniSharp.Abstractions/AssemblyInfo.cs
+++ b/src/OmniSharp.Abstractions/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("OmniSharp")]
 [assembly: InternalsVisibleTo("OmniSharp.Host")]
 [assembly: InternalsVisibleTo("OmniSharp.Roslyn")]
 [assembly: InternalsVisibleTo("OmniSharp.Roslyn.CSharp")]

--- a/src/OmniSharp.Http/Program.cs
+++ b/src/OmniSharp.Http/Program.cs
@@ -11,6 +11,8 @@ namespace OmniSharp.Http
             application.OnExecute(() =>
             {
                 var environment = application.CreateEnvironment();
+                OmniSharp.Configuration.ZeroBasedIndices = application.ZeroBasedIndices;
+
                 var writer = new SharedTextWriter(Console.Out);
                 var plugins = application.CreatePluginAssemblies();
 

--- a/src/OmniSharp.Stdio/Program.cs
+++ b/src/OmniSharp.Stdio/Program.cs
@@ -28,6 +28,8 @@ namespace OmniSharp.Stdio
                 var output = Console.Out;
 
                 var environment = application.CreateEnvironment();
+                OmniSharp.Configuration.ZeroBasedIndices = application.ZeroBasedIndices;
+
                 var writer = new SharedTextWriter(output);
                 var plugins = application.CreatePluginAssemblies();
                 var configuration = new ConfigurationBuilder(environment).Build();


### PR DESCRIPTION
This change fixes an issue where the --zero-based-indices command
line argument was not being passed along to Configuration.ZeroBasedIndices
so that location/range serialization uses zero-based indices. This
fix wires up the argument to configure the serializer correctly.