### PR TITLE
Return a diagnostic's Id from /codecheck calls

### DIFF
--- a/src/OmniSharp.Abstractions/Models/v1/Diagnostics/DiagnosticLocation.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/Diagnostics/DiagnosticLocation.cs
@@ -3,5 +3,6 @@
     public class DiagnosticLocation : QuickFix
     {
         public string LogLevel { get; set; }
+        public string Id { get; set; }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/DiagnosticExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/DiagnosticExtensions.cs
@@ -19,7 +19,8 @@ namespace OmniSharp.Helpers
                 EndLine = span.EndLinePosition.Line,
                 EndColumn = span.EndLinePosition.Character,
                 Text = diagnostic.GetMessage(),
-                LogLevel = diagnostic.Severity.ToString()
+                LogLevel = diagnostic.Severity.ToString(),
+                Id = diagnostic.Id
             };
         }
 


### PR DESCRIPTION
So that when displaying an error we can show the error code as well.

@DustinCampbell 