### PR TITLE
Retain single leading space when appending string in TypeLookUp

### DIFF
--- a/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
@@ -140,7 +140,25 @@ namespace OmniSharp.Models.TypeLookup
                     return null;
                 }
             }
-            return new DocumentationComment(summaryText.ToString(), typeParamElements.Select(s => s.ToString()).ToArray(), paramElements.Select(s => s.ToString()).ToArray(), returnsText.ToString(), remarksText.ToString(), exampleText.ToString(), valueText.ToString(), exception.Select(s => s.ToString()).ToArray());
+            /* return new DocumentationComment(
+                 TrimMultipleSpaces(summaryText),
+                 typeParamElements.Select(s => TrimMultipleSpaces(s)).ToArray(),
+                 paramElements.Select(s => TrimMultipleSpaces(s)).ToArray(),
+                 TrimMultipleSpaces(returnsText),
+                 TrimMultipleSpaces(remarksText),
+                 TrimMultipleSpaces(exampleText),
+                 TrimMultipleSpaces(valueText),
+                 exception.Select(s => TrimMultipleSpaces(s)).ToArray());*/
+            return new DocumentationComment(
+               summaryText.ToString(),
+               typeParamElements.Select(s => s.ToString()).ToArray(),
+               paramElements.Select(s => s.ToString()).ToArray(),
+               returnsText.ToString(),
+               remarksText.ToString(),
+               exampleText.ToString(),
+               valueText.ToString(),
+               exception.Select(s => s.ToString()).ToArray());
+
         }
 
         private static string TrimMultiLineString(string input, string lineEnding)
@@ -176,6 +194,11 @@ namespace OmniSharp.Models.TypeLookup
             return " " + input.Substring(offset);
         }
 
-        //private static string TrimMultipleSpaces()
+        // Replace multiple spaces occuring together with a single space
+        private static string TrimMultipleSpaces(string input)
+        {
+            //var convertedString = input.ToString();
+            return System.Text.RegularExpressions.Regex.Replace(input, @"[ ]+", " ");
+        }
     }
 }

--- a/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
@@ -147,7 +147,7 @@ namespace OmniSharp.Models.TypeLookup
         private static string TrimMultiLineString(string input, string lineEnding)
         {
             var lines = input.Split(new string[] { "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
-            return string.Join(lineEnding, lines.Select(l => RetainSingleLeadingSpace(l)));
+            return string.Join(lineEnding, lines.Select(l => TrimStartRetainingSingleLeadingSpace(l)));
         }
 
         private static string GetCref(string cref)
@@ -167,14 +167,13 @@ namespace OmniSharp.Models.TypeLookup
             return cref + " ";
         }
 
-        private static string RetainSingleLeadingSpace(string input)
+        private static string TrimStartRetainingSingleLeadingSpace(string input)
         {
             if (string.IsNullOrWhiteSpace(input))
                 return string.Empty;
             if (!Char.IsWhiteSpace(input[0]))
                 return input;
-            int offset = input.TakeWhile(c => char.IsWhiteSpace(c)).Count();
-            return " " + input.Substring(offset);
+            return $" {input.TrimStart()}";
         }
     }
 

--- a/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
@@ -146,7 +146,7 @@ namespace OmniSharp.Models.TypeLookup
         private static string TrimMultiLineString(string input, string lineEnding)
         {
             var lines = input.Split(new string[] { "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
-            return string.Join(lineEnding, lines.Select(l => l.TrimStart()));
+            return string.Join(lineEnding, lines.Select(l => TrimLeadingSpaces(l)));
         }
 
         private static string GetCref(string cref)
@@ -164,6 +164,14 @@ namespace OmniSharp.Models.TypeLookup
                 return cref.Substring(2, cref.Length - 2) + " ";
             }
             return cref + " ";
+        }
+
+        private static string TrimLeadingSpaces(string input)
+        {
+            if (!input.StartsWith(@"\s"))
+                return input;
+            int offset = input.TakeWhile(c => char.IsWhiteSpace(c)).Count();
+            return " " + input.Substring(offset);
         }
     }
 }

--- a/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
@@ -171,7 +171,7 @@ namespace OmniSharp.Models.TypeLookup
         {
             if (string.IsNullOrWhiteSpace(input))
                 return string.Empty;
-            if (!Char.IsWhiteSpace(input[0]))
+            if (!char.IsWhiteSpace(input[0]))
                 return input;
             return $" {input.TrimStart()}";
         }

--- a/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
@@ -147,7 +147,7 @@ namespace OmniSharp.Models.TypeLookup
         private static string TrimMultiLineString(string input, string lineEnding)
         {
             var lines = input.Split(new string[] { "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
-            return string.Join(lineEnding, lines.Select(l => TrimLeadingSpaces(l)));
+            return string.Join(lineEnding, lines.Select(l => RetainSingleLeadingSpace(l)));
         }
 
         private static string GetCref(string cref)
@@ -167,7 +167,7 @@ namespace OmniSharp.Models.TypeLookup
             return cref + " ";
         }
 
-        private static string TrimLeadingSpaces(string input)
+        private static string RetainSingleLeadingSpace(string input)
         {
             if (string.IsNullOrWhiteSpace(input))
                 return string.Empty;

--- a/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
@@ -168,10 +168,14 @@ namespace OmniSharp.Models.TypeLookup
 
         private static string TrimLeadingSpaces(string input)
         {
-            if (!input.StartsWith(@"\s"))
+            if (string.IsNullOrWhiteSpace(input))
+                return string.Empty;
+            if (!Char.IsWhiteSpace(input[0]))
                 return input;
             int offset = input.TakeWhile(c => char.IsWhiteSpace(c)).Count();
             return " " + input.Substring(offset);
         }
+
+        //private static string TrimMultipleSpaces()
     }
 }

--- a/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/TypeLookup/DocumentationComment.cs
@@ -176,13 +176,6 @@ namespace OmniSharp.Models.TypeLookup
             int offset = input.TakeWhile(c => char.IsWhiteSpace(c)).Count();
             return " " + input.Substring(offset);
         }
-
-        // Replace multiple spaces occuring together with a single space
-        private static string TrimMultipleSpaces(string input)
-        {
-            //var convertedString = input.ToString();
-            return System.Text.RegularExpressions.Regex.Replace(input, @"[ ]+", " ");
-        }
     }
 
     class DocumentationItemBuilder

--- a/src/OmniSharp.Roslyn.CSharp/Services/DocumentationConverter.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/DocumentationConverter.cs
@@ -109,7 +109,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Documentation
         private static string TrimMultiLineString(string input, string lineEnding)
         {
             var lines = input.Split(new string[] { "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
-            return string.Join(lineEnding, lines.Select(l => l.TrimStart()));
+            return string.Join(lineEnding, lines.Select(l => TrimLeadingSpaces(l)));
         }
 
         private static string GetCref(string cref)
@@ -134,6 +134,14 @@ namespace OmniSharp.Roslyn.CSharp.Services.Documentation
             if (string.IsNullOrEmpty(xmlDocumentation))
                 return null;
             return DocumentationComment.From(xmlDocumentation, lineEnding);
+        }
+
+        private static string TrimLeadingSpaces(string input)
+        {
+            if (!input.StartsWith(@"\s"))
+                return input;
+            int offset = input.TakeWhile(c => char.IsWhiteSpace(c)).Count();
+            return " " + input.Substring(offset);
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/DocumentationConverter.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/DocumentationConverter.cs
@@ -138,7 +138,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Documentation
 
         private static string TrimLeadingSpaces(string input)
         {
-            if (!input.StartsWith(@"\s"))
+            if (!Char.IsWhiteSpace(input[0]))
                 return input;
             int offset = input.TakeWhile(c => char.IsWhiteSpace(c)).Count();
             return " " + input.Substring(offset);

--- a/src/OmniSharp.Roslyn.CSharp/Services/DocumentationConverter.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/DocumentationConverter.cs
@@ -109,7 +109,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Documentation
         private static string TrimMultiLineString(string input, string lineEnding)
         {
             var lines = input.Split(new string[] { "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
-            return string.Join(lineEnding, lines.Select(l => TrimLeadingSpaces(l)));
+            return string.Join(lineEnding, lines.Select(l => l.TrimStart()));
         }
 
         private static string GetCref(string cref)
@@ -134,14 +134,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Documentation
             if (string.IsNullOrEmpty(xmlDocumentation))
                 return null;
             return DocumentationComment.From(xmlDocumentation, lineEnding);
-        }
-
-        private static string TrimLeadingSpaces(string input)
-        {
-            if (!Char.IsWhiteSpace(input[0]))
-                return input;
-            int offset = input.TakeWhile(c => char.IsWhiteSpace(c)).Count();
-            return " " + input.Substring(offset);
         }
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/TypeLookupFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/TypeLookupFacts.cs
@@ -540,9 +540,9 @@ Here's how you could make a second paragraph in a description.";
             string content = @"
 public class TestClass
 {
-    ///<summary>DoWork is a method in the TestClass class.
-    ///<seealso cref=""TestClass.Main""/>
-    ///</summary>
+    /// <summary>DoWork is a method in the TestClass class.
+    /// <seealso cref=""TestClass.Main""/>
+    /// </summary>
             public static void Do$$Work(int Int1)
             {
             }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/TypeLookupFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/TypeLookupFacts.cs
@@ -546,9 +546,9 @@ Here's how you could make a second paragraph in a description.";
             string content = @"
 public class TestClass
 {
-    /// <summary>DoWork is a method in the TestClass class.
-    /// <seealso cref=""TestClass.Main""/>
-    /// </summary>
+    ///<summary>DoWork is a method in the TestClass class.
+    ///<seealso cref=""TestClass.Main""/>
+    ///</summary>
             public static void Do$$Work(int Int1)
             {
             }
@@ -639,6 +639,23 @@ class testissue
             var expectedReturns =
             @"Returns: Returns an array of type T .";
             Assert.Equal(expectedReturns, response.StructuredDocumentation.ReturnsText);
+        }
+
+        [Fact]
+        public async Task StructuredDocumentationSpaceBeforeText()
+        {
+            string content = @"
+public class TestClass
+{
+    /// <summary><c>DoWork</c> is a method in the <c>TestClass</c> class.</summary>
+    public static void Do$$Work(int Int1)
+    {
+    }
+}";
+            var response = await GetTypeLookUpResponse(content);
+            var expected =
+            @"Summary: DoWork is a method in the TestClass class.";
+            Assert.Equal(expected, response.StructuredDocumentation.SummaryText);
         }
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/TypeLookupFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/TypeLookupFacts.cs
@@ -458,7 +458,7 @@ public class TestClass
 }";
             var response = await GetTypeLookUpResponse(content);
             var expected =
-            @"Summary: DoWork is a method in the TestClass class. System.Console.WriteLine(System.String) for information about output statements.";
+            @"Summary: DoWork is a method in the TestClass class. System.Console.WriteLine(System.String)  for information about output statements.";
             Assert.Equal(expected, response.StructuredDocumentation.SummaryText);
         }
 
@@ -505,7 +505,7 @@ public class TestClass
 }";
             var response = await GetTypeLookUpResponse(content);
             var expected =
-            @"Example: This sample shows how to call the TestClass.GetZero method.
+            @"Example: This sample shows how to call the TestClass.GetZero  method.
 
     class TestClass 
     {


### PR DESCRIPTION
Fixes: #1046 

Before concatenating the string, a TrimStart was being called that removed all the whitespaces. Added a call to a function that retains a single space if the string begins with a whitespace. Added a test for the same and modified the existing tests to match the behaviour.

Please review : @DustinCampbell @TheRealPiotrP @rchande 