### PR TITLE
Ensure that we don't subscribe the same file-watcher callback multiple times

### DIFF
--- a/src/OmniSharp.Host/FileWatching/ManualFileSystemWatcher.Callbacks.cs
+++ b/src/OmniSharp.Host/FileWatching/ManualFileSystemWatcher.Callbacks.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+namespace OmniSharp.FileWatching
+{
+    internal partial class ManualFileSystemWatcher
+    {
+        private class Callbacks
+        {
+            private List<FileSystemNotificationCallback> _callbacks = new List<FileSystemNotificationCallback>();
+            private HashSet<FileSystemNotificationCallback> _callbackSet = new HashSet<FileSystemNotificationCallback>();
+
+            public void Add(FileSystemNotificationCallback callback)
+            {
+                if (_callbackSet.Add(callback))
+                {
+                    _callbacks.Add(callback);
+                }
+            }
+
+            public void Invoke(string filePath, FileChangeType changeType)
+            {
+                foreach (var callback in _callbacks)
+                {
+                    callback(filePath, changeType);
+                }
+            }
+        }
+    }
+}

--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -51,6 +51,8 @@ namespace OmniSharp.MSBuild
         private readonly Task _processLoopTask;
         private bool _processingQueue;
 
+        private readonly FileSystemNotificationCallback _onDirectoryFileChanged;
+
         public ProjectManager(ILoggerFactory loggerFactory, IEventEmitter eventEmitter, IFileSystemWatcher fileSystemWatcher, MetadataFileReferenceCache metadataFileReferenceCache, PackageDependencyChecker packageDependencyChecker, ProjectLoader projectLoader, OmniSharpWorkspace workspace)
         {
             _logger = loggerFactory.CreateLogger<ProjectManager>();
@@ -65,6 +67,8 @@ namespace OmniSharp.MSBuild
             _queue = new BufferBlock<ProjectToUpdate>();
             _processLoopCancellation = new CancellationTokenSource();
             _processLoopTask = Task.Run(() => ProcessLoopAsync(_processLoopCancellation.Token));
+
+            _onDirectoryFileChanged = OnDirectoryFileChanged;
         }
 
         protected override void DisposeCore(bool disposing)
@@ -319,7 +323,7 @@ namespace OmniSharp.MSBuild
             // Add source files to the project.
             foreach (var sourceFile in sourceFiles)
             {
-                _fileSystemWatcher.Watch(Path.GetDirectoryName(sourceFile), OnDirectoryFileChanged);
+                _fileSystemWatcher.Watch(Path.GetDirectoryName(sourceFile), _onDirectoryFileChanged);
 
                 // If a document for this source file already exists in the project, carry on.
                 if (currentDocuments.Remove(sourceFile))


### PR DESCRIPTION
While refactoring some code, I noticed that we were queuing the same callback with the `IFileSystemWatcher` many, many times in order to watch source file directories. That means that these callbacks would be called multiple times for any notification. This change expands the `ManualFileSystemWatcher` to only add the same callback for a particular extension, file or directory once. Note that the callback is only checked for reference equality, so it's necessary to stash your callback in a field if you don't want it added multiple times.