### PR TITLE
Consume latest MSBuild in OmniSharp

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -9,10 +9,10 @@
     <MicrosoftAspNetCoreHostingVersion>1.1.0</MicrosoftAspNetCoreHostingVersion>
     <MicrosoftAspNetCoreHttpFeaturesVersion>1.1.0</MicrosoftAspNetCoreHttpFeaturesVersion>
     <MicrosoftAspNetCoreServerKestrelVersion>1.1.0</MicrosoftAspNetCoreServerKestrelVersion>
-    <MicrosoftBuildVersion>15.3.409</MicrosoftBuildVersion>
-    <MicrosoftBuildFrameworkVersion>15.3.409</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildTasksCoreVersion>15.3.409</MicrosoftBuildTasksCoreVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>15.3.409</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildVersion>15.6.82</MicrosoftBuildVersion>
+    <MicrosoftBuildFrameworkVersion>15.6.82</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildTasksCoreVersion>15.6.82</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>15.6.82</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftCodeAnalysisCommonVersion>2.6.1</MicrosoftCodeAnalysisCommonVersion>
     <MicrosoftCodeAnalysisCSharpVersion>2.6.1</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftCodeAnalysisCSharpFeaturesVersion>2.6.1</MicrosoftCodeAnalysisCSharpFeaturesVersion>

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -40,10 +40,10 @@
     <MicrosoftVisualStudioSetupConfigurationInteropVersion>1.14.114</MicrosoftVisualStudioSetupConfigurationInteropVersion>
     <MicrosoftVisualStudioSDKEmbedInteropTypesVersion>15.0.12</MicrosoftVisualStudioSDKEmbedInteropTypesVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
-    <NuGetPackagingVersion>4.3.0</NuGetPackagingVersion>
-    <NuGetPackagingCoreVersion>4.3.0</NuGetPackagingCoreVersion>
-    <NuGetProjectModelVersion>4.3.0</NuGetProjectModelVersion>
-    <NuGetVersioningVersion>4.3.0</NuGetVersioningVersion>
+    <NuGetPackagingVersion>4.6.0</NuGetPackagingVersion>
+    <NuGetPackagingCoreVersion>4.6.0</NuGetPackagingCoreVersion>
+    <NuGetProjectModelVersion>4.6.0</NuGetProjectModelVersion>
+    <NuGetVersioningVersion>4.6.0</NuGetVersioningVersion>
     <SystemCollectionsImmutableVersion>1.4.0</SystemCollectionsImmutableVersion>
     <SystemCompositionVersion>1.0.31</SystemCompositionVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>


### PR DESCRIPTION
This should get us some of the performance fixes that went into VS 15.6. cc @jonsequitur 