### PR TITLE
Report better version for VS preview consoles

### DIFF
--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/DevConsoleInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/DevConsoleInstanceProvider.cs
@@ -38,6 +38,17 @@ namespace OmniSharp.MSBuild.Discovery.Providers
 
             if (version == null)
             {
+                var dashIndex = versionString.IndexOf('-');
+
+                if (dashIndex > 0)
+                {
+                    versionString = versionString.Substring(0, dashIndex);
+                    Version.TryParse(versionString, out version);
+                }
+            }
+
+            if (version == null)
+            {
                 versionString = Environment.GetEnvironmentVariable("VisualStudioVersion");
                 Version.TryParse(versionString, out version);
             }


### PR DESCRIPTION
For prereleases, the Visual Studio command prompt sets the environment
variable `VSCMD_VER` to a value like `15.7.0-pre.3.0`, which is not
parseable by System.Version.

This could be handled by using a version parser that can handle this
SemVer 2 version as well as Windows 4-part versions, but that would be
another dependency, so I just special-cased the problematic dash.