### PR TITLE
Ensure that we don't load multiple compilation assemby versions

### DIFF
--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -112,7 +112,7 @@ namespace OmniSharp.Script
             }
             else
             {
-                HashSet<string> loadedFiles = new HashSet<string>();
+                HashSet<string> loadedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (var compilationAssembly in compilationDependencies.SelectMany(cd => cd.AssemblyPaths).Distinct())
                 {

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -112,10 +112,15 @@ namespace OmniSharp.Script
             }
             else
             {
+                HashSet<string> loadedFiles = new HashSet<string>();
+
                 foreach (var compilationAssembly in compilationDependencies.SelectMany(cd => cd.AssemblyPaths).Distinct())
                 {
-                    _logger.LogDebug("Discovered script compilation assembly reference: " + compilationAssembly);
-                    AddMetadataReference(commonReferences, compilationAssembly);
+                    if (loadedFiles.Add(Path.GetFileName(compilationAssembly)))
+                    {
+                        _logger.LogDebug("Discovered script compilation assembly reference: " + compilationAssembly);
+                        AddMetadataReference(commonReferences, compilationAssembly);
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR ensures that we don't load multiple versions of the same compilation assembly. This PR only affects loading metadata for scripts targeting .Net Core.

This PR also resolves the issue discussed here. 
https://github.com/filipw/dotnet-script/issues/194
