### PR TITLE
Fix typo that breaks discovery of more than one installed Visual Studio

### DIFF
--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/VisualStudioInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/VisualStudioInstanceProvider.cs
@@ -69,7 +69,7 @@ namespace OmniSharp.MSBuild.Discovery.Providers
                         }
                     }
                 }
-                while (fetched < 0);
+                while (fetched > 0);
 
                 return builder.ToImmutable();
             }


### PR DESCRIPTION
Oops