### PR TITLE
Set MSBuild property to allow the XAML markup compiler task to run

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
@@ -3,6 +3,7 @@
     internal static class PropertyNames
     {
         public const string AllowUnsafeBlocks = nameof(AllowUnsafeBlocks);
+        public const string AlwaysCompileMarkupFilesInSeparateDomain = nameof(AlwaysCompileMarkupFilesInSeparateDomain);
         public const string AssemblyName = nameof(AssemblyName);
         public const string AssemblyOriginatorKeyFile = nameof(AssemblyOriginatorKeyFile);
         public const string BuildProjectReferences = nameof(BuildProjectReferences);

--- a/src/OmniSharp.MSBuild/ProjectLoader.cs
+++ b/src/OmniSharp.MSBuild/ProjectLoader.cs
@@ -37,6 +37,13 @@ namespace OmniSharp.MSBuild
                 { PropertyNames._ResolveReferenceDependencies, "true" },
                 { PropertyNames.SolutionDir, solutionDirectory + Path.DirectorySeparatorChar },
 
+                // Setting this property will cause any XAML markup compiler tasks to run in the
+                // current AppDomain, rather than creating a new one. This is important because
+                // our AppDomain.AssemblyResolve handler for MSBuild will not be connected to
+                // the XAML markup compiler's AppDomain, causing the task not to be able to find
+                // MSBuild.
+                { PropertyNames.AlwaysCompileMarkupFilesInSeparateDomain, "false" },
+
                 // This properties allow the design-time build to handle the Compile target without actually invoking the compiler.
                 // See https://github.com/dotnet/roslyn/pull/4604 for details.
                 { PropertyNames.ProvideCommandLineArgs, "true" },


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/2173

We need to set the AlwaysCompileMarkupFilesInSeparateDomain property to false. Otherwise, the XAML markup compiler task will try to create an AppDomain to run the markup compiler in. In normal MSBuild scenarios, this is fine. However, in OmniSharp, our AppDomain.AssemblyResolve handler that's used to locate MSBuild will not be installed in the marker compiler task's AppDomain, causing it to fail.