### PR TITLE
Build: Wait for run scripts to idle rather than terminate them after a timeout

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -732,9 +732,9 @@ Task("ExecuteRunScript")
         var projectFolder = CombinePaths(env.Folders.Source, project);
         var script = project;
         var scriptPath = CombinePaths(env.Folders.ArtifactsScripts, script);
-        var didNotExitWithError = Run(env.ShellCommand, $"{env.ShellArgument}  \"{scriptPath}\" -s \"{projectFolder}\" --stdio",
-                                    new RunOptions(timeOut: 30000))
-                                .DidTimeOut;
+        var didNotExitWithError = Run(env.ShellCommand, $"{env.ShellArgument}  \"{scriptPath}\" -s \"{projectFolder}\"",
+                                    new RunOptions(waitForIdle: true))
+                                .WasIdle;
         if (!didNotExitWithError)
         {
             throw new Exception($"Failed to run {script}");


### PR DESCRIPTION
This change ensures that we get to see the whole run script before terminating it during a build. Recently, a bug was masked because the run scripts were terminated before the bug would have manifested.