### PR TITLE
Allow defining script target framework via configuration

### DIFF
--- a/src/OmniSharp.Script/ScriptHelper.cs
+++ b/src/OmniSharp.Script/ScriptHelper.cs
@@ -22,7 +22,7 @@ namespace OmniSharp.Script
         private const string ResolverField = "_resolver";
         private const string FileReferenceProviderField = "_fileReferenceProvider";
 
-        private readonly IConfiguration _configuration;
+        private readonly ScriptOptions _scriptOptions;
 
         // aligned with CSI.exe
         // https://github.com/dotnet/roslyn/blob/version-2.0.0-rc3/src/Interactive/csi/csi.rsp
@@ -45,9 +45,9 @@ namespace OmniSharp.Script
         private readonly Lazy<CSharpCompilationOptions> _compilationOptions;
         private readonly MetadataReferenceResolver _resolver = ScriptMetadataResolver.Default;
 
-        public ScriptHelper(IConfiguration configuration = null)
+        public ScriptHelper(ScriptOptions scriptOptions)
         {
-            _configuration = configuration;
+            _scriptOptions = scriptOptions;
             _compilationOptions = new Lazy<CSharpCompilationOptions>(CreateCompilationOptions);
             InjectXMLDocumentationProviderIntoRuntimeMetadataReferenceResolver();
         }
@@ -84,17 +84,7 @@ namespace OmniSharp.Script
 
         private CachingScriptMetadataResolver CreateMetadataReferenceResolver()
         {
-            bool enableScriptNuGetReferences = false;
-
-            if (_configuration != null)
-            {
-                if (!bool.TryParse(_configuration["enableScriptNuGetReferences"], out enableScriptNuGetReferences))
-                {
-                    enableScriptNuGetReferences = false;
-                }
-            }
-            
-            return enableScriptNuGetReferences
+            return _scriptOptions.IsNugetEnabled()
                 ? new CachingScriptMetadataResolver(new NuGetMetadataReferenceResolver(_resolver))
                 : new CachingScriptMetadataResolver(_resolver);
         }

--- a/src/OmniSharp.Script/ScriptOptions.cs
+++ b/src/OmniSharp.Script/ScriptOptions.cs
@@ -7,5 +7,12 @@ namespace OmniSharp.Script
         public bool EnableScriptNuGetReferences { get; set; }
 
         public string DefaultTargetFramework { get; set; } = "net46";
+
+        /// <summary>  
+        ///  Nuget for scripts is enabled when <see cref="EnableScriptNuGetReferences"/> is enabled or when <see cref="DefaultTargetFramework"/> is .NET Core
+        /// </summary>  
+        public bool IsNugetEnabled() =>
+            EnableScriptNuGetReferences ||
+            (DefaultTargetFramework != null && DefaultTargetFramework.StartsWith("netcoreapp", System.StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/OmniSharp.Script/ScriptOptions.cs
+++ b/src/OmniSharp.Script/ScriptOptions.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace OmniSharp.Script
+{
+    public class ScriptOptions
+    {
+        public bool EnableScriptNuGetReferences { get; set; }
+
+        public string DefaultTargetFramework { get; set; } = "net46";
+    }
+}

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -39,8 +39,8 @@ namespace OmniSharp.Script
 
         private readonly CompilationDependencyResolver _compilationDependencyResolver;
 
+        private ScriptOptions _scriptOptions;
         private ScriptHelper _scriptHelper;
-        private bool _enableScriptNuGetReferences;
         private CompilationDependency[] _compilationDependencies;
 
         [ImportingConstructor]
@@ -79,7 +79,9 @@ namespace OmniSharp.Script
 
         public void Initalize(IConfiguration configuration)
         {
-            _scriptHelper = new ScriptHelper(configuration);
+            _scriptOptions = new ScriptOptions();
+            ConfigurationBinder.Bind(configuration, _scriptOptions);
+            _scriptHelper = new ScriptHelper(_scriptOptions);
 
             _logger.LogInformation($"Detecting CSX files in '{_env.TargetDirectory}'.");
 
@@ -101,12 +103,7 @@ namespace OmniSharp.Script
             inheritedCompileLibraries.AddRange(DependencyContext.Default.CompileLibraries.Where(x =>
                 x.Name.ToLowerInvariant().StartsWith("system.valuetuple")));
 
-            if (!bool.TryParse(configuration["enableScriptNuGetReferences"], out _enableScriptNuGetReferences))
-            {
-                _enableScriptNuGetReferences = false;
-            }
-
-            _compilationDependencies = TryGetCompilationDependencies(_enableScriptNuGetReferences);
+            _compilationDependencies = TryGetCompilationDependencies();
 
             // if we have no compilation dependencies
             // we will assume desktop framework
@@ -171,7 +168,7 @@ namespace OmniSharp.Script
                 var csxFileName = Path.GetFileName(csxPath);
                 var project = _scriptHelper.CreateProject(csxFileName, _commonReferences, csxPath);
 
-                if (_enableScriptNuGetReferences)
+                if (_scriptOptions.IsNugetEnabled())
                 {
                     var scriptMap = _compilationDependencies.ToDictionary(rdt => rdt.Name, rdt => rdt.Scripts);
                     var options = project.CompilationOptions.WithSourceReferenceResolver(
@@ -201,11 +198,12 @@ namespace OmniSharp.Script
             }
         }
 
-        private CompilationDependency[] TryGetCompilationDependencies(bool enableScriptNuGetReferences)
+        private CompilationDependency[] TryGetCompilationDependencies()
         {
             try
             {
-                return _compilationDependencyResolver.GetDependencies(_env.TargetDirectory, enableScriptNuGetReferences).ToArray();
+                _logger.LogInformation($"Searching for compilation dependencies for target fallback framework '{_scriptOptions.DefaultTargetFramework}'.");
+                return _compilationDependencyResolver.GetDependencies(_env.TargetDirectory, _scriptOptions.IsNugetEnabled(), _scriptOptions.DefaultTargetFramework).ToArray();
             }
             catch (Exception e)
             {

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -202,7 +202,7 @@ namespace OmniSharp.Script
         {
             try
             {
-                _logger.LogInformation($"Searching for compilation dependencies for target fallback framework '{_scriptOptions.DefaultTargetFramework}'.");
+                _logger.LogInformation($"Searching for compilation dependencies with the fallback framework of '{_scriptOptions.DefaultTargetFramework}'.");
                 return _compilationDependencyResolver.GetDependencies(_env.TargetDirectory, _scriptOptions.IsNugetEnabled(), _scriptOptions.DefaultTargetFramework).ToArray();
             }
             catch (Exception e)

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -23,7 +23,7 @@ namespace TestUtility
         public static void AddCsxProjectToWorkspace(OmniSharpWorkspace workspace, TestFile testFile)
         {
             var references = GetReferences();
-            var scriptHelper = new ScriptHelper();            
+            var scriptHelper = new ScriptHelper(new ScriptOptions());            
             var project = scriptHelper.CreateProject(testFile.FileName, references.Union(new[] { MetadataReference.CreateFromFile(typeof(CommandLineScriptGlobals).GetTypeInfo().Assembly.Location) }), testFile.FileName,Enumerable.Empty<string>());
             workspace.AddProject(project);
 


### PR DESCRIPTION
At the moment, in the script project system, the following model is used:

 - default everything to desktop CLR / `net46`, without Nuget support in scripts - to support typical usage with `csi.exe` for Desktop .NET
 - if the user enabled Nuget support by setting `EnableScriptNuGetReferences  = true` in the OmniSharp settings, then OmniSharp additionally can resolve inline script NuGet packages (also in `net46` context)
 - on top of that, if the script contained a framework directive: `!# "netcoreapp2.0"` then OmniSharp used .NET Core context instead of Desktop .NET to resolve the packages - the typical usage scenario are folks running scripts with dotnet-script for .NET Core

This PR allows implicitly setting the framework version via the configuration file, instead of just reading it via the `!# "{framework}"`.
For example, I could have an `omnisharp.json` file:

```
{
    "script": {
        "defaultTargetFramework": "netcoreapp2.0"
    }
}
```

This means that I can now author *all* my scripts without `!# "netcoreapp2.0"`. This is beneficial for users who do not care about `csi.exe` and want to always use Nuget package resolution in scripts + .NET Core only for scripting. 
Additionally, the way the code is set up, setting .NET Core as `defaultTargetFramework` would automatically opt into nuget package references since the two must go together. 

As a bonus I added a strongly typed config object for script project system.