### PR TITLE
pretty print JSON when logging requests/responses in STDIO server

### DIFF
--- a/src/OmniSharp.Stdio/Host.cs
+++ b/src/OmniSharp.Stdio/Host.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using OmniSharp.Endpoint;
 using OmniSharp.Mef;
 using OmniSharp.Models.UpdateBuffer;
@@ -160,6 +161,11 @@ namespace OmniSharp.Stdio
                         }
                         catch (Exception e)
                         {
+                            if (e is AggregateException aggregateEx)
+                            {
+                                e = aggregateEx.Flatten().InnerException;
+                            }
+
                             _writer.WriteLine(new EventPacket()
                             {
                                 Event = "error",
@@ -218,6 +224,11 @@ namespace OmniSharp.Stdio
             }
             catch (Exception e)
             {
+                if (e is AggregateException aggregateEx)
+                {
+                    e = aggregateEx.Flatten().InnerException;
+                }
+
                 // updating the response object here so that the ResponseStream
                 // prints the latest state when being closed
                 response.Success = false;
@@ -241,7 +252,7 @@ namespace OmniSharp.Stdio
             try
             {
                 builder.AppendLine("************ Request ************");
-                builder.Append(json);
+                builder.Append(JToken.Parse(json).ToString(Formatting.Indented));
                 logger.LogDebug(builder.ToString());
             }
             finally
@@ -256,7 +267,7 @@ namespace OmniSharp.Stdio
             try
             {
                 builder.AppendLine("************  Response ************ ");
-                builder.Append(json);
+                builder.Append(JToken.Parse(json).ToString(Formatting.Indented));
                 logger.LogDebug(builder.ToString());
             }
             finally


### PR DESCRIPTION
Instead of logging STDIO Server requests/responses like this:

```
        ************ Request ************
{"Type":"request","Seq":30,"Command":"/findusages","Arguments":{"FileName":"c:\\code\\csharp-scripting-demos\\build\\build.csx","Line":14,"Column":5,"OnlyThisFile":false,"ExcludeDefinition":true}}
[dbug]: OmniSharp.Stdio.Host
        ************  Response ************ 
{"Request_seq":30,"Command":"/findusages","Running":true,"Success":true,"Message":null,"Body":{"QuickFixes":[{"FileName":"c:\\code\\csharp-scripting-demos\\build\\build.csx","Line":41,"Column":25,"EndLine":41,"EndColumn":35,"Text":"if (!Directory.Exists(outputPath)) {","Projects":["build.csx"]},{"FileName":"c:\\code\\csharp-scripting-demos\\build\\build.csx","Line":42,"Column":31,"EndLine":42,"EndColumn":41,"Text":"Directory.CreateDirectory(outputPath);","Projects":["build.csx"]},{"FileName":"c:\\code\\csharp-scripting-demos\\build\\build.csx","Line":47,"Column":39,"EndLine":47,"EndColumn":49,"Text":"p.OutputPath = Path.Combine(\"..\", outputPath);","Projects":["build.csx"]}]},"Seq":185,"Type":"response"}
[dbug]: OmniSharp.Stdio.Host
```

We now log them like this:
```
        ************ Request ************
{
  "Type": "request",
  "Seq": 17,
  "Command": "/findusages",
  "Arguments": {
    "FileName": "c:\\code\\csharp-scripting-demos\\build\\build.csx",
    "Line": 14,
    "Column": 5,
    "OnlyThisFile": false,
    "ExcludeDefinition": true
  }
}
[dbug]: OmniSharp.Stdio.Host
        ************  Response ************ 
{
  "Request_seq": 17,
  "Command": "/findusages",
  "Running": true,
  "Success": true,
  "Message": null,
  "Body": {
    "QuickFixes": [
      {
        "FileName": "c:\\code\\csharp-scripting-demos\\build\\build.csx",
        "Line": 41,
        "Column": 25,
        "EndLine": 41,
        "EndColumn": 35,
        "Text": "if (!Directory.Exists(outputPath)) {",
        "Projects": [
          "build.csx"
        ]
      },
      {
        "FileName": "c:\\code\\csharp-scripting-demos\\build\\build.csx",
        "Line": 42,
        "Column": 31,
        "EndLine": 42,
        "EndColumn": 41,
        "Text": "Directory.CreateDirectory(outputPath);",
        "Projects": [
          "build.csx"
        ]
      },
      {
        "FileName": "c:\\code\\csharp-scripting-demos\\build\\build.csx",
        "Line": 47,
        "Column": 39,
        "EndLine": 47,
        "EndColumn": 49,
        "Text": "p.OutputPath = Path.Combine(\"..\", outputPath);",
        "Projects": [
          "build.csx"
        ]
      }
    ]
  },
  "Seq": 142,
  "Type": "response"
}
```

This very much helps the readability of the log output. Additionally, flattened `AggregateException`.
Note that I didn't change formatting here https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Abstractions/Stdio/Protocol/Packet.cs#L22 as there is no reason to increase the payload size on the protocol - it's just when we log.