### PR TITLE
Format range

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Formatting/FormatRangeService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Formatting/FormatRangeService.cs
@@ -30,12 +30,8 @@ namespace OmniSharp.Roslyn.CSharp.Services.Formatting
             var text = await document.GetTextAsync();
             var start = text.Lines.GetPosition(new LinePosition(request.Line, request.Column));
             var end = text.Lines.GetPosition(new LinePosition(request.EndLine, request.EndColumn));
-            var syntaxTreeRoot = document.GetSyntaxRootAsync().Result;
-            var StartToken = syntaxTreeRoot.FindToken(start);
-            var tokenStart = StartToken.FullSpan.Start;
-            var EndToken = syntaxTreeRoot.FindToken(end);
-            var tokenEnd = EndToken.FullSpan.End;
-            var changes = await FormattingWorker.GetFormattingChanges(document, tokenStart, tokenEnd);
+            var tokenStart = document.GetSyntaxRootAsync().Result.FindToken(start).FullSpan.Start;
+            var changes = await FormattingWorker.GetFormattingChanges(document, tokenStart, end);
 
             return new FormatRangeResponse()
             {

--- a/src/OmniSharp.Roslyn.CSharp/Services/Formatting/FormatRangeService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Formatting/FormatRangeService.cs
@@ -26,11 +26,16 @@ namespace OmniSharp.Roslyn.CSharp.Services.Formatting
             {
                 return null;
             }
-
+           
             var text = await document.GetTextAsync();
             var start = text.Lines.GetPosition(new LinePosition(request.Line, request.Column));
             var end = text.Lines.GetPosition(new LinePosition(request.EndLine, request.EndColumn));
-            var changes = await FormattingWorker.GetFormattingChanges(document, start, end);
+            var syntaxTreeRoot = document.GetSyntaxRootAsync().Result;
+            var StartToken = syntaxTreeRoot.FindToken(start);
+            var tokenStart = StartToken.FullSpan.Start;
+            var EndToken = syntaxTreeRoot.FindToken(end);
+            var tokenEnd = EndToken.FullSpan.End;
+            var changes = await FormattingWorker.GetFormattingChanges(document, tokenStart, tokenEnd);
 
             return new FormatRangeResponse()
             {

--- a/src/OmniSharp.Roslyn.CSharp/Services/Formatting/FormatRangeService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Formatting/FormatRangeService.cs
@@ -26,11 +26,12 @@ namespace OmniSharp.Roslyn.CSharp.Services.Formatting
             {
                 return null;
             }
-           
+
             var text = await document.GetTextAsync();
             var start = text.Lines.GetPosition(new LinePosition(request.Line, request.Column));
             var end = text.Lines.GetPosition(new LinePosition(request.EndLine, request.EndColumn));
-            var tokenStart = document.GetSyntaxRootAsync().Result.FindToken(start).FullSpan.Start;
+            var syntaxTree = await document.GetSyntaxRootAsync();
+            var tokenStart = syntaxTree.FindToken(start).FullSpan.Start;
             var changes = await FormattingWorker.GetFormattingChanges(document, tokenStart, end);
 
             return new FormatRangeResponse()

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
@@ -140,13 +140,13 @@ class C {
                 "{",
                 "    public static void Main()",
                 "    {",
-                "[|       int foo = 1;|]",
+                "[|               int foo = 1;|]",
                 "    }",
                 "}",
             };
 
             await AssertTextChanges(string.Join("\r\n", source),
-                new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 0, NewText = "\n " });
+                new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 7, NewText = "\n" });
         }
 
         [Fact]
@@ -164,7 +164,7 @@ class C {
             };
 
             await AssertTextChanges(string.Join("\r\n", source),
-                new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 0, NewText = "\n " });
+                new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 7, NewText = "\n" });
         }
         
         [Fact]

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
@@ -128,11 +128,8 @@ class C {
                 new LinePositionSpanTextChange { StartLine = 2, StartColumn = 30, EndLine = 3, EndColumn = 0, NewText = "\n " });
         }
 
-
-
-
         [Fact]
-        public async Task TextChangesOnSelectingBeforeFirstPositionInLine()
+        public async Task TextChangesOnStaringSpanBeforeFirstCharacterInLine()
         {
             var source = new[]
             {
@@ -150,7 +147,7 @@ class C {
         }
 
         [Fact]
-        public async Task TextChangesOnSelectingAfterFirstPositionInLine()
+        public async Task TextChangesOnStartingSpanAtFirstCharacterInLine()
         {
             var source = new[]
             {
@@ -166,7 +163,47 @@ class C {
             await AssertTextChanges(string.Join("\r\n", source),
                 new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 7, NewText = "\n" });
         }
-        
+
+        [Fact]
+        public async Task TextChangesOnStartingSpanAfterFirstCharacterInLine()
+        {
+            var source = new[]
+            {
+                "class Program",
+                "{",
+                "    public static void Main()",
+                "    {",
+                "               i[|nt foo = 1;|]",
+                "    }",
+                "}",
+            };
+
+            await AssertTextChanges(string.Join("\r\n", source),
+                new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 7, NewText = "\n" });
+        }
+
+        [Fact]
+        public async Task TextChangesOnStartingSpanAfterFirstCharacterInLineWithMultipleLines()
+        {
+            var source = new[]
+            {
+                "class Program",
+                "{",
+                "    public static void Main()",
+                "    {",
+                "               i[|nt foo = 1;",
+                "               bool b = false;",
+                "               Console.WriteLine(foo);|] ",
+                "    }",
+                "}",
+            };
+
+            await AssertTextChanges(string.Join("\r\n", source),
+                new LinePositionSpanTextChange { StartLine = 5, StartColumn = 30, EndLine = 6, EndColumn = 7, NewText = "\n" },
+                new LinePositionSpanTextChange { StartLine = 4, StartColumn = 27, EndLine = 5, EndColumn = 7, NewText = "\n" },
+                new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 7, NewText = "\n" });
+        }
+
         [Fact]
         public async Task FormatRespectsIndentationSize()
         {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
@@ -341,7 +341,6 @@ class C {
                 var textChanges = GetTextChanges(oldText, response.Changes);
                 var actualText = oldText.WithChanges(textChanges).ToString();
                 Assert.Equal(expected.Replace("\r\n","\n"), actualText.Replace("\r\n","\n"));
-
             }
         }
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
@@ -128,6 +128,45 @@ class C {
                 new LinePositionSpanTextChange { StartLine = 2, StartColumn = 30, EndLine = 3, EndColumn = 0, NewText = "\n " });
         }
 
+
+
+
+        [Fact]
+        public async Task TextChangesOnSelectingBeforeFirstPositionInLine()
+        {
+            var source = new[]
+            {
+                "class Program",
+                "{",
+                "    public static void Main()",
+                "    {",
+                "[|       int foo = 1;|]",
+                "    }",
+                "}",
+            };
+
+            await AssertTextChanges(string.Join("\r\n", source),
+                new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 0, NewText = "\n " });
+        }
+
+        [Fact]
+        public async Task TextChangesOnSelectingAfterFirstPositionInLine()
+        {
+            var source = new[]
+            {
+                "class Program",
+                "{",
+                "    public static void Main()",
+                "    {",
+                "               [|int foo = 1;|]",
+                "    }",
+                "}",
+            };
+
+            await AssertTextChanges(string.Join("\r\n", source),
+                new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 0, NewText = "\n " });
+        }
+        
         [Fact]
         public async Task FormatRespectsIndentationSize()
         {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Models;
 using OmniSharp.Models.CodeFormat;
 using OmniSharp.Models.Format;
@@ -142,8 +144,16 @@ class C {
                 "}",
             };
 
-            await AssertTextChanges(string.Join("\r\n", source),
-                new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 7, NewText = "\n" });
+            var expected =
+@"class Program
+{
+    public static void Main()
+    {
+        int foo = 1;
+    }
+}";
+
+            await AssertTextChanges(string.Join("\r\n", source), expected);
         }
 
         [Fact]
@@ -160,8 +170,16 @@ class C {
                 "}",
             };
 
-            await AssertTextChanges(string.Join("\r\n", source),
-                new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 7, NewText = "\n" });
+            var expected =
+@"class Program
+{
+    public static void Main()
+    {
+        int foo = 1;
+    }
+}";
+
+            await AssertTextChanges(string.Join("\r\n", source), expected);
         }
 
         [Fact]
@@ -178,8 +196,16 @@ class C {
                 "}",
             };
 
-            await AssertTextChanges(string.Join("\r\n", source),
-                new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 7, NewText = "\n" });
+            var expected =
+@"class Program
+{
+    public static void Main()
+    {
+        int foo = 1;
+    }
+}";
+
+            await AssertTextChanges(string.Join("\r\n", source), expected);
         }
 
         [Fact]
@@ -193,16 +219,26 @@ class C {
                 "    {",
                 "               i[|nt foo = 1;",
                 "               bool b = false;",
-                "               Console.WriteLine(foo);|] ",
+                "               Console.WriteLine(foo);|]",
                 "    }",
                 "}",
             };
 
-            await AssertTextChanges(string.Join("\r\n", source),
-                new LinePositionSpanTextChange { StartLine = 5, StartColumn = 30, EndLine = 6, EndColumn = 7, NewText = "\n" },
-                new LinePositionSpanTextChange { StartLine = 4, StartColumn = 27, EndLine = 5, EndColumn = 7, NewText = "\n" },
-                new LinePositionSpanTextChange { StartLine = 3, StartColumn = 5, EndLine = 4, EndColumn = 7, NewText = "\n" });
+            var expected =
+@"class Program
+{
+    public static void Main()
+    {
+        int foo = 1;
+        bool b = false;
+        Console.WriteLine(foo);
+    }
+}";
+
+            await AssertTextChanges(string.Join("\r\n", source), expected);
         }
+
+
 
         [Fact]
         public async Task FormatRespectsIndentationSize()
@@ -275,6 +311,53 @@ class C {
                     Assert.Equal(expected[i].EndColumn, actual[i].EndColumn);
                 }
             }
+        }
+
+        private async Task AssertTextChanges(string source, string expected)
+        {
+            var testFile = new TestFile("dummy.cs", source);
+
+            using (var host = CreateOmniSharpHost(testFile))
+            {
+                var span = testFile.Content.GetSpans().Single();
+                var range = testFile.Content.GetRangeFromSpan(span);
+
+                var request = new FormatRangeRequest()
+                {
+                    Buffer = testFile.Content.Code,
+                    FileName = testFile.FileName,
+                    Line = range.Start.Line,
+                    Column = range.Start.Offset,
+                    EndLine = range.End.Line,
+                    EndColumn = range.End.Offset
+                };
+
+                var requestHandler = host.GetRequestHandler<FormatRangeService>(OmniSharpEndpoints.FormatRange);
+
+                var response = await requestHandler.Handle(request);
+                var actual = response.Changes.ToArray();
+
+                var oldText = testFile.Content.Text;
+                var textChanges = GetTextChanges(oldText, response.Changes);
+                var actualText = oldText.WithChanges(textChanges).ToString();
+                Assert.Equal(expected.Replace("\r\n","\n"), actualText.Replace("\r\n","\n"));
+
+            }
+        }
+
+        public static IEnumerable<TextChange> GetTextChanges(SourceText oldText, IEnumerable<LinePositionSpanTextChange> changes)
+        {
+            var textChanges = new List<TextChange>();
+            foreach( var change in changes)
+            {
+                var startPosition = new LinePosition(change.StartLine, change.StartColumn);
+                var endPosition = new LinePosition(change.EndLine, change.EndColumn);
+                var span = oldText.Lines.GetTextSpan(new LinePositionSpan(startPosition, endPosition));
+                var newText = change.NewText;
+                textChanges.Add(new TextChange(span, newText));
+            }
+
+            return textChanges.OrderBy(change => change.Span);
         }
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
@@ -336,7 +336,7 @@ class C {
         public static IEnumerable<TextChange> GetTextChanges(SourceText oldText, IEnumerable<LinePositionSpanTextChange> changes)
         {
             var textChanges = new List<TextChange>();
-            foreach(var change in changes)
+            foreach (var change in changes)
             {
                 var startPosition = new LinePosition(change.StartLine, change.StartColumn);
                 var endPosition = new LinePosition(change.EndLine, change.EndColumn);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
@@ -133,16 +133,14 @@ class C {
         [Fact]
         public async Task TextChangesOnStaringSpanBeforeFirstCharacterInLine()
         {
-            var source = new[]
-            {
-                "class Program",
-                "{",
-                "    public static void Main()",
-                "    {",
-                "[|               int foo = 1;|]",
-                "    }",
-                "}",
-            };
+            var source =
+ @"class Program
+{
+    public static void Main()
+    {
+         [|          int foo = 1;|]
+    }
+}";
 
             var expected =
 @"class Program
@@ -153,23 +151,20 @@ class C {
     }
 }";
 
-            await AssertTextChanges(string.Join("\r\n", source), expected);
+            await AssertTextChanges(source, expected);
         }
 
         [Fact]
         public async Task TextChangesOnStartingSpanAtFirstCharacterInLine()
         {
-            var source = new[]
-            {
-                "class Program",
-                "{",
-                "    public static void Main()",
-                "    {",
-                "               [|int foo = 1;|]",
-                "    }",
-                "}",
-            };
-
+            var source =
+ @"class Program
+{
+    public static void Main()
+    {
+                   [|int foo = 1;|]
+    }
+}";
             var expected =
 @"class Program
 {
@@ -179,22 +174,20 @@ class C {
     }
 }";
 
-            await AssertTextChanges(string.Join("\r\n", source), expected);
+            await AssertTextChanges(source, expected);
         }
 
         [Fact]
         public async Task TextChangesOnStartingSpanAfterFirstCharacterInLine()
         {
-            var source = new[]
-            {
-                "class Program",
-                "{",
-                "    public static void Main()",
-                "    {",
-                "               i[|nt foo = 1;|]",
-                "    }",
-                "}",
-            };
+            var source =
+ @"class Program
+{
+    public static void Main()
+    {
+                   i[|nt foo = 1;|]
+    }
+}";
 
             var expected =
 @"class Program
@@ -205,24 +198,22 @@ class C {
     }
 }";
 
-            await AssertTextChanges(string.Join("\r\n", source), expected);
+            await AssertTextChanges(source, expected);
         }
 
         [Fact]
         public async Task TextChangesOnStartingSpanAfterFirstCharacterInLineWithMultipleLines()
         {
-            var source = new[]
-            {
-                "class Program",
-                "{",
-                "    public static void Main()",
-                "    {",
-                "               i[|nt foo = 1;",
-                "               bool b = false;",
-                "               Console.WriteLine(foo);|]",
-                "    }",
-                "}",
-            };
+            var source =
+@"class Program
+{
+    public static void Main()
+    {
+                i[|nt foo = 1;
+                    bool b = false;
+                        Console.WriteLine(foo);|]
+    }
+}";
 
             var expected =
 @"class Program
@@ -235,10 +226,8 @@ class C {
     }
 }";
 
-            await AssertTextChanges(string.Join("\r\n", source), expected);
+            await AssertTextChanges(source, expected);
         }
-
-
 
         [Fact]
         public async Task FormatRespectsIndentationSize()
@@ -347,7 +336,7 @@ class C {
         public static IEnumerable<TextChange> GetTextChanges(SourceText oldText, IEnumerable<LinePositionSpanTextChange> changes)
         {
             var textChanges = new List<TextChange>();
-            foreach( var change in changes)
+            foreach(var change in changes)
             {
                 var startPosition = new LinePosition(change.StartLine, change.StartColumn);
                 var endPosition = new LinePosition(change.EndLine, change.EndColumn);


### PR DESCRIPTION
Issue : https://github.com/OmniSharp/omnisharp-vscode/issues/214

On selecting after the first (alphanumeric) character in "Format Selection" , the code was not trimming the preceding white spaces in the first line of the selection. Modified the code to set the start of the span to the full span of the intersecting token and added the relevant test cases.

Please review : @DustinCampbell @TheRealPiotrP @rchande 