### PR TITLE
Detect legacy ASP.NET Websites via project GUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to the project will be documented in this file.
 * Updated to Roslyn 2.6.1 packages - C# 7.2 support, PR: [#1055](https://github.com/OmniSharp/omnisharp-roslyn/pull/1055)
 * Shipped Language Server Protocol support in box.  PR: [#969](https://github.com/OmniSharp/omnisharp-roslyn/pull/969)
   - Additional information and features tracked at [#968](https://github.com/OmniSharp/omnisharp-roslyn/issues/968)
+* Do not crash when encoutering Legacy ASP.NET Website projects. PR: [#1066](https://github.com/OmniSharp/omnisharp-roslyn/pull/1066) and [#1084](https://github.com/OmniSharp/omnisharp-roslyn/pull/1084)
 
 ## [1.28.0] - 2017-12-14
 

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -134,7 +134,7 @@ namespace OmniSharp.MSBuild
 
             foreach (var project in solutionFile.Projects)
             {
-                if (project.IsSolutionFolder || project.IsAspWebsite())
+                if (project.IsSupported)
                 {
                     continue;
                 }

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -134,7 +134,7 @@ namespace OmniSharp.MSBuild
 
             foreach (var project in solutionFile.Projects)
             {
-                if (project.IsSupported)
+                if (project.IsNotSupported)
                 {
                     continue;
                 }

--- a/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
+++ b/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
@@ -35,7 +35,8 @@ namespace OmniSharp.MSBuild.SolutionParsing
 
         public bool IsNotSupported =>
             ProjectTypeGuid.Equals(SolutionFolderGuid, StringComparison.OrdinalIgnoreCase) ||
-            ProjectTypeGuid.Equals(LegacyAspNetWebsite, StringComparison.OrdinalIgnoreCase);
+            ProjectTypeGuid.Equals(LegacyAspNetWebsite, StringComparison.OrdinalIgnoreCase) ||
+            (RelativePath != null && RelativePath.ToLowerInvariant().StartsWith("http://"));
 
         private ProjectBlock(string projectTypeGuid, string projectName, string relativePath, string projectGuid, ImmutableArray<SectionBlock> sections)
         {

--- a/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
+++ b/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
@@ -46,12 +46,6 @@ namespace OmniSharp.MSBuild.SolutionParsing
             Sections = sections;
         }
 
-        public bool IsAspWebsite()
-        {
-            var match = Regex.Match(RelativePath, "http://", RegexOptions.IgnoreCase);
-            return match.Success;
-        }
-
         public static ProjectBlock Parse(string headerLine, Scanner scanner)
         {
             var match = s_lazyProjectHeader.Value.Match(headerLine);

--- a/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
+++ b/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
@@ -8,6 +8,7 @@ namespace OmniSharp.MSBuild.SolutionParsing
     internal class ProjectBlock
     {
         private const string SolutionFolderGuid = "{2150E333-8FDC-42A3-9474-1A3956D46DE8}";
+        private const string LegacyAspNetWebsite = "{E24C65DC-7377-472B-9ABA-BC803B73C61A}";
 
         // An example of a project line looks like this:
         //  Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary1", "ClassLibrary1\ClassLibrary1.csproj", "{DEBCE986-61B9-435E-8018-44B9EF751655}"
@@ -32,7 +33,9 @@ namespace OmniSharp.MSBuild.SolutionParsing
         public string ProjectGuid { get; }
         public ImmutableArray<SectionBlock> Sections { get; }
 
-        public bool IsSolutionFolder => ProjectTypeGuid.Equals(SolutionFolderGuid, StringComparison.OrdinalIgnoreCase);
+        public bool IsSupported =>
+            ProjectTypeGuid.Equals(SolutionFolderGuid, StringComparison.OrdinalIgnoreCase) ||
+            ProjectTypeGuid.Equals(LegacyAspNetWebsite, StringComparison.OrdinalIgnoreCase);
 
         private ProjectBlock(string projectTypeGuid, string projectName, string relativePath, string projectGuid, ImmutableArray<SectionBlock> sections)
         {

--- a/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
+++ b/src/OmniSharp.MSBuild/SolutionParsing/ProjectBlock.cs
@@ -33,7 +33,7 @@ namespace OmniSharp.MSBuild.SolutionParsing
         public string ProjectGuid { get; }
         public ImmutableArray<SectionBlock> Sections { get; }
 
-        public bool IsSupported =>
+        public bool IsNotSupported =>
             ProjectTypeGuid.Equals(SolutionFolderGuid, StringComparison.OrdinalIgnoreCase) ||
             ProjectTypeGuid.Equals(LegacyAspNetWebsite, StringComparison.OrdinalIgnoreCase);
 

--- a/tests/OmniSharp.MSBuild.Tests/SolutionParsingTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/SolutionParsingTests.cs
@@ -162,6 +162,32 @@ namespace OmniSharp.MSBuild.Tests
                 EndGlobalSection
             EndGlobal";
         #endregion
+        #region LegacyAspNetWebsiteSolutionContent
+        private const string LegacyAspNetWebsiteSolutionContent = @"
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            # Visual Studio 2013
+            VisualStudioVersion = 12.0.31101.0
+            MinimumVisualStudioVersion = 10.0.40219.1
+            Project(""{E24C65DC-7377-472B-9ABA-BC803B73C61A}"") = ""OmniSharp_Test_Website"", ""localhost"", ""{914CBCF1-2DED-4994-AE99-C1CE5FE79EDF}""
+
+                ProjectSection(WebsiteProperties) = preProject
+		            Debug.AspNetCompiler.Debug = ""True""
+                    Release.AspNetCompiler.Debug = ""False""
+	            EndProjectSection
+            EndProject
+            Global
+	            GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		            Debug|Any CPU = Debug|Any CPU
+	            EndGlobalSection
+	            GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		            {914CBCF1-2DED-4994-AE99-C1CE5FE79EDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		            {914CBCF1-2DED-4994-AE99-C1CE5FE79EDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	            EndGlobalSection
+	            GlobalSection(SolutionProperties) = preSolution
+		            HideSolutionNode = FALSE
+	            EndGlobalSection
+            EndGlobal";
+        #endregion
 
         [Fact]
         public void SolutionFile_Parse_throws_with_null_text()
@@ -297,6 +323,13 @@ namespace OmniSharp.MSBuild.Tests
             Assert.Equal("SolutionProperties", solution.GlobalSections[1].Name);
             Assert.Equal("ProjectConfigurationPlatforms", solution.GlobalSections[2].Name);
             Assert.Equal("NestedProjects", solution.GlobalSections[3].Name);
+        }
+
+        [Fact]
+        public void SolutionFile_LegacyAspNetWebsite_NotSupported()
+        {
+            var solution = SolutionFile.Parse(LegacyAspNetWebsiteSolutionContent);
+            Assert.True(solution.Projects[0].IsSupported);
         }
     }
 }

--- a/tests/OmniSharp.MSBuild.Tests/SolutionParsingTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/SolutionParsingTests.cs
@@ -329,7 +329,7 @@ namespace OmniSharp.MSBuild.Tests
         public void SolutionFile_LegacyAspNetWebsite_NotSupported()
         {
             var solution = SolutionFile.Parse(LegacyAspNetWebsiteSolutionContent);
-            Assert.True(solution.Projects[0].IsSupported);
+            Assert.True(solution.Projects[0].IsNotSupported);
         }
     }
 }


### PR DESCRIPTION
This is a follow up to #1066.

I just noticed the logic there wasn't sufficient as these projects don't necessarily start with `http://` - for example it could be `localhost` or any other string really (up to the user).
 
However, the legacy ASP.NET Websites have a common well-known project GUID so we can use that to exclude it from OmniSharp (since they don't have csproj files, we can't support them at the moment).

I threw in a test just to be on the safe side.