### PR TITLE
Align OmniSharp.Script with Dotnet.Script.DependencyModel 0.3.0

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -3,8 +3,8 @@
 
   <PropertyGroup>
     <CakeScriptinTransportVersion>0.1.0</CakeScriptinTransportVersion>
-    <DotnetScriptDependencyModelVersion>0.2.0</DotnetScriptDependencyModelVersion>
-    <DotnetScriptDependencyModelNuGetVersion>0.2.0</DotnetScriptDependencyModelNuGetVersion>
+    <DotnetScriptDependencyModelVersion>0.3.0</DotnetScriptDependencyModelVersion>
+    <DotnetScriptDependencyModelNuGetVersion>0.3.0</DotnetScriptDependencyModelNuGetVersion>
     <MicrosoftAspNetCoreDiagnosticsVersion>1.1.0</MicrosoftAspNetCoreDiagnosticsVersion>
     <MicrosoftAspNetCoreHostingVersion>1.1.0</MicrosoftAspNetCoreHostingVersion>
     <MicrosoftAspNetCoreHttpFeaturesVersion>1.1.0</MicrosoftAspNetCoreHttpFeaturesVersion>

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -5,16 +5,16 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Dotnet.Script.DependencyModel.Compilation;
+using Dotnet.Script.DependencyModel.NuGet;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Models.WorkspaceInformation;
 using OmniSharp.Services;
 using OmniSharp.Roslyn.Utilities;
-using Dotnet.Script.DependencyModel.Compilation;
-using Dotnet.Script.DependencyModel.NuGet;
-using Microsoft.CodeAnalysis.Scripting;
 using LogLevel = Dotnet.Script.DependencyModel.Logging.LogLevel;
 
 namespace OmniSharp.Script


### PR DESCRIPTION
This PR aligns OmniSharp.Script with Dotnet.Script.DependencyModel 0.3.0 and adds support for providing metadata for script packages. 

Also took the liberty to fix a typo 😄  ("Destkop CLR scripts" -> "Desktop CLR scripts")