### PR TITLE
Attempt to fix rename file same as type issue.

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/RunCodeActionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/RunCodeActionService.cs
@@ -76,22 +76,19 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
                     solution = applyChangesOperation.ChangedSolution;
                 }
 
-                if (request.WantsAllCodeActionOperations)
+                if (IsRenameDocumentOperation(o, out var originalDocumentId, out var newDocumentId, out var newFileName))
                 {
-                    if (IsRenameDocumentOperation(o, out var originalDocumentId, out var newDocumentId, out var newFileName))
-                    {
-                        var originalDocument = solution.GetDocument(originalDocumentId);
-                        string newFilePath = GetNewFilePath(newFileName, originalDocument.FilePath);
-                        var text = await originalDocument.GetTextAsync();
-                        var temp = solution.RemoveDocument(originalDocumentId);
-                        solution = temp.AddDocument(newDocumentId, newFileName, text, originalDocument.Folders, newFilePath);
-                        changes.Add(new RenamedFileResponse(originalDocument.FilePath, newFilePath));
-                    }
-                    else if (o is OpenDocumentOperation openDocumentOperation)
-                    {
-                        var document = solution.GetDocument(openDocumentOperation.DocumentId);
-                        changes.Add(new OpenFileResponse(document.FilePath));
-                    }
+                    var originalDocument = solution.GetDocument(originalDocumentId);
+                    string newFilePath = GetNewFilePath(newFileName, originalDocument.FilePath);
+                    var text = await originalDocument.GetTextAsync();
+                    var temp = solution.RemoveDocument(originalDocumentId);
+                    solution = temp.AddDocument(newDocumentId, newFileName, text, originalDocument.Folders, newFilePath);
+                    changes.Add(new RenamedFileResponse(originalDocument.FilePath, newFilePath));
+                }
+                else if (request.WantsAllCodeActionOperations && o is OpenDocumentOperation openDocumentOperation)
+                {
+                    var document = solution.GetDocument(openDocumentOperation.DocumentId);
+                    changes.Add(new OpenFileResponse(document.FilePath));
                 }
             }
 


### PR DESCRIPTION
Fixes: https://github.com/OmniSharp/omnisharp-vscode/issues/1384

However i have question: 

Issue was that this code was never invoked because `WantsAllCodeActionOperations` was not set. Is this correct fix or is real underlaying issue that vscode-omnisharp extension doesn't set that true on request? I have no idea what WantsAllCodeActionOperations is for.