### PR TITLE
Disable cake diagnostics endpoint for requests that don't specify a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.29.1] - Not Yet Released
+* Fixed duplicate diagnostics in C# ([omnisharp-vscode#1830](https://github.com/OmniSharp/omnisharp-vscode/issues/1830), PR: [#1107](https://github.com/OmniSharp/omnisharp-roslyn/pull/1107))
+
 ## [1.29.0] - 2018-1-29
-* Updated to Roslyn 2.6.1 packages - C# 7.2 support, (PR: [#1055](https://github.com/OmniSharp/omnisharp-roslyn/pull/1055))
+* Updated to Roslyn 2.6.1 packages - C# 7.2 support (PR: [#1055](https://github.com/OmniSharp/omnisharp-roslyn/pull/1055))
 * Shipped Language Server Protocol support in box.  (PR: [#969](https://github.com/OmniSharp/omnisharp-roslyn/pull/969))
   - Additional information and features tracked at [#968](https://github.com/OmniSharp/omnisharp-roslyn/issues/968)
 * Fixed locating Visual Studio with more than one installation (PR: [#1063](https://github.com/OmniSharp/omnisharp-roslyn/pull/1063))

--- a/src/OmniSharp.Cake/Services/RequestHandlers/CakeRequestHandler.cs
+++ b/src/OmniSharp.Cake/Services/RequestHandlers/CakeRequestHandler.cs
@@ -54,15 +54,14 @@ namespace OmniSharp.Cake.Services.RequestHandlers
 
             request = await TranslateRequestAsync(request);
 
-            var response = await HandleCore(request, service);
+            var response = IsValid(request)
+                ? await service.Handle(request)
+                : default(TResponse)
 
             return await TranslateResponse(response, request);
         }
 
-        public virtual  Task<TResponse> HandleCore(TRequest request, IRequestHandler<TRequest, TResponse> service)
-        {
-            return service.Handle(request);
-        }
+        public virtual bool IsValid(TRequest request) => true;
 
         protected virtual async Task<TRequest> TranslateRequestAsync(TRequest req)
         {

--- a/src/OmniSharp.Cake/Services/RequestHandlers/CakeRequestHandler.cs
+++ b/src/OmniSharp.Cake/Services/RequestHandlers/CakeRequestHandler.cs
@@ -54,9 +54,14 @@ namespace OmniSharp.Cake.Services.RequestHandlers
 
             request = await TranslateRequestAsync(request);
 
-            var response = await service.Handle(request);
+            var response = await HandleCore(request, service);
 
             return await TranslateResponse(response, request);
+        }
+
+        public virtual  Task<TResponse> HandleCore(TRequest request, IRequestHandler<TRequest, TResponse> service)
+        {
+            return service.Handle(request);
         }
 
         protected virtual async Task<TRequest> TranslateRequestAsync(TRequest req)

--- a/src/OmniSharp.Cake/Services/RequestHandlers/CakeRequestHandler.cs
+++ b/src/OmniSharp.Cake/Services/RequestHandlers/CakeRequestHandler.cs
@@ -56,7 +56,7 @@ namespace OmniSharp.Cake.Services.RequestHandlers
 
             var response = IsValid(request)
                 ? await service.Handle(request)
-                : default(TResponse)
+                : default(TResponse);
 
             return await TranslateResponse(response, request);
         }

--- a/src/OmniSharp.Cake/Services/RequestHandlers/Diagnostics/CodeCheckHandler.cs
+++ b/src/OmniSharp.Cake/Services/RequestHandlers/Diagnostics/CodeCheckHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Composition;
+using System.Threading.Tasks;
 using OmniSharp.Mef;
 using OmniSharp.Models;
 using OmniSharp.Models.CodeCheck;
@@ -13,6 +14,16 @@ namespace OmniSharp.Cake.Services.RequestHandlers.Diagnostics
             OmniSharpWorkspace workspace)
             : base(workspace)
         {
+        }
+
+        public override Task<QuickFixResponse> HandleCore(CodeCheckRequest request, IRequestHandler<CodeCheckRequest, QuickFixResponse> service)
+        {
+            if (string.IsNullOrEmpty(request.FileName))
+            {
+                return Task.FromResult(new QuickFixResponse());
+            }
+
+            return service.Handle(request);
         }
     }
 }

--- a/src/OmniSharp.Cake/Services/RequestHandlers/Diagnostics/CodeCheckHandler.cs
+++ b/src/OmniSharp.Cake/Services/RequestHandlers/Diagnostics/CodeCheckHandler.cs
@@ -16,14 +16,7 @@ namespace OmniSharp.Cake.Services.RequestHandlers.Diagnostics
         {
         }
 
-        public override Task<QuickFixResponse> HandleCore(CodeCheckRequest request, IRequestHandler<CodeCheckRequest, QuickFixResponse> service)
-        {
-            if (string.IsNullOrEmpty(request.FileName))
-            {
-                return Task.FromResult(new QuickFixResponse());
-            }
-
-            return service.Handle(request);
-        }
+        public override bool IsValid(CodeCheckRequest request) =>
+            !string.IsNullOrEmpty(request.FileName);
     }
 }

--- a/tests/OmniSharp.Cake.Tests/CodeCheckFacts.cs
+++ b/tests/OmniSharp.Cake.Tests/CodeCheckFacts.cs
@@ -1,12 +1,8 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Cake.Services.RequestHandlers.Diagnostics;
 using OmniSharp.Models;
-using OmniSharp.Models.AutoComplete;
 using OmniSharp.Models.CodeCheck;
 using OmniSharp.Models.UpdateBuffer;
 using TestUtility;

--- a/tests/OmniSharp.Cake.Tests/CodeCheckFacts.cs
+++ b/tests/OmniSharp.Cake.Tests/CodeCheckFacts.cs
@@ -39,6 +39,7 @@ namespace OmniSharp.Cake.Tests
             var diagnostics = await FindDiagnostics(input, includeFileName: false);
             Assert.Null(diagnostics);
         }
+        
         private async Task<QuickFixResponse> FindDiagnostics(string contents, bool includeFileName)
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("CakeProject", shadowCopy : false))

--- a/tests/OmniSharp.Cake.Tests/CodeCheckFacts.cs
+++ b/tests/OmniSharp.Cake.Tests/CodeCheckFacts.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Cake.Services.RequestHandlers.Diagnostics;
+using OmniSharp.Models;
+using OmniSharp.Models.AutoComplete;
+using OmniSharp.Models.CodeCheck;
+using OmniSharp.Models.UpdateBuffer;
+using TestUtility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OmniSharp.Cake.Tests
+{
+    public class CodeCheckFacts : CakeSingleRequestHandlerTestFixture<CodeCheckHandler>
+    {
+        private readonly ILogger _logger;
+
+        public CodeCheckFacts(ITestOutputHelper testOutput) : base(testOutput)
+        {
+            _logger = LoggerFactory.CreateLogger<AutoCompleteFacts>();
+        }
+
+        protected override string EndpointName => OmniSharpEndpoints.CodeCheck;
+
+        [Fact]
+        public async Task ShouldProvideDiagnosticsIfRequestContainsCakeFileName()
+        {
+            const string input = @"zzz";
+
+            var diagnostics = await FindDiagnostics(input, includeFileName: true);
+            Assert.NotEmpty(diagnostics.QuickFixes);
+        }
+
+        [Fact]
+        public async Task ShouldNotCallCodeCheckServiceIfRequestDoesNotSpecifyFileName()
+        {
+            const string input = @"zzz$$";
+
+            var diagnostics = await FindDiagnostics(input, includeFileName: false);
+            Assert.Null(diagnostics.QuickFixes);
+        }
+
+
+        private async Task<QuickFixResponse> FindDiagnostics(string contents, bool includeFileName)
+        {
+            using (var testProject = await TestAssets.Instance.GetTestProjectAsync("CakeProject", shadowCopy : false))
+            using (var host = CreateOmniSharpHost(testProject.Directory))
+            {
+                var testFile = new TestFile(Path.Combine(testProject.Directory, "build.cake"), contents);
+
+                var request = new CodeCheckRequest
+                {
+                    FileName = includeFileName ? testFile.FileName : string.Empty,
+                };
+
+                var updateBufferRequest = new UpdateBufferRequest
+                {
+                    Buffer = testFile.Content.Code,
+                    Column = request.Column,
+                    FileName = testFile.FileName,
+                    Line = request.Line,
+                    FromDisk = false
+                };
+
+                await GetUpdateBufferHandler(host).Handle(updateBufferRequest);
+
+                var requestHandler = GetRequestHandler(host);
+
+                return await requestHandler.Handle(request);
+            }
+        }
+    }
+}

--- a/tests/OmniSharp.Cake.Tests/CodeCheckFacts.cs
+++ b/tests/OmniSharp.Cake.Tests/CodeCheckFacts.cs
@@ -37,7 +37,7 @@ namespace OmniSharp.Cake.Tests
             const string input = @"zzz$$";
 
             var diagnostics = await FindDiagnostics(input, includeFileName: false);
-            Assert.Null(diagnostics.QuickFixes);
+            Assert.Null(diagnostics);
         }
         private async Task<QuickFixResponse> FindDiagnostics(string contents, bool includeFileName)
         {

--- a/tests/OmniSharp.Cake.Tests/CodeCheckFacts.cs
+++ b/tests/OmniSharp.Cake.Tests/CodeCheckFacts.cs
@@ -43,8 +43,6 @@ namespace OmniSharp.Cake.Tests
             var diagnostics = await FindDiagnostics(input, includeFileName: false);
             Assert.Null(diagnostics.QuickFixes);
         }
-
-
         private async Task<QuickFixResponse> FindDiagnostics(string contents, bool includeFileName)
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("CakeProject", shadowCopy : false))


### PR DESCRIPTION
Cake's diagnostics engine calls the generic CodeCheckService, which generates all diagnostics for the solution if called without a specific file path. This results in duplicate errors in C# projects when VS Code requests project level diagnostics. The solution is to only compute diagnostics for specified files.

Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1830

Diagnostics window in VS Code now looks like:
![image](https://user-images.githubusercontent.com/3751401/35930872-efecb8b0-0be7-11e8-86b8-499905865666.png)

cc @mholo65 