### PR TITLE
Fixed a scenario where legacy clients were issueing commands without …

### DIFF
--- a/src/OmniSharp.Stdio/Host.cs
+++ b/src/OmniSharp.Stdio/Host.cs
@@ -213,6 +213,10 @@ namespace OmniSharp.Stdio
 
             try
             {
+                if (!request.Command.StartsWith("/"))
+                {
+                    request.Command = $"/{request.Command}";
+                }
                 // hand off request to next layer
                 if (_endpointHandlers.TryGetValue(request.Command, out var handler))
                 {


### PR DESCRIPTION
…the leading /.  This was previously allowed.

I don't think ever created an issue for this, but I was reminded about this when talking to Joe in slack.