### PR TITLE
Changes for empty reponse for GoToDefinition on PropertyAccessorSymbol

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionService.cs
@@ -47,6 +47,8 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                 // go to definition for namespaces is not supported
                 if (symbol != null && !(symbol is INamespaceSymbol))
                 {
+                    if (symbol is IMethodSymbol methodSymbol && methodSymbol.AssociatedSymbol is IPropertySymbol)
+                        return response;
                     // for partial methods, pick the one with body
                     if (symbol is IMethodSymbol method)
                     {

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionService.cs
@@ -47,11 +47,13 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                 // go to definition for namespaces is not supported
                 if (symbol != null && !(symbol is INamespaceSymbol))
                 {
-                    if (symbol is IMethodSymbol methodSymbol && methodSymbol.AssociatedSymbol is IPropertySymbol)
-                        return response;
                     // for partial methods, pick the one with body
                     if (symbol is IMethodSymbol method)
                     {
+                        // Return an empty response for property accessor symbols like get and set
+                        if (method.AssociatedSymbol is IPropertySymbol)
+                            return response;
+
                         symbol = method.PartialImplementationPart ?? symbol;
                     }
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
@@ -31,6 +31,110 @@ class {|def:Foo|} {
             await TestGoToSourceAsync(testFile);
         }
 
+        [Fact]
+        public async Task DoesnotReturnOnPropertAccessorGet()
+        {
+            var testFile = new TestFile("foo.cs", @"
+class Test {
+    public string Foo{ g$$et; set; }
+}");
+
+            await TestGoToSourceAsync(testFile);
+        }
+
+        [Fact]
+        public async Task DoesnotReturnOnPropertAccessorSet()
+        {
+            var testFile = new TestFile("foo.cs", @"
+class Test {
+    public int Foo{ get; s$$et; }
+}");
+
+            await TestGoToSourceAsync(testFile);
+        }
+
+        [Fact]
+        public async Task DoesnotReturnOnPropertyAccessorPropertyDef()
+        {
+            var testFile = new TestFile("foo.cs", @"
+class Test {
+    public int |def:Foo| Fo$$o{ get; set; }
+}");
+
+            await TestGoToSourceAsync(testFile);
+        }
+
+        [Fact]
+        public async Task ReturnsOnPropertyAccessorPropertySetting()
+        {
+            var testFile = new TestFile("foo.cs", @"
+class Test {
+    public int |def:Foo|{ get; set; }
+
+    public static void main()
+    {
+        F$$oo = 3;
+    }
+}");
+
+            await TestGoToSourceAsync(testFile);
+        }
+
+        [Fact]
+        public async Task ReturnsOnPropertyAccessorField1()
+        {
+            var testFile = new TestFile("foo.cs", @"
+class Test {
+
+    public int |def:foo|;
+
+    public int Foo
+    {
+        get => f$$oo;
+        set => foo = value;
+    }
+}");
+
+            await TestGoToSourceAsync(testFile);
+        }
+
+        [Fact]
+        public async Task ReturnsOnPropertyAccessorField2()
+        {
+            var testFile = new TestFile("foo.cs", @"
+class Test {
+
+    public int |def:foo|;
+
+    public int Foo
+    {
+        get => foo;
+        set => f$$oo = value;
+    }
+}");
+
+            await TestGoToSourceAsync(testFile);
+        }
+
+        [Fact]
+        public async Task ReturnsOnPropertyAccessorPropertyGetting()
+        {
+            var testFile = new TestFile("foo.cs", @"
+class Test {
+    public int |def:Foo|{ get; set; }
+
+    public static void main()
+    {
+        Foo = 3;
+    Console.WriteLine(F$$oo);
+    }
+}");
+
+            await TestGoToSourceAsync(testFile);
+        }
+
+
+
         [Theory]
         [InlineData("bar.cs")]
         [InlineData("bar.csx")]

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
@@ -32,7 +32,7 @@ class {|def:Foo|} {
         }
 
         [Fact]
-        public async Task DoesnotReturnOnPropertAccessorGet()
+        public async Task DoesNotReturnOnPropertAccessorGet()
         {
             var testFile = new TestFile("foo.cs", @"
 class Test {
@@ -43,7 +43,7 @@ class Test {
         }
 
         [Fact]
-        public async Task DoesnotReturnOnPropertAccessorSet()
+        public async Task DoesNotReturnOnPropertAccessorSet()
         {
             var testFile = new TestFile("foo.cs", @"
 class Test {
@@ -54,7 +54,7 @@ class Test {
         }
 
         [Fact]
-        public async Task DoesnotReturnOnPropertyAccessorPropertyDef()
+        public async Task DoesNotReturnOnPropertyAccessorPropertyDef()
         {
             var testFile = new TestFile("foo.cs", @"
 class Test {


### PR DESCRIPTION
Fixes: https://github.com/OmniSharp/omnisharp-vscode/issues/1949

Changes:

1. Check for property accessors in GoToTypeDefinition.
2. Test cases for the same.

Please review : @DustinCampbell @TheRealPiotrP @rchande 