### PR TITLE
Update Cake.Scripting dependencies to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All changes to the project will be documented in this file.
 * Improvements to the Cake bakery resolver to resolve from both OmniSharp options and PATH. (PR: [#1047](https://github.com/OmniSharp/omnisharp-roslyn/pull/1047))
 * Ensure that the Cake.Core assembly is not locked on disk when loading the host object type. (PR: [#1044](https://github.com/OmniSharp/omnisharp-roslyn/pull/1044))
 * Added internal support for watching for changes by file extension. (PR: [#1053](https://github.com/OmniSharp/omnisharp-roslyn/pull/1053))
+* Updated `Cake.Scripting.Transport` dependencies to 0.2.0 in order to improve performance when working with Cake files. (PR: [#1057](https://github.com/OmniSharp/omnisharp-roslyn/pull/1057))
 
 ## [1.27.2] - 2017-11-10
 

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <CakeScriptinTransportVersion>0.1.0</CakeScriptinTransportVersion>
+    <CakeScriptinTransportVersion>0.2.0</CakeScriptinTransportVersion>
     <DotnetScriptDependencyModelVersion>0.3.0</DotnetScriptDependencyModelVersion>
     <DotnetScriptDependencyModelNuGetVersion>0.3.0</DotnetScriptDependencyModelNuGetVersion>
     <MicrosoftAspNetCoreDiagnosticsVersion>1.1.0</MicrosoftAspNetCoreDiagnosticsVersion>

--- a/test-assets/test-projects/CakeProject/tools/packages.config
+++ b/test-assets/test-projects/CakeProject/tools/packages.config
@@ -1,4 +1,4 @@
 <packages>
     <package id="Cake" version="0.23.0" />
-    <package id="Cake.Bakery" version="0.1.0" />
+    <package id="Cake.Bakery" version="0.2.0" />
 </packages>


### PR DESCRIPTION
Just leaving this here as a reminder that it would be good to get `Cake.Scripting` 0.2.x into next OmniSharp-Roslyn release as it will bring significant performance improvements to Cake.

0.2.x is not released yet (therefore the beta reference), but I'll make sure to create a release right before you'll start preparing the OmniSharp-Roslyn release.