### PR TITLE
Feature/script supersede lower versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All changes to the project will be documented in this file.
 
-## [1.29.0] - not yet released
+## [1.30.0] - not yet released
 * Ensure that the lower assembly versions are always superseded in C# scripts (PR: [#1103](https://github.com/OmniSharp/omnisharp-roslyn/pull/1103))
 
 ## [1.29.0] - 2018-1-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.29.0] - not yet released
+* Ensure that the lower assembly versions are always superseded in C# scripts (PR: [#1103](https://github.com/OmniSharp/omnisharp-roslyn/pull/1103))
+
 ## [1.29.0] - 2018-1-29
 * Updated to Roslyn 2.6.1 packages - C# 7.2 support, (PR: [#1055](https://github.com/OmniSharp/omnisharp-roslyn/pull/1055))
 * Shipped Language Server Protocol support in box.  (PR: [#969](https://github.com/OmniSharp/omnisharp-roslyn/pull/969))

--- a/src/OmniSharp.Script/ScriptHelper.cs
+++ b/src/OmniSharp.Script/ScriptHelper.cs
@@ -16,6 +16,7 @@ namespace OmniSharp.Script
     {
         private const string BinderFlagsType = "Microsoft.CodeAnalysis.CSharp.BinderFlags";
         private const string TopLevelBinderFlagsProperty = "TopLevelBinderFlags";
+        private const string ReferencesSupersedeLowerVersionsProperty = "ReferencesSupersedeLowerVersions_internal_protected_set";
         private const string IgnoreCorLibraryDuplicatedTypesField = "IgnoreCorLibraryDuplicatedTypes";
         private const string RuntimeMetadataReferenceResolverType = "Microsoft.CodeAnalysis.Scripting.Hosting.RuntimeMetadataReferenceResolver";
         private const string ResolverField = "_resolver";
@@ -71,6 +72,14 @@ namespace OmniSharp.Script
             if (ignoreCorLibraryDuplicatedTypesValue != null)
             {
                 topLevelBinderFlagsProperty?.SetValue(compilationOptions, ignoreCorLibraryDuplicatedTypesValue);
+            }
+
+            // in scripts, the option to supersede lower versions is ALWAYS enabled
+            // see: https://github.com/dotnet/roslyn/blob/version-2.6.0-beta3/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs#L199
+            var referencesSupersedeLowerVersionsProperty = typeof(CompilationOptions).GetProperty(ReferencesSupersedeLowerVersionsProperty, BindingFlags.Instance | BindingFlags.NonPublic);
+            if (referencesSupersedeLowerVersionsProperty != null)
+            {
+                referencesSupersedeLowerVersionsProperty?.SetValue(compilationOptions, true);
             }
 
             return compilationOptions;

--- a/src/OmniSharp.Script/ScriptHelper.cs
+++ b/src/OmniSharp.Script/ScriptHelper.cs
@@ -77,10 +77,7 @@ namespace OmniSharp.Script
             // in scripts, the option to supersede lower versions is ALWAYS enabled
             // see: https://github.com/dotnet/roslyn/blob/version-2.6.0-beta3/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs#L199
             var referencesSupersedeLowerVersionsProperty = typeof(CompilationOptions).GetProperty(ReferencesSupersedeLowerVersionsProperty, BindingFlags.Instance | BindingFlags.NonPublic);
-            if (referencesSupersedeLowerVersionsProperty != null)
-            {
-                referencesSupersedeLowerVersionsProperty?.SetValue(compilationOptions, true);
-            }
+            referencesSupersedeLowerVersionsProperty?.SetValue(compilationOptions, true);
 
             return compilationOptions;
         }


### PR DESCRIPTION
Conflicting assembly versions in scripting are typically resolved via [identity comparer](https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Script/ScriptHelper.cs#L63), which we already use. 

However, scripting scenarios in Roslyn additionally set [a special flag in the ReferenceManager](https://github.com/dotnet/roslyn/blob/version-2.6.0-beta3/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs#L473-L484) to enable additional tie-breaking behavior in case of conflicting references. This flag [is propagated from](https://github.com/dotnet/roslyn/blob/version-2.6.0-beta3/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs#L199) the compilation options, and is always implicitly injected for script compilations.

To mirror 1:1 the runtime behavior of scripts, we should ensure the same flag is set at tooling level (at the moment we have it set to to `false` which can lead to edge case false-positive intellisense errors). Unfortunately the flag is internal so it's set with reflection (along with a few other things we do with reflection in script tooling ☹️).