### PR TITLE
Build on ArchLinux

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -48,7 +48,7 @@ bool AllowLegacyTests()
 
     if (platform.IsLinux)
     {
-        var version = platform.Version.ToString();
+        var version = $"{platform.Version}";
 
         // Taken from https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
         switch (platform.DistroName)


### PR DESCRIPTION
This is my attempt at trying to get this build on ArchLinux (addresses #943). Creating a PR, so that it would be easier to discuss.

The version of the distro is null, so this is the fix I needed to do. Then I installed the following packages from AUR and stable repositories:
```bash
~/src/github/omnisharp-roslyn arch-build 59s
❯ pacman -Qs dotnet
local/dotnet 2.0.0-1
    Meta package to pull in the latest stable dotnet package
local/dotnet-host 2.0.3-1
    A generic driver for the .NET Core Command Line Interface
local/dotnet-runtime 2.0.3-1
    The .NET Core runtime
local/dotnet-runtime-1.1-compat 1.1.5-2
    Provides the .NET core shared framework 1.1
local/dotnet-sdk-2.0 1:2.0.3-1
    A command line utility for building, testing, packaging and running .NET Core applications and libraries

~/src/github/omnisharp-roslyn arch-build
❯ pacman -Qs mono
local/mono-beta 5.4.0.201-1
    Free implementation of the .NET platform including runtime and compiler

~/src/github/omnisharp-roslyn arch-build
❯ pacman -Qs msbuild
local/msbuild-stable 15.4_xamarinxplat.2017.09.14.16.14_0xamarin1_ubuntu1404b1-3
    Xamarin implementation of the Microsoft build system
```

Then trying to build it with:
```bash
~/src/github/omnisharp-roslyn arch-build
❯ ./build.sh --use-global-dotnet-sdk
```

Currently it fails with:
```
Build FAILED.

"/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj" (default target) (1) ->
(GenerateBuildDependencyFile target) ->
  /usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018: The "GenerateDepsFile" task failed unexpectedly. [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018: System.TypeInitializationException: The type initializer for 'Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment' threw an exception. ---> System.NullReferenceException: Object reference not set to an instance of an object [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.DotNet.PlatformAbstractions.Native.PlatformApis.NormalizeDistroInfo (Microsoft.DotNet.PlatformAbstractions.Native.PlatformApis+DistroInfo distroInfo) [0x00000] in <6cee8c6529ed46ccb5b504eab8905bad>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.DotNet.PlatformAbstractions.Native.PlatformApis.LoadDistroInfo () [0x00095] in <6cee8c6529ed46ccb5b504eab8905bad>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at System.Lazy`1[T].CreateValue () [0x00081] in <86946becea244f64b084ee9718b6e104>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at System.Lazy`1[T].LazyInitValue () [0x00080] in <86946becea244f64b084ee9718b6e104>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at System.Lazy`1[T].get_Value () [0x0003a] in <86946becea244f64b084ee9718b6e104>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.DotNet.PlatformAbstractions.Native.PlatformApis.GetDistroVersionId () [0x00000] in <6cee8c6529ed46ccb5b504eab8905bad>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.DotNet.PlatformAbstractions.Native.PlatformApis.GetOSVersion () [0x0002b] in <6cee8c6529ed46ccb5b504eab8905bad>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment..cctor () [0x00014] in <6cee8c6529ed46ccb5b504eab8905bad>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:    --- End of inner exception stack trace --- [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.Extensions.DependencyModel.Resolution.DotNetReferenceAssembliesPathResolver.GetDefaultDotNetReferenceAssembliesPath (Microsoft.Extensions.DependencyModel.IFileSystem fileSystem) [0x00000] in <5af45d7022ef444082f2ee77b03e0224>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.Extensions.DependencyModel.Resolution.DotNetReferenceAssembliesPathResolver.Resolve (Microsoft.Extensions.DependencyModel.IEnvironment envirnment, Microsoft.Extensions.DependencyModel.IFileSystem fileSystem) [0x00016] in <5af45d7022ef444082f2ee77b03e0224>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.Extensions.DependencyModel.Resolution.DotNetReferenceAssembliesPathResolver.Resolve () [0x0000a] in <5af45d7022ef444082f2ee77b03e0224>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.NET.Build.Tasks.FrameworkReferenceResolver.GetDefaultReferenceAssembliesPath () [0x00000] in <b5accd71ae844201a740485e2071fb28>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.NET.Build.Tasks.GenerateDepsFile.ExecuteCore () [0x000e1] in <b5accd71ae844201a740485e2071fb28>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.NET.Build.Tasks.TaskBase.Execute () [0x00000] in <b5accd71ae844201a740485e2071fb28>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute () [0x00023] in <75cf81f9e79c4309b9cb3d9a1e0dde06>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]
/usr/lib/mono/msbuild/15.0/bin/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.Sdk.targets(114,5): error MSB4018:   at Microsoft.Build.BackEnd.TaskBuilder+<ExecuteInstantiatedTask>d__26.MoveNext () [0x0022d] in <75cf81f9e79c4309b9cb3d9a1e0dde06>:0  [/home/ia/src/github/omnisharp-roslyn/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj]

    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:23.68
An error occurred when executing task 'BuildTest'.
Error: One or more errors occurred.
```

Could anyone help me understand the reason of the above?