### PR TITLE
Remove unnecessary binding redirect from tests app.config

### DIFF
--- a/tests/app.config
+++ b/tests/app.config
@@ -61,10 +61,6 @@
                 <bindingRedirect oldVersion="0.0.0.0-1.0.31.0" newVersion="1.0.31.0"/>
             </dependentAssembly>
             <dependentAssembly>
-                <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
-            </dependentAssembly>
-            <dependentAssembly>
                 <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
                 <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
             </dependentAssembly>


### PR DESCRIPTION
This is causing warnings during builds and doesn't appear to be necessary.