### PR TITLE
don't parse ASP.NET websites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All changes to the project will be documented in this file.
 
-## [1.28.0] - not yet released
+## [1.28.0] - 2017-12-14
 
 * Fixed issue with loading XML documentation for `#r` assembly references in CSX scripts ([#1026](https://github.com/OmniSharp/omnisharp-roslyn/issues/1026), PR: [#1027](https://github.com/OmniSharp/omnisharp-roslyn/pull/1027))
 * Updated the `/v2/runcodeaction` end point to return document "renames" and "opens" that a code action might perform. (PR: [#1023](https://github.com/OmniSharp/omnisharp-roslyn/pull/1023))

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -134,7 +134,7 @@ namespace OmniSharp.MSBuild
 
             foreach (var project in solutionFile.Projects)
             {
-                if (project.IsSolutionFolder)
+                if (project.IsSolutionFolder || project.IsAspWebsite())
                 {
                     continue;
                 }

--- a/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
+++ b/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
@@ -43,6 +43,11 @@ namespace OmniSharp.MSBuild.SolutionParsing
             Sections = sections;
         }
 
+        public bool IsAspWebsite()
+        {
+            return RelativePath.StartsWith("http://");
+        }
+
         public static ProjectBlock Parse(string headerLine, Scanner scanner)
         {
             var match = s_lazyProjectHeader.Value.Match(headerLine);

--- a/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
+++ b/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
@@ -45,7 +45,8 @@ namespace OmniSharp.MSBuild.SolutionParsing
 
         public bool IsAspWebsite()
         {
-            return RelativePath.StartsWith("http://");
+            var match = Regex.Match(RelativePath, "http://", RegexOptions.IgnoreCase);
+            return match.Success;
         }
 
         public static ProjectBlock Parse(string headerLine, Scanner scanner)


### PR DESCRIPTION
Fixes issue "The given path's format is not supported" #1036 when you have an ASP.NET website in your solution. 