### PR TITLE
Further build performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ addons:
 install:
 - |
   if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    # On Linux, we build libuv from source
     sudo apt-get install make automake libtool
     curl -sSL https://github.com/libuv/libuv/archive/v1.14.0.tar.gz | sudo tar zxf - -C /usr/local/src
     pushd /usr/local/src/libuv-1.14.0
@@ -51,14 +52,7 @@ install:
     sudo rm -rf /usr/local/src/libuv-1.14.0
     sudo ldconfig
   elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    brew update
-
-    # Need to install openssl for .NET Core SDK 1.0 (legacy tests)
-    brew install openssl
-    mkdir -p /usr/local/lib
-    ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
-    ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
-
+    # On OSX, we install libuv via Homebrew
     brew install libuv
   fi
 - export PATH="$PWD/.dotnet:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,6 @@ os:
 - linux
 - osx
 osx_image: xcode9.2
-cache:
-  directories:
-  - tools
-  - ".dotnet-legacy"
-  - "$HOME/.nuget/packages"
-before_cache:
-- rm -f tools/packages.config
 script:
 - git fetch --unshallow
 - git fetch origin '+refs/heads/*:refs/heads/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - secure: m2PtYwYOhaK0uFMZ19ZxApZwWZeAIq1dS//jx/5I3txpIWD+TfycQMAWYxycFJ/GJkeVF29P4Zz1uyS2XKKjPJpp2Pds98FNQyDv3OftpLAVa0drsjfhurVlBmSdrV7GH6ncKfvhd+h7KVK5vbZc+NeR4dH7eNvN/jraS//AMJg=
   - secure: EA2fP5ymar2/ZM2G4cyP3FzK437zv1wP03AgUPCcQgke8Z5oG8Y5U632AzxBeeaqGAxHEi5Ewbq2A8N93pN+xAsoGlQf+AdLJROCeo7gy9O589Z8tmp/vAdMzZzyNhKi7SUSxOJ/TIDzLMlvBHZwj1XqFyCbOGABzkxl9sW4+uk=
   - secure: UYglcVukRlhS09V7MXwMQ5pU6gZZZ+bsaKnCSlPV+CQyh+ExabEYYmF7NBJirF/RDK30tbuI6mlSYagjX18PpLZ3390WI3WkKRbP0F1SfylHKlMh5MDcKNTsSwYMcQ0BX7teg7kpYmxbigP7jing8LPehP/QdQAhnkhpdXe1P/o=
+  - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 mono: 5.8.0
 os:
 - linux
@@ -60,7 +61,6 @@ install:
 
     brew install libuv
   fi
-- export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 - export PATH="$PWD/.dotnet:$PATH"
 after_success: |
   if [[ "$TRAVIS_OS_NAME" == "linux" && $TRAVIS_BRANCH == "master" && $TRAVIS_PULL_REQUEST == "false" ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@
 init:
   - git config --global core.autocrlf true
 image: Visual Studio 2017
+environment:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 test: off # this turns of AppVeyor automatic searching for test-assemblies, not the actual testing
 build_script:
   - ps: .\build.ps1 -configuration Release -target All -publish-all -archive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@ build_script:
   - ps: .\build.ps1 -configuration Release -target All -publish-all -archive
 after_build:
   - ps: Get-ChildItem ./artifacts/package/*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-cache:
-  - tools -> tools/packages.config
 deploy:
   - provider: GitHub
     tag: $(APPVEYOR_REPO_TAG_NAME)


### PR DESCRIPTION
These aren't huge improvements, but they help a bit.

* Ensure that we set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true for ALL CI builds to avoid the first run population of the NuGet cache. Previously, we only did this for Travis. Now we do it for AppVeyor as well.
* Don't install openssl on OSX builds. At one time, this was needed for the legacy .NET Core SDK, but we don't even run those tests on OSX builds anymore.
* Disable caching in CI builds.

    Now that the build performance has been improved a great deal, it's clear that the build caching itself is taking a big chunk of time. On Linux, it takes ~90 seconds to set up the build cache and about ~130 to pack and upload the cache. From what I can tell, it does this for every single build, adding around 3.5 minutes on Linux. Disabling the caching wins back ~2-3 minutes on Linux builds.