### PR TITLE
VS Code Issue 1057 - Problem with Newlines in displaying XML Documentation

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Types/TypeLookup.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Types/TypeLookup.cs
@@ -1,4 +1,5 @@
-﻿using System.Composition;
+﻿using System;
+using System.Composition;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
@@ -45,7 +46,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Types
 
                     if (request.IncludeDocumentation)
                     {
-                        response.Documentation = DocumentationConverter.ConvertDocumentation(symbol.GetDocumentationCommentXml(), _formattingOptions.NewLine);
+                        string newLine = Environment.NewLine + Environment.NewLine;
+                        //VS Code renders a single new line for two newline sequences in the response, hence two new lines are passed in the lineEnding parameter 
+                        response.Documentation = DocumentationConverter.ConvertDocumentation(symbol.GetDocumentationCommentXml(),newLine);
                     }
                 }
             }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/DocumentationConverterFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/DocumentationConverterFacts.cs
@@ -1,5 +1,5 @@
-using OmniSharp.Roslyn.CSharp.Services.Documentation;
 using System;
+using OmniSharp.Roslyn.CSharp.Services.Documentation;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests
@@ -61,7 +61,6 @@ The <paramref name=""arg""/> parameter takes a number and <paramref name=""arg2"
             var expected =
 @"DoWork is a method in the TestClass class.
 The arg parameter takes a number and arg2 takes a string.";
-            
             plainText = plainText.Replace(lineEnding+lineEnding,lineEnding);
             Assert.Equal(expected, plainText, ignoreLineEndingDifferences: true);
         }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/DocumentationConverterFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/DocumentationConverterFacts.cs
@@ -1,4 +1,3 @@
-using System;
 using OmniSharp.Roslyn.CSharp.Services.Documentation;
 using Xunit;
 
@@ -27,9 +26,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
     </code>
     </example>
 </member>";
-            string lineEnding = Environment.NewLine;
-            //VS Code renders a single new line for two newline sequences in the response, hence two new lines are passed in the lineEnding parameter 
-            var plainText = DocumentationConverter.ConvertDocumentation(documentation,lineEnding+lineEnding);
+            var plainText = DocumentationConverter.ConvertDocumentation(documentation, "\n");
             var expected =
 @"The GetZero method.
 
@@ -44,8 +41,6 @@ This sample shows how to call the TestNamespace.TestClass.GetZero method.
         }
     }
     ";
-            //To remove the extra new lines added for VS Code for comparison, Replace function is being used
-            plainText = plainText.Replace(lineEnding + lineEnding, lineEnding);
             Assert.Equal(expected, plainText, ignoreLineEndingDifferences: true);
         }
 
@@ -56,12 +51,10 @@ This sample shows how to call the TestNamespace.TestClass.GetZero method.
 <summary>DoWork is a method in the TestClass class.
 The <paramref name=""arg""/> parameter takes a number and <paramref name=""arg2""/> takes a string.
 </summary>";
-            string lineEnding = Environment.NewLine;
-            var plainText = DocumentationConverter.ConvertDocumentation(documentation, lineEnding+lineEnding);
+            var plainText = DocumentationConverter.ConvertDocumentation(documentation, "\n");
             var expected =
 @"DoWork is a method in the TestClass class.
 The arg parameter takes a number and arg2 takes a string.";
-            plainText = plainText.Replace(lineEnding+lineEnding,lineEnding);
             Assert.Equal(expected, plainText, ignoreLineEndingDifferences: true);
         }
     }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/DocumentationConverterFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/DocumentationConverterFacts.cs
@@ -1,4 +1,5 @@
 using OmniSharp.Roslyn.CSharp.Services.Documentation;
+using System;
 using Xunit;
 
 namespace OmniSharp.Roslyn.CSharp.Tests
@@ -26,7 +27,9 @@ namespace OmniSharp.Roslyn.CSharp.Tests
     </code>
     </example>
 </member>";
-            var plainText = DocumentationConverter.ConvertDocumentation(documentation, "\n");
+            string lineEnding = Environment.NewLine;
+            //VS Code renders a single new line for two newline sequences in the response, hence two new lines are passed in the lineEnding parameter 
+            var plainText = DocumentationConverter.ConvertDocumentation(documentation,lineEnding+lineEnding);
             var expected =
 @"The GetZero method.
 
@@ -41,6 +44,8 @@ This sample shows how to call the TestNamespace.TestClass.GetZero method.
         }
     }
     ";
+            //To remove the extra new lines added for VS Code for comparison, Replace function is being used
+            plainText = plainText.Replace(lineEnding + lineEnding, lineEnding);
             Assert.Equal(expected, plainText, ignoreLineEndingDifferences: true);
         }
 
@@ -51,10 +56,13 @@ This sample shows how to call the TestNamespace.TestClass.GetZero method.
 <summary>DoWork is a method in the TestClass class.
 The <paramref name=""arg""/> parameter takes a number and <paramref name=""arg2""/> takes a string.
 </summary>";
-            var plainText = DocumentationConverter.ConvertDocumentation(documentation, "\n");
+            string lineEnding = Environment.NewLine;
+            var plainText = DocumentationConverter.ConvertDocumentation(documentation, lineEnding+lineEnding);
             var expected =
 @"DoWork is a method in the TestClass class.
 The arg parameter takes a number and arg2 takes a string.";
+            
+            plainText = plainText.Replace(lineEnding+lineEnding,lineEnding);
             Assert.Equal(expected, plainText, ignoreLineEndingDifferences: true);
         }
     }


### PR DESCRIPTION
Issue : https://github.com/OmniSharp/omnisharp-vscode/issues/1057

The issue was of absence of New Lines in Parsed XML Documentation. The problem was that VS Code is displaying a  newline character( like "\n" or "\r\n" ) as a space and not a newline. It is rather accepting two newline characters as a newline ("\n\n" or "\r\n\r\n" ). So the TypeLookUp handler has been modified to pass the appropriate lineEnding parameter. Accordingly a test has also been added.

