### PR TITLE
Added attribute span property for fileMemberElement

### DIFF
--- a/src/OmniSharp.Abstractions/Models/v1/MembersTree/FileMemberElement.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/MembersTree/FileMemberElement.cs
@@ -9,6 +9,10 @@ namespace OmniSharp.Models.MembersTree
 
         public QuickFix Location { get; set; }
 
+        public int AttributeSpanStart { get; set; }
+
+        public int AttributeSpanEnd { get; set; }
+
         public string Kind { get; set; }
         
         public ICollection<SyntaxFeature> Features { get; } = new List<SyntaxFeature>();


### PR DESCRIPTION
Issue : https://github.com/OmniSharp/omnisharp-vscode/issues/429

Added properties to contain the attribute span in a file member element, which will be used by the editor to display the "# of references" before the attributes.