### PR TITLE
Add back code that sets MSBuildSDKsPath environment variable for each project

### DIFF
--- a/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/MSBuildProjectSystem.cs
@@ -33,6 +33,7 @@ namespace OmniSharp.MSBuild
         private readonly OmniSharpWorkspace _workspace;
         private readonly MSBuildInstance _msbuildInstance;
         private readonly DotNetCliService _dotNetCli;
+        private readonly SdksPathResolver _sdksPathResolver;
         private readonly MetadataFileReferenceCache _metadataFileReferenceCache;
         private readonly IEventEmitter _eventEmitter;
         private readonly IFileSystemWatcher _fileSystemWatcher;
@@ -57,6 +58,7 @@ namespace OmniSharp.MSBuild
             OmniSharpWorkspace workspace,
             IMSBuildLocator msbuildLocator,
             DotNetCliService dotNetCliService,
+            SdksPathResolver sdksPathResolver,
             MetadataFileReferenceCache metadataFileReferenceCache,
             IEventEmitter eventEmitter,
             IFileSystemWatcher fileSystemWatcher,
@@ -66,6 +68,7 @@ namespace OmniSharp.MSBuild
             _workspace = workspace;
             _msbuildInstance = msbuildLocator.RegisteredInstance;
             _dotNetCli = dotNetCliService;
+            _sdksPathResolver = sdksPathResolver;
             _metadataFileReferenceCache = metadataFileReferenceCache;
             _eventEmitter = eventEmitter;
             _fileSystemWatcher = fileSystemWatcher;
@@ -315,7 +318,7 @@ namespace OmniSharp.MSBuild
 
             try
             {
-                project = ProjectFileInfo.Create(projectFilePath, _environment.TargetDirectory, _loggerFactory.CreateLogger<ProjectFileInfo>(), _msbuildInstance, _options, diagnostics);
+                project = ProjectFileInfo.Create(projectFilePath, _environment.TargetDirectory, _loggerFactory.CreateLogger<ProjectFileInfo>(), _msbuildInstance, _sdksPathResolver, _options, diagnostics);
 
                 if (project == null)
                 {
@@ -341,7 +344,7 @@ namespace OmniSharp.MSBuild
                 if (_projects.TryGetValue(projectFilePath, out var oldProjectFileInfo))
                 {
                     var diagnostics = new List<MSBuildDiagnosticsMessage>();
-                    var newProjectFileInfo = oldProjectFileInfo.Reload(_environment.TargetDirectory, _loggerFactory.CreateLogger<ProjectFileInfo>(), _msbuildInstance, _options, diagnostics);
+                    var newProjectFileInfo = oldProjectFileInfo.Reload(_environment.TargetDirectory, _loggerFactory.CreateLogger<ProjectFileInfo>(), _msbuildInstance, _sdksPathResolver, _options, diagnostics);
 
                     if (newProjectFileInfo != null)
                     {

--- a/src/OmniSharp.MSBuild/SdksPathResolver.cs
+++ b/src/OmniSharp.MSBuild/SdksPathResolver.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Composition;
+using System.IO;
+using OmniSharp.Services;
+
+namespace OmniSharp.MSBuild
+{
+    [Export, Shared]
+    public class SdksPathResolver
+    {
+        private const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
+        private const string Sdks = nameof(Sdks);
+
+        private readonly DotNetCliService _dotNetCli;
+
+        [ImportingConstructor]
+        public SdksPathResolver(DotNetCliService dotNetCli)
+        {
+            _dotNetCli = dotNetCli;
+        }
+
+        public bool TryGetSdksPath(string projectFilePath, out string sdksPath)
+        {
+            var projectFileDirectory = Path.GetDirectoryName(projectFilePath);
+
+            var info = _dotNetCli.GetInfo(projectFileDirectory);
+
+            if (info.IsEmpty || string.IsNullOrWhiteSpace(info.BasePath))
+            {
+                sdksPath = null;
+                return false;
+            }
+
+            sdksPath = Path.Combine(info.BasePath, Sdks);
+
+            if (Directory.Exists(sdksPath))
+            {
+                return true;
+            }
+
+            sdksPath = null;
+            return false;
+        }
+
+        public IDisposable SetSdksPathEnvironmentVariable(string projectFilePath)
+        {
+            if (!TryGetSdksPath(projectFilePath, out var sdksPath))
+            {
+                return NullDisposable.Instance;
+            }
+
+            var oldMSBuildSDKsPath = Environment.GetEnvironmentVariable(MSBuildSDKsPath);
+            Environment.SetEnvironmentVariable(MSBuildSDKsPath, sdksPath);
+
+            return new ResetSdksPathEnvironmentVariable(oldMSBuildSDKsPath);
+        }
+
+        private class NullDisposable : IDisposable
+        {
+            public static IDisposable Instance { get; } = new NullDisposable();
+
+            public void Dispose() { }
+        }
+
+        private class ResetSdksPathEnvironmentVariable : IDisposable
+        {
+            private readonly string _oldValue;
+
+            public ResetSdksPathEnvironmentVariable(string oldValue)
+            {
+                _oldValue = oldValue;
+            }
+
+            public void Dispose()
+            {
+                Environment.SetEnvironmentVariable(MSBuildSDKsPath, _oldValue);
+            }
+        }
+    }
+}

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -26,8 +26,9 @@ namespace OmniSharp.MSBuild.Tests
         private ProjectFileInfo CreateProjectFileInfo(OmniSharpTestHost host, ITestProject testProject, string projectFilePath)
         {
             var msbuildLocator = host.GetExport<IMSBuildLocator>();
+            var sdksPathResolver = host.GetExport<SdksPathResolver>();
 
-            return ProjectFileInfo.Create(projectFilePath, testProject.Directory, this._logger, msbuildLocator.RegisteredInstance);
+            return ProjectFileInfo.Create(projectFilePath, testProject.Directory, this._logger, msbuildLocator.RegisteredInstance, sdksPathResolver);
         }
 
         [Fact]


### PR DESCRIPTION
Unfortunately, it seems that there are some [reliability issues](https://github.com/Microsoft/msbuild/issues/2532) with the MSBuild SDK Resolvers that we haven't gotten to the bottom of yet. So, I'm adding back code to set the `MSBuildSDKsPath` environment variable per project based on running the `dotnet` in that project's directory.

This should address issues like https://github.com/OmniSharp/omnisharp-vscode/issues/1849 and https://github.com/OmniSharp/omnisharp-vscode/issues/1846.

Note that this is not a long term solution. It will work for now, but there are several future concerns that we need to be mindful of:

1. Setting an environment variable will be problematic if we ever want to run design-time builds in parallel. Currently, that's blocked by several issues, but maybe someday.
2. If the `dotnet --info` output changes such that `Base Path` no longer appears in the text, this will break and need to be updated.
3. This requires a process to be launched for every project. This isn't out biggest performance issue at the moment and it's what we were doing before, but this is something to keep in mind.

cc @nguerrera, @livarcocc