### PR TITLE
allow plugins to be specified by a dll file path

### DIFF
--- a/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
+++ b/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
@@ -40,15 +40,17 @@ namespace OmniSharp.Services
             }
         }
 
-        public static Assembly LoadByAssemblyNameOrPath(string assemblyName)
+        public static Assembly LoadByAssemblyNameOrPath(
+            this IAssemblyLoader loader,
+            string assemblyName)
         {
             if (File.Exists(assemblyName))
             {
-                return Assembly.LoadFrom(assemblyName);
+                return loader.LoadFrom(assemblyName);
             }
             else
             {
-                return Assembly.Load(assemblyName);
+                return loader.Load(assemblyName);
             }
         }
 
@@ -56,7 +58,7 @@ namespace OmniSharp.Services
         {
             foreach (var assemblyName in assemblyNames)
             {
-                yield return LoadByAssemblyNameOrPath(assemblyName);
+                yield return loader.LoadByAssemblyNameOrPath(assemblyName);
             }
         }
     }

--- a/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
+++ b/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
@@ -44,7 +44,7 @@ namespace OmniSharp.Services
         {
             if (File.Exists(assemblyName))
             {
-                return Assembly.LoadFile(assemblyName);
+                return Assembly.LoadFrom(assemblyName);
             }
             else
             {

--- a/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
+++ b/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 
 namespace OmniSharp.Services
@@ -36,6 +37,26 @@ namespace OmniSharp.Services
             foreach (var name in assemblyNames)
             {
                 yield return Load(loader, name);
+            }
+        }
+
+        public static Assembly LoadByAssemblyNameOrPath(string assemblyName)
+        {
+            if (File.Exists(assemblyName))
+            {
+                return Assembly.LoadFile(assemblyName);
+            }
+            else
+            {
+                return Assembly.Load(assemblyName);
+            }
+        }
+
+        public static IEnumerable<Assembly> LoadByAssemblyNameOrPath(this IAssemblyLoader loader, IEnumerable<string>  assemblyNames)
+        {
+            foreach (var assemblyName in assemblyNames)
+            {
+                yield return LoadByAssemblyNameOrPath(assemblyName);
             }
         }
     }

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -3,7 +3,6 @@ using System.Composition.Hosting;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
@@ -91,10 +90,12 @@ namespace OmniSharp.LanguageServerProtocol
 
             var eventEmitter = new LanguageServerEventEmitter(_server);
             var plugins = _application.CreatePluginAssemblies();
+
+            var assemblyLoader = _serviceProvider.GetRequiredService<IAssemblyLoader>();
             var compositionHostBuilder = new CompositionHostBuilder(_serviceProvider, _environment, eventEmitter)
                 .WithOmniSharpAssemblies()
                 .WithAssemblies(typeof(LanguageServerHost).Assembly)
-                .WithAssemblies(plugins.AssemblyNames.Select(Assembly.Load).ToArray());
+                .WithAssemblies(assemblyLoader.LoadByAssemblyNameOrPath(plugins.AssemblyNames).ToArray());
 
             _compositionHost = compositionHostBuilder.Build();
 

--- a/src/OmniSharp.Stdio/Program.cs
+++ b/src/OmniSharp.Stdio/Program.cs
@@ -1,15 +1,10 @@
 using System;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using OmniSharp.Eventing;
-using OmniSharp.Extensions.LanguageServer;
 using OmniSharp.LanguageServerProtocol;
-using OmniSharp.LanguageServerProtocol.Eventing;
 using OmniSharp.Services;
 using OmniSharp.Stdio.Eventing;
 
@@ -59,9 +54,11 @@ namespace OmniSharp.Stdio
                     var plugins = application.CreatePluginAssemblies();
 
                     var writer = new SharedTextWriter(output);
+
+                    var assemblyLoader = serviceProvider.GetRequiredService<IAssemblyLoader>();
                     var compositionHostBuilder = new CompositionHostBuilder(serviceProvider, environment, new StdioEventEmitter(writer))
                         .WithOmniSharpAssemblies()
-                        .WithAssemblies(plugins.AssemblyNames.Select(Assembly.Load).ToArray());
+                        .WithAssemblies(assemblyLoader.LoadByAssemblyNameOrPath(plugins.AssemblyNames).ToArray());
                     using (var host = new Host(input, writer, environment, configuration, serviceProvider, compositionHostBuilder, loggerFactory, cancellation))
                     {
                         host.Start();


### PR DESCRIPTION
This allows plugins to be specified using the path to a dll. This adds to the existing behavior of allowing plugins to be specified using an assembly name.