### PR TITLE
Fix a regression causing netcore projects to fail to load

### DIFF
--- a/src/OmniSharp.Roslyn/Utilities/CompilationOptionsHelper.cs
+++ b/src/OmniSharp.Roslyn/Utilities/CompilationOptionsHelper.cs
@@ -24,7 +24,7 @@ namespace OmniSharp.Helpers
         {
             if (suppressedDiagnosticIds == null || !suppressedDiagnosticIds.Any()) return GetDefaultSuppressedDiagnosticOptions();
 
-            var suppressedDiagnostics = suppressedDiagnosticIds.ToDictionary(d => d, d => ReportDiagnostic.Suppress);
+            var suppressedDiagnostics = suppressedDiagnosticIds.Distinct().ToDictionary(d => d, d => ReportDiagnostic.Suppress);
             foreach (var diagnostic in defaultSuppressedDiagnostics)
             {
                 if (!suppressedDiagnostics.ContainsKey(diagnostic.Key))


### PR DESCRIPTION
Diagnostic ids can be repeated when passed in from a project system. A [recent refactoring](https://github.com/OmniSharp/omnisharp-roslyn/pull/1025) seems to have changed code in such a way that creating a dictionary fails and that causes the workspace to not get populated with projects. Making the diagnostic ids distinct before creating a dictionary fixes the issue.

@filipw @DustinCampbell 