### PR TITLE
Update OmniSharp to latest MSBuild

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,6 +4,5 @@
         <clear />
         <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
         <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-        <add key="dotnet-cli" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     </packageSources>
 </configuration>

--- a/build.json
+++ b/build.json
@@ -12,8 +12,8 @@
   "MonoRuntimeLinux32": "mono.linux-x86-5.10.1.20.zip",
   "MonoRuntimeLinux64": "mono.linux-x86_64-5.10.1.20.zip",
   "MonoFramework": "framework-5.10.1.20.zip",
-  "MonoMSBuildRuntime": "Microsoft.Build.Runtime.Mono-alpha6.zip",
-  "MonoMSBuildLib": "Microsoft.Build.Lib.Mono-alpha6.zip",
+  "MonoMSBuildRuntime": "Microsoft.Build.Runtime.Mono-mono-5.10.1.20.zip",
+  "MonoMSBuildLib": "Microsoft.Build.Lib.Mono-mono-5.10.1.20.zip",
   "HostProjects": [
     "OmniSharp.Stdio",
     "OmniSharp.Http"

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -9,10 +9,10 @@
     <MicrosoftAspNetCoreHostingVersion>1.1.0</MicrosoftAspNetCoreHostingVersion>
     <MicrosoftAspNetCoreHttpFeaturesVersion>1.1.0</MicrosoftAspNetCoreHttpFeaturesVersion>
     <MicrosoftAspNetCoreServerKestrelVersion>1.1.0</MicrosoftAspNetCoreServerKestrelVersion>
-    <MicrosoftBuildVersion>15.3.409</MicrosoftBuildVersion>
-    <MicrosoftBuildFrameworkVersion>15.3.409</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildTasksCoreVersion>15.3.409</MicrosoftBuildTasksCoreVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>15.3.409</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildVersion>15.6.82</MicrosoftBuildVersion>
+    <MicrosoftBuildFrameworkVersion>15.6.82</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildTasksCoreVersion>15.6.82</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>15.6.82</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftCodeAnalysisCommonVersion>2.7.0</MicrosoftCodeAnalysisCommonVersion>
     <MicrosoftCodeAnalysisCSharpVersion>2.7.0</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftCodeAnalysisCSharpFeaturesVersion>2.7.0</MicrosoftCodeAnalysisCSharpFeaturesVersion>

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
@@ -30,19 +30,29 @@ namespace OmniSharp.MSBuild.Discovery.Providers
 
             var propertyOverrides = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            // To better support older versions of Mono that don't include
-            // MSBuild 15, we attempt to set property overrides to the locations
-            // of Mono's 'xbuild' and 'xbuild-frameworks' paths.
-            if (_allowMonoPaths && PlatformHelper.IsMono)
+            if (PlatformHelper.IsMono)
             {
-                if (TryGetMonoXBuildPath(out var xbuildPath))
-                {
-                    extensionsPath = xbuildPath;
-                }
+                // This disables a hack in the "GetReferenceAssemblyPaths" task which attempts
+                // guarantee that .NET Framework SP1 is installed when the target framework is
+                // .NET Framework, but the version is less than 4.0. The hack attempts to locate
+                // a particular assembly in the GAC as a "guarantee". However, we don't include that
+                // in our Mono package. So, we'll just bypass the check.
+                propertyOverrides.Add("BypassFrameworkInstallChecks", "true");
 
-                if (TryGetMonoXBuildFrameworksPath(out var xbuildFrameworksPath))
+                // To better support older versions of Mono that don't include
+                // MSBuild 15, we attempt to set property overrides to the locations
+                // of Mono's 'xbuild' and 'xbuild-frameworks' paths.
+                if (_allowMonoPaths)
                 {
-                    propertyOverrides.Add("TargetFrameworkRootPath", xbuildFrameworksPath);
+                    if (TryGetMonoXBuildPath(out var xbuildPath))
+                    {
+                        extensionsPath = xbuildPath;
+                    }
+
+                    if (TryGetMonoXBuildFrameworksPath(out var xbuildFrameworksPath))
+                    {
+                        propertyOverrides.Add("TargetFrameworkRootPath", xbuildFrameworksPath);
+                    }
                 }
             }
 

--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
@@ -7,6 +7,7 @@
         public const string AssemblyOriginatorKeyFile = nameof(AssemblyOriginatorKeyFile);
         public const string BuildProjectReferences = nameof(BuildProjectReferences);
         public const string BuildingInsideVisualStudio = nameof(BuildingInsideVisualStudio);
+        public const string BypassFrameworkInstallChecks = nameof(BypassFrameworkInstallChecks);
         public const string Configuration = nameof(Configuration);
         public const string CscToolExe = nameof(CscToolExe);
         public const string CscToolPath = nameof(CscToolPath);

--- a/src/OmniSharp.MSBuild/ProjectLoader.cs
+++ b/src/OmniSharp.MSBuild/ProjectLoader.cs
@@ -52,6 +52,11 @@ namespace OmniSharp.MSBuild
             globalProperties.AddPropertyOverride(PropertyNames.Configuration, options.Configuration, propertyOverrides, logger);
             globalProperties.AddPropertyOverride(PropertyNames.Platform, options.Platform, propertyOverrides, logger);
 
+            if (propertyOverrides.TryGetValue(PropertyNames.BypassFrameworkInstallChecks, out var value))
+            {
+                globalProperties.Add(PropertyNames.BypassFrameworkInstallChecks, value);
+            }
+
             return globalProperties;
         }
 

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,13 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Cake" version="0.23" />
-    <package id="Microsoft.Build" version="15.3.409" />
-    <package id="Microsoft.Build.Framework" version="15.3.409" />
-    <package id="Microsoft.Build.Runtime" version="15.3.409" />
-    <package id="Microsoft.Build.Tasks.Core" version="15.3.409" />
-    <package id="Microsoft.Build.Utilities.Core" version="15.3.409" />
-    <package id="Microsoft.Net.Compilers" version="2.3.2" />
+    <package id="Microsoft.Build" version="15.6.82" />
+    <package id="Microsoft.Build.Framework" version="15.6.82" />
+    <package id="Microsoft.Build.Runtime" version="15.6.82" />
+    <package id="Microsoft.Build.Tasks.Core" version="15.6.82" />
+    <package id="Microsoft.Build.Utilities.Core" version="15.6.82" />
+    <package id="Microsoft.Net.Compilers" version="2.7.0" />
     <package id="Microsoft.DotNet.MSBuildSdkResolver" version="2.1.300-preview2-008523" />
+    <package id="NuGet.Build.Tasks" version="4.6.1" />
+    <package id="NuGet.Commands" version="4.6.1" />
+    <package id="NuGet.Common" version="4.6.1" />
+    <package id="NuGet.Configuration" version="4.6.1" />
+    <package id="NuGet.Frameworks" version="4.6.1" />
+    <package id="NuGet.ProjectModel" version="4.6.1" />
+    <package id="NuGet.Protocol" version="4.6.1" />
+    <package id="NuGet.Versioning" version="4.6.1" />
     <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="2.1.0-preview3-26404-02" />
     <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="2.1.0-preview3-26404-02" />
     <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="2.1.0-preview3-26404-02" />


### PR DESCRIPTION
This change updates OmniSharp with the latest MSBuild binaries. Recent performance changes for MSBuild now require NuGet.Build.Tasks, which requires a set of NuGet binaries be included as well. Because the versions of these NuGet binaries might be different (actually, they *are* different) than the binaries that OmniSharp uses, there's a bit of duplication.