### PR TITLE
Support RSP-based configuration for scripting project system

### DIFF
--- a/src/OmniSharp.Script/ScriptHelper.cs
+++ b/src/OmniSharp.Script/ScriptHelper.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
-using Microsoft.Extensions.Configuration;
 using OmniSharp.Helpers;
 
 namespace OmniSharp.Script
@@ -43,12 +42,12 @@ namespace OmniSharp.Script
         private static readonly CSharpParseOptions ParseOptions = new CSharpParseOptions(LanguageVersion.Latest, DocumentationMode.Parse, SourceCodeKind.Script);
 
         private readonly Lazy<CSharpCompilationOptions> _compilationOptions;
-        private readonly MetadataReferenceResolver _resolver = ScriptMetadataResolver.Default;
+        private readonly ScriptOptions _scriptOptions;
 
         public ScriptHelper(ScriptOptions scriptOptions)
         {
-            _scriptOptions = scriptOptions;
             _compilationOptions = new Lazy<CSharpCompilationOptions>(CreateCompilationOptions);
+            _scriptOptions = scriptOptions;
             InjectXMLDocumentationProviderIntoRuntimeMetadataReferenceResolver();
         }
 
@@ -84,9 +83,9 @@ namespace OmniSharp.Script
 
         private CachingScriptMetadataResolver CreateMetadataReferenceResolver()
         {
-            return _scriptOptions.IsNugetEnabled()
-                ? new CachingScriptMetadataResolver(new NuGetMetadataReferenceResolver(_resolver))
-                : new CachingScriptMetadataResolver(_resolver);
+            return _scriptOptions != null && _scriptOptions.EnableScriptNuGetReferences
+                ? new CachingScriptMetadataResolver(new NuGetMetadataReferenceResolver(ScriptMetadataResolver.Default)) 
+                : new CachingScriptMetadataResolver(ScriptMetadataResolver.Default);
         }
  
         public ProjectInfo CreateProject(string csxFileName, IEnumerable<MetadataReference> references, string csxFilePath, IEnumerable<string> namespaces = null)

--- a/src/OmniSharp.Script/ScriptHelper.cs
+++ b/src/OmniSharp.Script/ScriptHelper.cs
@@ -141,10 +141,19 @@ namespace OmniSharp.Script
                 var resolvedRspReferences = csharpCommandLineArguments.ResolveMetadataReferences(_compilationOptions.Value.MetadataReferenceResolver);
                 foreach (var resolvedRspReference in resolvedRspReferences)
                 {
-                    _logger.LogDebug($"{csxFileName} project. Adding RSP reference to: {resolvedRspReference.Display}");
+                    if (resolvedRspReference is UnresolvedMetadataReference)
+                    {
+                        _logger.LogWarning($"{csxFileName} project. Skipping RSP reference to: {resolvedRspReference.Display} as it can't be resolved.");
+                    }
+                    else
+                    {
+                        _logger.LogDebug($"{csxFileName} project. Adding RSP reference to: {resolvedRspReference.Display}");
+                    }
                 }
 
-                references = resolvedRspReferences.Union(references, MetadataReferenceEqualityComparer.Instance);
+                references = resolvedRspReferences.
+                    Where(reference => !(reference is UnresolvedMetadataReference)).
+                    Union(references, MetadataReferenceEqualityComparer.Instance);
             }
 
             var project = ProjectInfo.Create(

--- a/src/OmniSharp.Script/ScriptHelper.cs
+++ b/src/OmniSharp.Script/ScriptHelper.cs
@@ -62,16 +62,13 @@ namespace OmniSharp.Script
 
         private CSharpCommandLineArguments CreateCommandLineArguments()
         {
-            var scriptRunnerParserProperty = typeof(CSharpCommandLineParser).GetProperty("ScriptRunner", BindingFlags.Static | BindingFlags.NonPublic);
-            var scriptRunnerParser = scriptRunnerParserProperty?.GetValue(null) as CSharpCommandLineParser;
-
-            if (scriptRunnerParser != null && !string.IsNullOrWhiteSpace(_scriptOptions.RspFilePath))
+            if (!string.IsNullOrWhiteSpace(_scriptOptions.RspFilePath))
             {
                 var rspFilePath = _scriptOptions.GetNormalizedRspFilePath(_env);
                 if (rspFilePath != null)
                 {
                     _logger.LogInformation($"Discovered an RSP file at '{rspFilePath}' - will use this file to discover CSX namespaces and references.");
-                    return scriptRunnerParser.Parse(new string[] { $"@{rspFilePath}" },
+                    return CSharpCommandLineParser.Script.Parse(new string[] { $"@{rspFilePath}" },
                         _env.TargetDirectory,
                         _isDesktopClr ? Path.GetDirectoryName(typeof(object).GetTypeInfo().Assembly.ManifestModule.FullyQualifiedName) : null);
                 }

--- a/src/OmniSharp.Script/ScriptOptions.cs
+++ b/src/OmniSharp.Script/ScriptOptions.cs
@@ -16,5 +16,13 @@ namespace OmniSharp.Script
             (DefaultTargetFramework != null && DefaultTargetFramework.StartsWith("netcoreapp", System.StringComparison.OrdinalIgnoreCase));
 
         public string RspFilePath { get; set; }
+
+        public string GetNormalizedRspFilePath(IOmniSharpEnvironment env)
+        {
+            if (string.IsNullOrWhiteSpace(RspFilePath)) return null;
+            return Path.IsPathRooted(RspFilePath)
+                ? RspFilePath
+                : Path.Combine(env.TargetDirectory, RspFilePath);
+        }
     }
 }

--- a/src/OmniSharp.Script/ScriptOptions.cs
+++ b/src/OmniSharp.Script/ScriptOptions.cs
@@ -14,5 +14,7 @@ namespace OmniSharp.Script
         public bool IsNugetEnabled() =>
             EnableScriptNuGetReferences ||
             (DefaultTargetFramework != null && DefaultTargetFramework.StartsWith("netcoreapp", System.StringComparison.OrdinalIgnoreCase));
+
+        public string RspFilePath { get; set; }
     }
 }

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -104,7 +104,7 @@ namespace OmniSharp.Script
             // explicitly include System.ValueTuple
             inheritedCompileLibraries.AddRange(DependencyContext.Default.CompileLibraries.Where(x =>
                 x.Name.ToLowerInvariant().StartsWith("system.valuetuple")));
-            
+
 
             var compilationDependencies = TryGetCompilationDependencies(scriptOptions.EnableScriptNuGetReferences);
 
@@ -112,7 +112,8 @@ namespace OmniSharp.Script
             // we will assume desktop framework
             // and add default CLR references
             // same applies for having a context that is not a .NET Core app
-            if (!_compilationDependencies.Any())
+
+            if (!compilationDependencies.Any())
             {
                 _logger.LogInformation("Unable to find dependency context for CSX files. Will default to non-context usage (Desktop CLR scripts).");
                 AddDefaultClrMetadataReferences(_commonReferences);
@@ -171,14 +172,14 @@ namespace OmniSharp.Script
                 var csxFileName = Path.GetFileName(csxPath);
                 var project = _scriptHelper.CreateProject(csxFileName, _commonReferences, csxPath);
 
-                if (_scriptOptions.IsNugetEnabled())
-                {
-                    var scriptMap = _compilationDependencies.ToDictionary(rdt => rdt.Name, rdt => rdt.Scripts);
-                    var options = project.CompilationOptions.WithSourceReferenceResolver(
-                        new NuGetSourceReferenceResolver(ScriptSourceResolver.Default,
-                            scriptMap));
-                    project = project.WithCompilationOptions(options);
-                }
+                    if (scriptOptions.IsNugetEnabled())
+                    {
+                        var scriptMap = compilationDependencies.ToDictionary(rdt => rdt.Name, rdt => rdt.Scripts);
+                        var options = project.CompilationOptions.WithSourceReferenceResolver(
+                            new NuGetSourceReferenceResolver(ScriptSourceResolver.Default,
+                                scriptMap));
+                        project = project.WithCompilationOptions(options);
+                    }
 
                 // add CSX project to workspace
                 _workspace.AddProject(project);

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -86,7 +86,6 @@ namespace OmniSharp.Script
             _scriptOptions = new ScriptOptions();
             ConfigurationBinder.Bind(configuration, _scriptOptions);
 
-            _scriptHelper = new ScriptHelper(_scriptOptions, _env, _loggerFactory);
             _logger.LogInformation($"Detecting CSX files in '{_env.TargetDirectory}'.");
 
             // Nothing to do if there are no CSX files
@@ -109,6 +108,7 @@ namespace OmniSharp.Script
 
             _compilationDependencies = TryGetCompilationDependencies(_scriptOptions.EnableScriptNuGetReferences);
 
+            var isDesktopClr = true;
             // if we have no compilation dependencies
             // we will assume desktop framework
             // and add default CLR references
@@ -120,6 +120,7 @@ namespace OmniSharp.Script
             }
             else
             {
+                isDesktopClr = false;
                 HashSet<string> loadedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (var compilationAssembly in _compilationDependencies.SelectMany(cd => cd.AssemblyPaths).Distinct())
@@ -138,6 +139,8 @@ namespace OmniSharp.Script
                 _logger.LogDebug("Adding implicit reference: " + inheritedCompileLib);
                 AddMetadataReference(_commonReferences, inheritedCompileLib);
             }
+
+            _scriptHelper = new ScriptHelper(_scriptOptions, _env, _loggerFactory, isDesktopClr);
 
             // Each .CSX file becomes an entry point for it's own project
             // Every #loaded file will be part of the project too

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -106,7 +106,7 @@ namespace OmniSharp.Script
             inheritedCompileLibraries.AddRange(DependencyContext.Default.CompileLibraries.Where(x =>
                 x.Name.ToLowerInvariant().StartsWith("system.valuetuple")));
 
-            _compilationDependencies = TryGetCompilationDependencies(_scriptOptions.EnableScriptNuGetReferences);
+            _compilationDependencies = TryGetCompilationDependencies();
 
             var isDesktopClr = true;
             // if we have no compilation dependencies

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -81,10 +81,10 @@ namespace OmniSharp.Script
 
         public void Initalize(IConfiguration configuration)
         {
-            _scriptOptions = new ScriptOptions();
-            ConfigurationBinder.Bind(configuration, _scriptOptions);
-            _scriptHelper = new ScriptHelper(_scriptOptions);
+            var scriptOptions = new ScriptOptions();
+            ConfigurationBinder.Bind(configuration, scriptOptions);
 
+            _scriptHelper = new ScriptHelper(scriptOptions);
             _logger.LogInformation($"Detecting CSX files in '{_env.TargetDirectory}'.");
 
             // Nothing to do if there are no CSX files
@@ -104,8 +104,9 @@ namespace OmniSharp.Script
             // explicitly include System.ValueTuple
             inheritedCompileLibraries.AddRange(DependencyContext.Default.CompileLibraries.Where(x =>
                 x.Name.ToLowerInvariant().StartsWith("system.valuetuple")));
+            
 
-            _compilationDependencies = TryGetCompilationDependencies();
+            var compilationDependencies = TryGetCompilationDependencies(scriptOptions.EnableScriptNuGetReferences);
 
             // if we have no compilation dependencies
             // we will assume desktop framework

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -84,7 +84,7 @@ namespace OmniSharp.Script
             var scriptOptions = new ScriptOptions();
             ConfigurationBinder.Bind(configuration, scriptOptions);
 
-            _scriptHelper = new ScriptHelper(scriptOptions);
+            var scriptHelper = new ScriptHelper(scriptOptions, _env);
             _logger.LogInformation($"Detecting CSX files in '{_env.TargetDirectory}'.");
 
             // Nothing to do if there are no CSX files

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -26,19 +26,19 @@ namespace OmniSharp.Script
     public class ScriptProjectSystem : IProjectSystem
     {
         private const string CsxExtension = ".csx";
-        private readonly MetadataFileReferenceCache _metadataFileReferenceCache;
 
         // used for tracking purposes only
         private readonly HashSet<string> _assemblyReferences = new HashSet<string>();
-        private readonly HashSet<MetadataReference> _commonReferences = new HashSet<MetadataReference>(MetadataReferenceEqualityComparer.Instance);
-
         private readonly ConcurrentDictionary<string, ProjectInfo> _projects;
         private readonly OmniSharpWorkspace _workspace;
         private readonly IOmniSharpEnvironment _env;
         private readonly ILogger _logger;
+
         private readonly IFileSystemWatcher _fileSystemWatcher;
+        private readonly ILoggerFactory _loggerFactory;
         private readonly FileSystemHelper _fileSystemHelper;
         private readonly CompilationDependencyResolver _compilationDependencyResolver;
+        private readonly MetadataFileReferenceCache _metadataFileReferenceCache;
 
         private ScriptOptions _scriptOptions;
         private ScriptHelper _scriptHelper;
@@ -51,6 +51,7 @@ namespace OmniSharp.Script
             _metadataFileReferenceCache = metadataFileReferenceCache;
             _workspace = workspace;
             _env = env;
+            _loggerFactory = loggerFactory;
             _fileSystemWatcher = fileSystemWatcher;
             _fileSystemHelper = fileSystemHelper;
             _logger = loggerFactory.CreateLogger<ScriptProjectSystem>();
@@ -84,7 +85,7 @@ namespace OmniSharp.Script
             var scriptOptions = new ScriptOptions();
             ConfigurationBinder.Bind(configuration, scriptOptions);
 
-            var scriptHelper = new ScriptHelper(scriptOptions, _env);
+            var scriptHelper = new ScriptHelper(scriptOptions, _env, _loggerFactory);
             _logger.LogInformation($"Detecting CSX files in '{_env.TargetDirectory}'.");
 
             // Nothing to do if there are no CSX files
@@ -112,7 +113,6 @@ namespace OmniSharp.Script
             // we will assume desktop framework
             // and add default CLR references
             // same applies for having a context that is not a .NET Core app
-
             if (!compilationDependencies.Any())
             {
                 _logger.LogInformation("Unable to find dependency context for CSX files. Will default to non-context usage (Desktop CLR scripts).");

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -23,7 +23,7 @@ namespace TestUtility
         public static void AddCsxProjectToWorkspace(OmniSharpWorkspace workspace, TestFile testFile)
         {
             var references = GetReferences();
-            var scriptHelper = new ScriptHelper(new ScriptOptions(), new OmniSharpEnvironment(), new LoggerFactory());            
+            var scriptHelper = new ScriptHelper(new ScriptOptions(), new OmniSharpEnvironment(), new LoggerFactory(), true);            
             var project = scriptHelper.CreateProject(testFile.FileName, references.Union(new[] { MetadataReference.CreateFromFile(typeof(CommandLineScriptGlobals).GetTypeInfo().Assembly.Location) }), testFile.FileName, Enumerable.Empty<string>());
             workspace.AddProject(project);
 

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -23,7 +23,7 @@ namespace TestUtility
         public static void AddCsxProjectToWorkspace(OmniSharpWorkspace workspace, TestFile testFile)
         {
             var references = GetReferences();
-            var scriptHelper = new ScriptHelper(new ScriptOptions(), new OmniSharpEnvironment());            
+            var scriptHelper = new ScriptHelper(new ScriptOptions(), new OmniSharpEnvironment(), new LoggerFactory());            
             var project = scriptHelper.CreateProject(testFile.FileName, references.Union(new[] { MetadataReference.CreateFromFile(typeof(CommandLineScriptGlobals).GetTypeInfo().Assembly.Location) }), testFile.FileName, Enumerable.Empty<string>());
             workspace.AddProject(project);
 

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -24,7 +24,7 @@ namespace TestUtility
         {
             var references = GetReferences();
             var scriptHelper = new ScriptHelper(new ScriptOptions());            
-            var project = scriptHelper.CreateProject(testFile.FileName, references.Union(new[] { MetadataReference.CreateFromFile(typeof(CommandLineScriptGlobals).GetTypeInfo().Assembly.Location) }), testFile.FileName,Enumerable.Empty<string>());
+            var project = scriptHelper.CreateProject(testFile.FileName, references.Union(new[] { MetadataReference.CreateFromFile(typeof(CommandLineScriptGlobals).GetTypeInfo().Assembly.Location) }), testFile.FileName, Enumerable.Empty<string>());
             workspace.AddProject(project);
 
             var documentInfo = DocumentInfo.Create(

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -23,7 +23,7 @@ namespace TestUtility
         public static void AddCsxProjectToWorkspace(OmniSharpWorkspace workspace, TestFile testFile)
         {
             var references = GetReferences();
-            var scriptHelper = new ScriptHelper(new ScriptOptions());            
+            var scriptHelper = new ScriptHelper(new ScriptOptions(), new OmniSharpEnvironment());            
             var project = scriptHelper.CreateProject(testFile.FileName, references.Union(new[] { MetadataReference.CreateFromFile(typeof(CommandLineScriptGlobals).GetTypeInfo().Assembly.Location) }), testFile.FileName, Enumerable.Empty<string>());
             workspace.AddProject(project);
 


### PR DESCRIPTION
Fixes #1024 

This PR introduces the ability to configure a path to RSP file which is picked up by the scripting project system.
The RSP is not supported in the compiler-specific traditional way (where it can configure almost all of the compilation options) but rather is just a vessel to provide custom assembly references (`/r:...`) and global namespaces (`/u:...`). This is consistent with CSI behavior, which also uses RSP files only for these two types of input (when it comes to compilation options at least).

The obvious user benefit of all of this is, if I built my own custom script runner using Roslyn Scripting Engine, I could use OmniSharp for intellisense and language services against it (or at least to certain degree). That's due to the fact that I'd be able to predefine my implicitly available namespaces and assembly references using an RSP file now.

The way it all works:

 - I can specify a path to an RSP file in my `omnisharp.json` file - at global or local level, relative or absolute

```
{
    "Script": {
        "EnableScriptNuGetReferences": true,
        "RspFilePath": "C:/omnisharp-ext/foo.rsp"
    }
}
```

 - if there are any namespaces in the RSP file, they **replace** the default set we normally have (the CSI-set) 
 - if there are any assembly references in the RSP file, they **are merged** with default set we have (the one we have is really only aiming to bring in `object` reference - this is default requirement of C# scripting anyway, hence the merge not replace)
 - this feature relies on an API that @DustinCampbell opened up recently https://github.com/dotnet/roslyn/pull/23435. However, that hasn't shipped yet, so the PR still is based on reflection. Not sure whether we want to wait with it until next Roslyn release is out?

As a bonus, I added strongly typed scripting configuration (it was dictionary based).
I will try to invent some creative way to test this, at the moment the PR comes without any tests unfortunately.