### PR TITLE
Intellisense not showing methods from the Base class in Signature Help

### DIFF
--- a/build/Settings.props
+++ b/build/Settings.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
+     <LangVersion>7.1</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
+++ b/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
@@ -5,6 +5,14 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\OmniSharp.Abstractions\OmniSharp.Abstractions.csproj" />
     <ProjectReference Include="..\OmniSharp.Roslyn\OmniSharp.Roslyn.csproj" />

--- a/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
+++ b/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
@@ -5,14 +5,6 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\OmniSharp.Abstractions\OmniSharp.Abstractions.csproj" />
     <ProjectReference Include="..\OmniSharp.Roslyn\OmniSharp.Roslyn.csproj" />

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/CheckStaticInvocation.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/CheckStaticInvocation.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-
+// Adapted from https://github.com/dotnet/roslyn/blob/master/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/CheckStaticInvocation.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/CheckStaticInvocation.cs
@@ -1,0 +1,175 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+namespace OmniSharp.Roslyn.CSharp.Services.Signatures
+{
+    static internal class CheckForStatic
+    {
+        public static bool IsInStaticContext(this SyntaxNode node)
+        {
+            // this/base calls are always static.
+            if (node.FirstAncestorOrSelf<ConstructorInitializerSyntax>() != null)
+            {
+                return true;
+            }
+
+            var memberDeclaration = node.FirstAncestorOrSelf<MemberDeclarationSyntax>();
+            if (memberDeclaration == null)
+            {
+                return false;
+            }
+
+            switch (memberDeclaration.Kind())
+            {
+                case SyntaxKind.MethodDeclaration:
+                case SyntaxKind.ConstructorDeclaration:
+                case SyntaxKind.EventDeclaration:
+                case SyntaxKind.IndexerDeclaration:
+                    return GetModifiers(memberDeclaration).Any(SyntaxKind.StaticKeyword);
+
+                case SyntaxKind.PropertyDeclaration:
+                    return GetModifiers(memberDeclaration).Any(SyntaxKind.StaticKeyword) ||
+                        node.IsFoundUnder((PropertyDeclarationSyntax p) => p.Initializer);
+
+                case SyntaxKind.FieldDeclaration:
+                case SyntaxKind.EventFieldDeclaration:
+                    // Inside a field one can only access static members of a type (unless it's top-level).
+                    return !memberDeclaration.Parent.IsKind(SyntaxKind.CompilationUnit);
+
+                case SyntaxKind.DestructorDeclaration:
+                    return false;
+            }
+
+            // Global statements are not a static context.
+            if (node.FirstAncestorOrSelf<GlobalStatementSyntax>() != null)
+            {
+                return false;
+            }
+
+            // any other location is considered static
+            return true;
+        }
+        public static SyntaxTokenList GetModifiers(SyntaxNode member)
+        {
+            if (member != null)
+            {
+                switch (member.Kind())
+                {
+                    case SyntaxKind.EnumDeclaration:
+                        return ((EnumDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.ClassDeclaration:
+                    case SyntaxKind.InterfaceDeclaration:
+                    case SyntaxKind.StructDeclaration:
+                        return ((TypeDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.DelegateDeclaration:
+                        return ((DelegateDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.FieldDeclaration:
+                        return ((FieldDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.EventFieldDeclaration:
+                        return ((EventFieldDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.ConstructorDeclaration:
+                        return ((ConstructorDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.DestructorDeclaration:
+                        return ((DestructorDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.PropertyDeclaration:
+                        return ((PropertyDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.EventDeclaration:
+                        return ((EventDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.IndexerDeclaration:
+                        return ((IndexerDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.OperatorDeclaration:
+                        return ((OperatorDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.ConversionOperatorDeclaration:
+                        return ((ConversionOperatorDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.MethodDeclaration:
+                        return ((MethodDeclarationSyntax)member).Modifiers;
+                    case SyntaxKind.GetAccessorDeclaration:
+                    case SyntaxKind.SetAccessorDeclaration:
+                    case SyntaxKind.AddAccessorDeclaration:
+                    case SyntaxKind.RemoveAccessorDeclaration:
+                        return ((AccessorDeclarationSyntax)member).Modifiers;
+                }
+            }
+
+            return default;
+        }
+        public static bool IsFoundUnder<TParent>(this SyntaxNode node, Func<TParent, SyntaxNode> childGetter)
+           where TParent : SyntaxNode
+        {
+            var ancestor = node.GetAncestor<TParent>();
+            if (ancestor == null)
+            {
+                return false;
+            }
+
+            var child = childGetter(ancestor);
+
+            // See if node passes through child on the way up to ancestor.
+            return node.GetAncestorsOrThis<SyntaxNode>().Contains(child);
+        }
+        public static TNode GetAncestor<TNode>(this SyntaxNode node)
+           where TNode : SyntaxNode
+        {
+            var current = node.Parent;
+            while (current != null)
+            {
+                if (current is TNode tNode)
+                {
+                    return tNode;
+                }
+
+                current = current.GetParent();
+            }
+
+            return null;
+        }
+        private static SyntaxNode GetParent(this SyntaxNode node)
+        {
+            return node is IStructuredTriviaSyntax trivia ? trivia.ParentTrivia.Token.Parent : node.Parent;
+        }
+
+        public static TNode FirstAncestorOrSelfUntil<TNode>(this SyntaxNode node, Func<SyntaxNode, bool> predicate)
+            where TNode : SyntaxNode
+        {
+            for (var current = node; current != null; current = current.GetParent())
+            {
+                if (current is TNode tnode)
+                {
+                    return tnode;
+                }
+
+                if (predicate(current))
+                {
+                    break;
+                }
+            }
+
+            return default;
+        }
+
+        public static TNode GetAncestorOrThis<TNode>(this SyntaxNode node)
+                where TNode : SyntaxNode
+        {
+            return node?.GetAncestorsOrThis<TNode>().FirstOrDefault();
+        }
+
+        public static IEnumerable<TNode> GetAncestorsOrThis<TNode>(this SyntaxNode node)
+            where TNode : SyntaxNode
+        {
+            var current = node;
+            while (current != null)
+            {
+                if (current is TNode tNode)
+                {
+                    yield return tNode;
+                }
+
+                current = current.GetParent();
+            }
+        }
+    }
+}
+

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/CheckStaticInvocation.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/CheckStaticInvocation.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace OmniSharp.Roslyn.CSharp.Services.Signatures
 {
-    //TO DO: Reomove this class once a public API for Signature Help from Roslyn is available
+    //TO DO: Remove this class once a public API for Signature Help from Roslyn is available
     internal static class CheckForStaticExtension
     {
         public static bool IsInStaticContext(this SyntaxNode node)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/CheckStaticInvocation.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/CheckStaticInvocation.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -7,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace OmniSharp.Roslyn.CSharp.Services.Signatures
 {
+    //TO DO: Reomove this class once a public API for Signature Help from Roslyn is available
     internal static class CheckForStaticExtension
     {
         public static bool IsInStaticContext(this SyntaxNode node)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/CheckStaticInvocation.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/CheckStaticInvocation.cs
@@ -1,12 +1,13 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 namespace OmniSharp.Roslyn.CSharp.Services.Signatures
 {
-    static internal class CheckForStatic
+    internal static class CheckForStaticExtension
     {
         public static bool IsInStaticContext(this SyntaxNode node)
         {
@@ -52,6 +53,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
             // any other location is considered static
             return true;
         }
+
         public static SyntaxTokenList GetModifiers(SyntaxNode member)
         {
             if (member != null)
@@ -96,6 +98,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
 
             return default;
         }
+
         public static bool IsFoundUnder<TParent>(this SyntaxNode node, Func<TParent, SyntaxNode> childGetter)
            where TParent : SyntaxNode
         {
@@ -110,6 +113,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
             // See if node passes through child on the way up to ancestor.
             return node.GetAncestorsOrThis<SyntaxNode>().Contains(child);
         }
+
         public static TNode GetAncestor<TNode>(this SyntaxNode node)
            where TNode : SyntaxNode
         {
@@ -126,6 +130,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
 
             return null;
         }
+
         private static SyntaxNode GetParent(this SyntaxNode node)
         {
             return node is IStructuredTriviaSyntax trivia ? trivia.ParentTrivia.Token.Parent : node.Parent;

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/InvocationContext.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/InvocationContext.cs
@@ -13,7 +13,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
         public SyntaxNode Receiver { get; }
         public IEnumerable<TypeInfo> ArgumentTypes { get; }
         public IEnumerable<SyntaxToken> Separators { get; }
-        public bool IsStatic { get; } 
+        public bool IsInStaticContext { get; } 
 
         public InvocationContext(SemanticModel semModel, int position, SyntaxNode receiver, ArgumentListSyntax argList, bool isStatic)
         {
@@ -22,7 +22,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
             Receiver = receiver;
             ArgumentTypes = argList.Arguments.Select(argument => semModel.GetTypeInfo(argument.Expression));
             Separators = argList.Arguments.GetSeparators();
-            IsStatic = isStatic;
+            IsInStaticContext = isStatic;
         }
 
         public InvocationContext(SemanticModel semModel, int position, SyntaxNode receiver, AttributeArgumentListSyntax argList, bool isStatic)
@@ -32,7 +32,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
             Receiver = receiver;
             ArgumentTypes = argList.Arguments.Select(argument => semModel.GetTypeInfo(argument.Expression));
             Separators = argList.Arguments.GetSeparators();
-            IsStatic = isStatic;
+            IsInStaticContext = isStatic;
         }
     }  
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/InvocationContext.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/InvocationContext.cs
@@ -13,23 +13,26 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
         public SyntaxNode Receiver { get; }
         public IEnumerable<TypeInfo> ArgumentTypes { get; }
         public IEnumerable<SyntaxToken> Separators { get; }
+        public bool IsStatic { get; } 
 
-        public InvocationContext(SemanticModel semModel, int position, SyntaxNode receiver, ArgumentListSyntax argList)
+        public InvocationContext(SemanticModel semModel, int position, SyntaxNode receiver, ArgumentListSyntax argList, bool isStatic)
         {
             SemanticModel = semModel;
             Position = position;
             Receiver = receiver;
             ArgumentTypes = argList.Arguments.Select(argument => semModel.GetTypeInfo(argument.Expression));
             Separators = argList.Arguments.GetSeparators();
+            IsStatic = isStatic;
         }
 
-        public InvocationContext(SemanticModel semModel, int position, SyntaxNode receiver, AttributeArgumentListSyntax argList)
+        public InvocationContext(SemanticModel semModel, int position, SyntaxNode receiver, AttributeArgumentListSyntax argList, bool isStatic)
         {
             SemanticModel = semModel;
             Position = position;
             Receiver = receiver;
             ArgumentTypes = argList.Arguments.Select(argument => semModel.GetTypeInfo(argument.Expression));
             Separators = argList.Arguments.GetSeparators();
+            IsStatic = isStatic;
         }
     }  
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -135,7 +135,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
 
             var MethodOverloads = symbol.ContainingType.GetMembers(symbol.Name).OfType<IMethodSymbol>();
             var BaseType = symbol.ContainingType.BaseType;
-            while(BaseType!=null)
+            while(BaseType!=null && BaseType.ContainingNamespace.Name!= "System")
             {
                 MethodOverloads = MethodOverloads.Concat(BaseType.GetMembers(symbol.Name).OfType<IMethodSymbol>());
                 BaseType = BaseType.BaseType;

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -72,8 +72,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
                     var includeStatic = (throughSymbol is INamedTypeSymbol) || throughType != null;
                     methodGroup = methodGroup.Where(m => (m.IsStatic && includeStatic) || (!m.IsStatic && includeInstance));
                 }
-
-                else if (invocation.Receiver is SimpleNameSyntax && invocation.IsStatic)
+                else if (invocation.Receiver is SimpleNameSyntax && invocation.IsInStaticContext)
                 {
                     methodGroup = methodGroup.Where(m => m.IsStatic);
                 }
@@ -119,7 +118,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
                 if (node is ObjectCreationExpressionSyntax objectCreation && objectCreation.ArgumentList.Span.Contains(position))
                 {
                     var semanticModel = await document.GetSemanticModelAsync();
-                    return new InvocationContext(semanticModel, position, objectCreation, objectCreation.ArgumentList,objectCreation.IsInStaticContext());
+                    return new InvocationContext(semanticModel, position, objectCreation, objectCreation.ArgumentList, objectCreation.IsInStaticContext());
                 }
 
                 if (node is AttributeSyntax attributeSyntax && attributeSyntax.ArgumentList.Span.Contains(position))

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -133,15 +133,15 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
                 return new IMethodSymbol[] { };
             }
 
-            var MethodOverloads = symbol.ContainingType.GetMembers(symbol.Name).OfType<IMethodSymbol>();
-            var BaseType = symbol.ContainingType.BaseType;
-            while(BaseType!=null && BaseType.ContainingNamespace.Name!= "System")
+            var methodOverloads = symbol.ContainingType.GetMembers(symbol.Name).OfType<IMethodSymbol>();
+            var baseTypeSymbol = symbol.ContainingType.BaseType;
+            while(baseTypeSymbol != null && baseTypeSymbol.ContainingNamespace.Name != "System")
             {
-                MethodOverloads = MethodOverloads.Concat(BaseType.GetMembers(symbol.Name).OfType<IMethodSymbol>());
-                BaseType = BaseType.BaseType;
+                methodOverloads = methodOverloads.Concat(baseTypeSymbol.GetMembers(symbol.Name).OfType<IMethodSymbol>());
+                baseTypeSymbol = baseTypeSymbol.BaseType;
             }
 
-            return MethodOverloads;
+            return methodOverloads;
         }
 
         private int InvocationScore(IMethodSymbol symbol, IEnumerable<TypeInfo> types)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -133,7 +133,15 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
                 return new IMethodSymbol[] { };
             }
 
-            return symbol.ContainingType.GetMembers(symbol.Name).OfType<IMethodSymbol>();
+            var MethodOverloads = symbol.ContainingType.GetMembers(symbol.Name).OfType<IMethodSymbol>();
+            var BaseType = symbol.ContainingType.BaseType;
+            while(BaseType!=null)
+            {
+                MethodOverloads = MethodOverloads.Concat(BaseType.GetMembers(symbol.Name).OfType<IMethodSymbol>());
+                BaseType = BaseType.BaseType;
+            }
+
+            return MethodOverloads;
         }
 
         private int InvocationScore(IMethodSymbol symbol, IEnumerable<TypeInfo> types)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -117,7 +117,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
 
         private int InvocationScore(IMethodSymbol symbol, IEnumerable<TypeInfo> types)
         {
-            var parameters = GetParameters(symbol);
+            var parameters = symbol.Parameters;
             if (parameters.Count() < types.Count())
             {
                 return int.MinValue;
@@ -151,7 +151,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
             signature.Name = symbol.MethodKind == MethodKind.Constructor ? symbol.ContainingType.Name : symbol.Name;
             signature.Label = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
 
-            signature.Parameters = GetParameters(symbol).Select(parameter =>
+            signature.Parameters = symbol.Parameters.Select(parameter =>
             {
                 return new SignatureHelpParameter()
                 {
@@ -162,18 +162,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
             });
 
             return signature;
-        }
-
-        private static IEnumerable<IParameterSymbol> GetParameters(IMethodSymbol methodSymbol)
-        {
-            if (!methodSymbol.IsExtensionMethod)
-            {
-                return methodSymbol.Parameters;
-            }
-            else
-            {
-                return methodSymbol.Parameters.RemoveAt(0);
-            }
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -3,6 +3,7 @@ using System.Composition;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Mef;
@@ -59,7 +60,25 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
             foreach (var invocation in invocations)
             {
                 var types = invocation.ArgumentTypes;
-                foreach (var methodOverload in invocation.SemanticModel.GetMemberGroup(invocation.Receiver).OfType<IMethodSymbol>())
+                ISymbol throughSymbol = null;
+                ISymbol throughType = null;
+                var methodGroup = invocation.SemanticModel.GetMemberGroup(invocation.Receiver).OfType<IMethodSymbol>();
+                if (invocation.Receiver is MemberAccessExpressionSyntax)
+                {
+                    var throughExpression = ((MemberAccessExpressionSyntax)invocation.Receiver).Expression;
+                    throughSymbol = invocation.SemanticModel.GetSpeculativeSymbolInfo(invocation.Position, throughExpression, SpeculativeBindingOption.BindAsExpression).Symbol;
+                    throughType = invocation.SemanticModel.GetSpeculativeTypeInfo(invocation.Position, throughExpression, SpeculativeBindingOption.BindAsTypeOrNamespace).Type;
+                    var includeInstance = throughSymbol != null && !(throughSymbol is ITypeSymbol);
+                    var includeStatic = (throughSymbol is INamedTypeSymbol) || throughType != null;
+                    methodGroup = methodGroup.Where(m => (m.IsStatic && includeStatic) || (!m.IsStatic && includeInstance));
+                }
+
+                else if (invocation.Receiver is SimpleNameSyntax && invocation.IsStatic)
+                {
+                    methodGroup = methodGroup.Where(m => m.IsStatic);
+                }
+
+                foreach (var methodOverload in methodGroup)
                 {
                     var signature = BuildSignature(methodOverload);
                     signaturesSet.Add(signature);
@@ -94,19 +113,19 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
                 if (node is InvocationExpressionSyntax invocation && invocation.ArgumentList.Span.Contains(position))
                 {
                     var semanticModel = await document.GetSemanticModelAsync();
-                    return new InvocationContext(semanticModel, position, invocation.Expression, invocation.ArgumentList);
+                    return new InvocationContext(semanticModel, position, invocation.Expression, invocation.ArgumentList, invocation.IsInStaticContext());
                 }
 
                 if (node is ObjectCreationExpressionSyntax objectCreation && objectCreation.ArgumentList.Span.Contains(position))
                 {
                     var semanticModel = await document.GetSemanticModelAsync();
-                    return new InvocationContext(semanticModel, position, objectCreation, objectCreation.ArgumentList);
+                    return new InvocationContext(semanticModel, position, objectCreation, objectCreation.ArgumentList,objectCreation.IsInStaticContext());
                 }
 
                 if (node is AttributeSyntax attributeSyntax && attributeSyntax.ArgumentList.Span.Contains(position))
                 {
                     var semanticModel = await document.GetSemanticModelAsync();
-                    return new InvocationContext(semanticModel, position, attributeSyntax, attributeSyntax.ArgumentList);
+                    return new InvocationContext(semanticModel, position, attributeSyntax, attributeSyntax.ArgumentList, attributeSyntax.IsInStaticContext());
                 }
 
                 node = node.Parent;
@@ -141,7 +160,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
                 }
             }
 
-            return score; 
+            return score;
         }
 
         private static SignatureHelpItem BuildSignature(IMethodSymbol symbol)
@@ -163,5 +182,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
 
             return signature;
         }
+
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -535,6 +535,9 @@ public class Class2
  }";
             var actual = await GetSignatureHelp(source);
             Assert.Single(actual.Signatures);
+
+            var signature = actual.Signatures.ElementAt(0);
+            Assert.Equal(3, signature.Parameters.Count());
         }
 
         [Fact]
@@ -670,6 +673,7 @@ class B : A
             var actual = await GetSignatureHelp(source);
             Assert.Equal(4, actual.Signatures.Count());
         }
+
         [Fact]
         public async Task OverloadedExtensionMethods1()
         {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -661,11 +661,11 @@ class B : A
 
 class B : A
 {
-    static void M1(int a,int b,int c)
+    void M1(int a,int b,int c)
     {
         M1($$)
     }
-    public void M1(int a,int b,int c,int d) { }
+    static void M1(int a,int b,int c,int d) { }
 }";
             var actual = await GetSignatureHelp(source);
             Assert.Equal(4, actual.Signatures.Count());

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -508,6 +508,35 @@ public class Class2
             var actual = await GetSignatureHelp(source);
             Assert.Equal(4, actual.Signatures.Count());
         }
+
+        [Fact]
+        public async Task SignatureHelpForOverloadedInaccesibleMethods()
+        {
+            const string source =
+@"public class MyBase
+{
+    private void MyMethod(int a) { }
+}
+
+public class Class1 : MyBase
+{
+    public void MyMethod(int a, int b, int c) { }
+    protected void MyMethod(int a, int b, int c, int d) { }
+}
+
+public class Class2
+{
+    public void foo()
+    {
+        Class1 c1 = new Class1();
+        c1.MyMethod($$);
+    }
+
+ }";
+            var actual = await GetSignatureHelp(source);
+            Assert.Equal(2, actual.Signatures.Count());
+        }
+
         [Fact]
         public async Task SkipReceiverOfExtensionMethods()
         {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -481,7 +481,7 @@ public class MyTestAttribute : Attribute
         }
 
         [Fact]
-        public async Task SignatureHelpForOverloadedMethodsInheritance()
+        public async Task SignatureHelpForInheritedMethods()
         {
             const string source =
 @"public class MyBase
@@ -510,7 +510,7 @@ public class Class2
         }
 
         [Fact]
-        public async Task SignatureHelpForOverloadedInaccesibleMethods()
+        public async Task SignatureHelpForInheritedInaccesibleMethods()
         {
             const string source =
 @"public class MyBase
@@ -535,6 +535,64 @@ public class Class2
  }";
             var actual = await GetSignatureHelp(source);
             Assert.Single(actual.Signatures);
+        }
+
+        [Fact]
+        public async Task SignatureHelpForOverloadedExtensionMethods1()
+        {
+            const string source =
+@"public static class ExtensionMethods
+{
+    public static void MyMethod(this string value, int number)
+    {
+    }
+}
+
+class Program
+{
+    public static void MyMethod(string a, int b)
+    {
+    }
+    public static void Main()
+    {
+        string value = ""Hello"";
+        value.MyMethod($$);
+    }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Single(actual.Signatures);
+
+            var signature = actual.Signatures.ElementAt(0);
+            Assert.Equal("void string.MyMethod(int number)",signature.Label);
+        }
+
+        [Fact]
+        public async Task SignatureHelpForOverloadedExtensionMethods2()
+        {
+            const string source =
+@"public static class ExtensionMethods
+{
+    public static void MyMethod(this string value, int number)
+    {
+    }
+}
+
+class Program
+{
+    public static void MyMethod(string a, int b)
+    {
+    }
+    public static void Main()
+    {
+        string value = ""Hello"";
+        MyMethod($$);
+    }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Single(actual.Signatures);
+
+            var signature = actual.Signatures.ElementAt(0);
+            Assert.Equal("void Program.MyMethod(string a, int b)", signature.Label);
         }
 
         [Fact]

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -534,7 +534,7 @@ public class Class2
 
  }";
             var actual = await GetSignatureHelp(source);
-            Assert.Equal(2, actual.Signatures.Count());
+            Assert.Single(actual.Signatures);
         }
 
         [Fact]

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -564,6 +564,8 @@ class Program
 
             var signature = actual.Signatures.ElementAt(0);
             Assert.Equal("void string.MyMethod(int number)",signature.Label);
+            Assert.Single(signature.Parameters);
+            Assert.Equal("number", signature.Parameters.ElementAt(0).Name);
         }
 
         [Fact]
@@ -599,27 +601,34 @@ class Program
         public async Task SkipReceiverOfExtensionMethods()
         {
             const string source =
-@"class Program
+@"public class Program1
 {
-    public static void Main()
-    {
-        new Program().B($$);
-    }
-    public Program()
-    {
-    }
-    public bool B(this Program p, int n)
+    public Program1() { }
+}
+
+public static class ExtensionClass{
+    public static bool B(this Program1 p, int n)
     {
         return p.Foo() > n;
     }
-}";
+}
 
+public class ProgramClass
+{
+    public static void Main()
+    {
+        new Program1().B($$);
+    }
+}";
             var actual = await GetSignatureHelp(source);
             Assert.Single(actual.Signatures);
-            Assert.Single(actual.Signatures.ElementAt(actual.ActiveSignature).Parameters);
-            Assert.Equal("n", actual.Signatures.ElementAt(actual.ActiveSignature).Parameters.ElementAt(0).Name);
-        }
 
+            var signature = actual.Signatures.ElementAt(0);
+            Assert.Single(signature.Parameters);
+            Assert.Equal("n", signature.Parameters.ElementAt(0).Name);
+            Assert.Equal("int n", signature.Parameters.ElementAt(0).Label);
+        }
+      
         private async Task<SignatureHelpResponse> GetSignatureHelp(string source)
         {
             var testFile = new TestFile("dummy.cs", source);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -153,7 +153,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         }
 
         [Fact]
-        public async Task SignatureHelpforAttributeCtorSingleParam()
+        public async Task AttributeCtorSingleParam()
         {
             const string source =
 @"using System;
@@ -180,7 +180,7 @@ public class MyTestAttribute : Attribute
         }
 
         [Fact]
-        public async Task SignatureHelpforAttributeCtorTestParameterLabels()
+        public async Task AttributeCtorTestParameterLabels()
         {
             const string source =
 @"using System;
@@ -210,7 +210,7 @@ public class MyTestAttribute : Attribute
         }
 
         [Fact]
-        public async Task SignatureHelpforAttributeCtorActiveParamBasedOnComma()
+        public async Task AttributeCtorActiveParamBasedOnComma()
         {
             const string source =
 @"using System;
@@ -233,7 +233,7 @@ public class MyTestAttribute : Attribute
         }
 
         [Fact]
-        public async Task SignatureHelpforAttributeCtorNoParam()
+        public async Task AttributeCtorNoParam()
         {
             const string source =
 @"using System;
@@ -429,7 +429,7 @@ public class MyTestAttribute : Attribute
         }
 
         [Fact]
-        public async Task SignatureHelpForCtor()
+        public async Task TestForConstructorHelp()
         {
             const string source =
 @"class Program
@@ -454,7 +454,7 @@ public class MyTestAttribute : Attribute
         }
 
         [Fact]
-        public async Task SignatureHelpForCtorWithOverloads()
+        public async Task TestForCtorWithOverloads()
         {
             const string source =
 @"class Program
@@ -481,7 +481,7 @@ public class MyTestAttribute : Attribute
         }
 
         [Fact]
-        public async Task SignatureHelpForInheritedMethods()
+        public async Task TestForInheritedMethods()
         {
             const string source =
 @"public class MyBase
@@ -510,7 +510,7 @@ public class Class2
         }
 
         [Fact]
-        public async Task SignatureHelpForInheritedInaccesibleMethods()
+        public async Task InheritedInaccesibleMethods()
         {
             const string source =
 @"public class MyBase
@@ -538,7 +538,140 @@ public class Class2
         }
 
         [Fact]
-        public async Task SignatureHelpForOverloadedExtensionMethods1()
+        public async Task InheritedProtectedMethod()
+        {
+            const string source =
+@"class A
+{
+    protected void M1() { }
+}
+
+class B : A
+{
+    void M1(int a)
+    {
+       M1($$)
+    }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Equal(2,actual.Signatures.Count());
+        }
+
+        [Fact]
+        public async Task InheritedProtectedMethodWithThis()
+        {
+            const string source =
+@"class A
+{
+    protected void M1() { }
+}
+
+class B : A
+{
+    void M1(int a)
+    {
+        this.M1($$)
+    }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Equal(2, actual.Signatures.Count());
+        }
+
+        [Fact]
+        public async Task InheritedProtectedMethodWithBase()
+        {
+            const string source =
+@"class A
+{
+    protected void M1() { }
+}
+
+class B : A
+{
+    void M1(int a)
+    {
+        base.M1($$);
+    }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Single(actual.Signatures);
+            Assert.Empty(actual.Signatures.ElementAt(0).Parameters);
+        }
+
+        [Fact]
+        public async Task StaticContextMethod1()
+        {
+            const string source =
+@"class A
+{
+    protected static void M1(int a) { }
+    public void M1(double b) { }
+}
+
+class B : A
+{
+    static void M1()
+    {
+        A.M1($$);
+    }
+    public void M1(string c) { }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Single(actual.Signatures);
+
+            var signature = actual.Signatures.ElementAt(0);
+            Assert.Single(signature.Parameters);
+            Assert.Equal("int a", signature.Parameters.ElementAt(0).Label);
+        }
+
+        [Fact]
+        public async Task StaticContextMethod2()
+        {
+            const string source =
+@"class A
+{
+    protected static void M1(int a) { }
+    public void M1(int a,int b) { }
+}
+
+class B : A
+{
+    static void M1(int a,int b,int c)
+    {
+        B.M1($$)
+    }
+    public void M1(int a,int b,int c,int d) { }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Equal(2, actual.Signatures.Count());
+            var signatures = actual.Signatures.OrderBy(sig => sig.Parameters.Count());
+            Assert.Single(signatures.ElementAt(0).Parameters);
+            Assert.Equal(3,signatures.ElementAt(1).Parameters.Count());
+        }
+
+        [Fact]
+        public async Task InstanceContextMethod()
+        {
+            const string source =
+@"class A
+{
+    protected static void M1(int a) { }
+    public void M1(int a, int b) { }
+}
+
+class B : A
+{
+    static void M1(int a,int b,int c)
+    {
+        M1($$)
+    }
+    public void M1(int a,int b,int c,int d) { }
+}";
+            var actual = await GetSignatureHelp(source);
+            Assert.Equal(4, actual.Signatures.Count());
+        }
+        [Fact]
+        public async Task OverloadedExtensionMethods1()
         {
             const string source =
 @"public static class ExtensionMethods
@@ -569,7 +702,7 @@ class Program
         }
 
         [Fact]
-        public async Task SignatureHelpForOverloadedExtensionMethods2()
+        public async Task OverloadedExtensionMethods2()
         {
             const string source =
 @"public static class ExtensionMethods

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -474,13 +474,40 @@ public class MyTestAttribute : Attribute
     {
     }
 }";
-
             var actual = await GetSignatureHelp(source);
             Assert.Equal(3, actual.Signatures.Count());
             Assert.Equal(1, actual.ActiveParameter);
             Assert.Contains("ctor2", actual.Signatures.ElementAt(actual.ActiveSignature).Documentation);
         }
 
+        [Fact]
+        public async Task SignatureHelpForOverloadedMethodsInheritance()
+        {
+            const string source =
+@"public class MyBase
+{
+    public void MyMethod(int a) { }
+    public void MyMethod(int a, int b) { }
+}
+
+public class Class1 : MyBase
+{
+    public void MyMethod(int a, int b, int c) { }
+    public void MyMethod(int a, int b, int c, int d) { }
+}
+
+public class Class2
+{
+    public void foo()
+    {
+        Class1 c1 = new Class1();
+        c1.MyMethod($$);
+    }
+
+ }";
+            var actual = await GetSignatureHelp(source);
+            Assert.Equal(4, actual.Signatures.Count());
+        }
         [Fact]
         public async Task SkipReceiverOfExtensionMethods()
         {


### PR DESCRIPTION
Issue : https://github.com/OmniSharp/omnisharp-vscode/issues/1440

During the search for the signature help, only the immediate Type that contains the given method  was being searched for possible method overloads hence the overloads present in the Base Classes were not appearing. Added the code to search for members using the GetMemberGroup. Added a test for the same. 

Please review @DustinCampbell @TheRealPiotrP @rchande 