### PR TITLE
reuse JsonSerializer in the HTTP server

### DIFF
--- a/src/OmniSharp.Host/WorkspaceInitializer.cs
+++ b/src/OmniSharp.Host/WorkspaceInitializer.cs
@@ -30,7 +30,7 @@ namespace OmniSharp
             {
                 try
                 {
-                    var projectConfiguration = configuration.GetSection((string)projectSystem.Key);
+                    var projectConfiguration = configuration.GetSection(projectSystem.Key);
                     var enabledProjectFlag = projectConfiguration.GetValue<bool>("enabled", defaultValue: true);
                     if (enabledProjectFlag)
                     {
@@ -45,7 +45,7 @@ namespace OmniSharp
                 {
                     var message = $"The project system '{projectSystem.GetType().FullName}' threw exception during initialization.";
                     // if a project system throws an unhandled exception it should not crash the entire server
-                    LoggerExceptions.LogError((ILogger)logger, e, message);
+                    logger.LogError(e, message);
                 }
             }
 
@@ -61,7 +61,7 @@ namespace OmniSharp
                 ProvideWorkspaceOptions(compositionHost, workspace, options, logger);
             });
 
-            LoggerExtensions.LogInformation((ILogger)logger, "Configuration finished.");
+            logger.LogInformation("Configuration finished.");
         }
 
         private static void ProvideWorkspaceOptions(
@@ -83,7 +83,7 @@ namespace OmniSharp
                 catch (Exception e)
                 {
                     var message = $"The workspace options provider '{providerName}' threw exception during initialization.";
-                    LoggerExceptions.LogError(logger, e, message);
+                    logger.LogError(e, message);
                 }
             }
         }

--- a/src/OmniSharp.Http/Middleware/EndpointMiddleware.cs
+++ b/src/OmniSharp.Http/Middleware/EndpointMiddleware.cs
@@ -93,7 +93,8 @@ namespace OmniSharp.Http.Middleware
                             Command = endpoint,
                             ArgumentsStream = httpContext.Request.Body
                         });
-                        MiddlewareHelpers.WriteTo(httpContext.Response, response);
+
+                        httpContext.Response.WriteJson(response);
                         return;
                     }
                 }

--- a/src/OmniSharp.Http/Middleware/MiddlewareExtensions.cs
+++ b/src/OmniSharp.Http/Middleware/MiddlewareExtensions.cs
@@ -5,18 +5,18 @@ using Newtonsoft.Json;
 
 namespace OmniSharp.Http.Middleware
 {
-    static class MiddlewareHelpers
+    static class MiddlewareExtensions
     {
-        private static readonly Encoding _encoding = new System.Text.UTF8Encoding(false);
+        private static readonly JsonSerializer _jsonSerializer = JsonSerializer.Create();
+        private static readonly Encoding _encoding = new UTF8Encoding(false);
 
-        public static void WriteTo(HttpResponse response, object value)
+        public static void WriteJson(this HttpResponse response, object value)
         {
             using (var writer = new StreamWriter(response.Body, _encoding, 1024, true))
             using (var jsonWriter = new JsonTextWriter(writer))
             {
                 jsonWriter.CloseOutput = false;
-                var jsonSerializer = JsonSerializer.Create(/*TODO: SerializerSettings*/);
-                jsonSerializer.Serialize(jsonWriter, value);
+                _jsonSerializer.Serialize(jsonWriter, value);
             }
         }
     }

--- a/src/OmniSharp.Http/Middleware/StatusMiddleware.cs
+++ b/src/OmniSharp.Http/Middleware/StatusMiddleware.cs
@@ -21,13 +21,13 @@ namespace OmniSharp.Http.Middleware
                 var endpoint = httpContext.Request.Path.Value;
                 if (endpoint == OmniSharpEndpoints.CheckAliveStatus)
                 {
-                    MiddlewareHelpers.WriteTo(httpContext.Response, true);
+                    httpContext.Response.WriteJson(true);
                     return;
                 }
 
                 if (endpoint == OmniSharpEndpoints.CheckReadyStatus)
                 {
-                    MiddlewareHelpers.WriteTo(httpContext.Response, _workspace.Initialized);
+                    httpContext.Response.WriteJson(_workspace.Initialized);
                     return;
                 }
             }

--- a/src/OmniSharp.Http/Startup.cs
+++ b/src/OmniSharp.Http/Startup.cs
@@ -44,10 +44,7 @@ namespace OmniSharp.Http
             IApplicationBuilder app,
             IServiceProvider serviceProvider,
             ILoggerFactory loggerFactory,
-            IEventEmitter eventEmitter,
-            ISharedTextWriter writer,
-            HttpEnvironment httpEnvironment,
-            IOptionsMonitor<OmniSharpOptions> options)
+            HttpEnvironment httpEnvironment)
         {
             var workspace = _compositionHost.GetExport<OmniSharpWorkspace>();
             var logger = loggerFactory.CreateLogger<Startup>();


### PR DESCRIPTION
JsonSerializers are relatively expensive to create, and are thread safe, so for the HTTP server we can just reuse the same instance.
Also updated a few places where extension methods were not invoked like extension methods.