### PR TITLE
Roslyn 2.6.0 + C# 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [not yet released]
+* Updated to Roslyn 2.6.1 packages - C# 7.2 support, PR: [#1055](https://github.com/OmniSharp/omnisharp-roslyn/pull/1055)
+
 ## [1.28.0] - 2017-12-14
 
 * Fixed issue with loading XML documentation for `#r` assembly references in CSX scripts ([#1026](https://github.com/OmniSharp/omnisharp-roslyn/issues/1026), PR: [#1027](https://github.com/OmniSharp/omnisharp-roslyn/pull/1027))

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -13,12 +13,12 @@
     <MicrosoftBuildFrameworkVersion>15.3.409</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildTasksCoreVersion>15.3.409</MicrosoftBuildTasksCoreVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.3.409</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftCodeAnalysisCommonVersion>2.6.0</MicrosoftCodeAnalysisCommonVersion>
-    <MicrosoftCodeAnalysisCSharpVersion>2.6.0</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesVersion>2.6.0</MicrosoftCodeAnalysisCSharpFeaturesVersion>
-    <MicrosoftCodeAnalysisCSharpScriptingVersion>2.6.0</MicrosoftCodeAnalysisCSharpScriptingVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>2.6.0</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonVersion>2.6.0</MicrosoftCodeAnalysisWorkspacesCommonVersion>
+    <MicrosoftCodeAnalysisCommonVersion>2.6.1</MicrosoftCodeAnalysisCommonVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>2.6.1</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesVersion>2.6.1</MicrosoftCodeAnalysisCSharpFeaturesVersion>
+    <MicrosoftCodeAnalysisCSharpScriptingVersion>2.6.1</MicrosoftCodeAnalysisCSharpScriptingVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>2.6.1</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonVersion>2.6.1</MicrosoftCodeAnalysisWorkspacesCommonVersion>
     <MicrosoftExtensionsCachingMemoryVersion>1.1.0</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsCommandLineUtilsVersion>1.1.0</MicrosoftExtensionsCommandLineUtilsVersion>
     <MicrosoftExtensionsConfigurationVersion>1.1.0</MicrosoftExtensionsConfigurationVersion>

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -13,12 +13,12 @@
     <MicrosoftBuildFrameworkVersion>15.3.409</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildTasksCoreVersion>15.3.409</MicrosoftBuildTasksCoreVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.3.409</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftCodeAnalysisCommonVersion>2.4.0</MicrosoftCodeAnalysisCommonVersion>
-    <MicrosoftCodeAnalysisCSharpVersion>2.4.0</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesVersion>2.4.0</MicrosoftCodeAnalysisCSharpFeaturesVersion>
-    <MicrosoftCodeAnalysisCSharpScriptingVersion>2.4.0</MicrosoftCodeAnalysisCSharpScriptingVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>2.4.0</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonVersion>2.4.0</MicrosoftCodeAnalysisWorkspacesCommonVersion>
+    <MicrosoftCodeAnalysisCommonVersion>2.6.0</MicrosoftCodeAnalysisCommonVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>2.6.0</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesVersion>2.6.0</MicrosoftCodeAnalysisCSharpFeaturesVersion>
+    <MicrosoftCodeAnalysisCSharpScriptingVersion>2.6.0</MicrosoftCodeAnalysisCSharpScriptingVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>2.6.0</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonVersion>2.6.0</MicrosoftCodeAnalysisWorkspacesCommonVersion>
     <MicrosoftExtensionsCachingMemoryVersion>1.1.0</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsCommandLineUtilsVersion>1.1.0</MicrosoftExtensionsCommandLineUtilsVersion>
     <MicrosoftExtensionsConfigurationVersion>1.1.0</MicrosoftExtensionsConfigurationVersion>

--- a/src/OmniSharp.Abstractions/Configuration.cs
+++ b/src/OmniSharp.Abstractions/Configuration.cs
@@ -4,7 +4,7 @@ namespace OmniSharp
     {
         public static bool ZeroBasedIndices = false;
 
-        public const string RoslynVersion = "2.4.0.0";
+        public const string RoslynVersion = "2.6.0.0";
         public const string RoslynPublicKeyToken = "31bf3856ad364e35";
 
         public readonly static string RoslynFeatures = GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.Features");

--- a/src/OmniSharp.Http/app.config
+++ b/src/OmniSharp.Http/app.config
@@ -7,15 +7,15 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0"/>
             </dependentAssembly>
 
             <dependentAssembly>

--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
@@ -46,6 +46,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 case "6": return LanguageVersion.CSharp6;
                 case "7": return LanguageVersion.CSharp7;
                 case "7.1": return LanguageVersion.CSharp7_1;
+                case "7.2": return LanguageVersion.CSharp7_2;
                 default: return LanguageVersion.Default;
             }
         }

--- a/src/OmniSharp.Stdio/app.config
+++ b/src/OmniSharp.Stdio/app.config
@@ -7,15 +7,15 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0"/>
             </dependentAssembly>
 
             <dependentAssembly>

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
@@ -61,10 +61,10 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         public async Task CanFindOverride(string filename)
         {
             const string code = @"
-                public class BaseClass { public abstract Some$$Method() {} }
+                public abstract class BaseClass { public abstract void Some$$Method(); }
                 public class SomeClass : BaseClass
                 {
-                    public override SomeMethod() {}
+                    public override void SomeMethod() {}
                 }";
 
             var implementations = await FindImplementationsAsync(code, filename);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -444,6 +444,25 @@ class C
             ContainsCompletions(completions.Select(c => c.CompletionText), new[] { "number1", "number2" });
         }
 
+        [Fact]
+        public async Task Scripting_by_default_returns_completions_for_CSharp7_2()
+        {
+            const string source =
+                @"
+                  public class Foo { private protected int myValue = 0; }
+                  public class Bar : Foo
+                  {
+                    public Bar()
+                    {
+                        var x = myv$$
+                    }
+                  }
+                ";
+
+            var completions = await FindCompletionsAsync("dummy.csx", source);
+            ContainsCompletions(completions.Select(c => c.CompletionText), new[] { "myValue" });
+        }
+
         private void ContainsCompletions(IEnumerable<string> completions, params string[] expected)
         {
             if (!completions.SequenceEqual(expected))

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -115,7 +115,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
     public static void Main(){
         Foo($$);
     }
-    public static Foo(bool b, int n = 1234)
+    public static void Foo(bool b, int n = 1234)
     {
     }
 }";

--- a/tests/app.config
+++ b/tests/app.config
@@ -7,15 +7,15 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0"/>
             </dependentAssembly>
 
             <dependentAssembly>


### PR DESCRIPTION
 - upgraded to Roslyn 2.6.0
 - added C# 7.2 support
 - added a C# 7.2 test for scripting (scripting by design should default to latest language version)
 - fixed some tests that contained invalid C#