### PR TITLE
when fixing usings, return namespaces associated with ambiguous result

### DIFF
--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FixUsingsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FixUsingsFacts.cs
@@ -250,7 +250,7 @@ namespace OmniSharp
                     Line = point.Line,
                     Column = point.Offset,
                     FileName = TestFileName,
-                    Text = "`classX` is ambiguous"
+                    Text = "`classX` is ambiguous. Namespaces: using nsA; using nsB;",
                 }
             };
 


### PR DESCRIPTION
the potential using statements are added to the Text of the QuickFix response, allowing the user manually choose which using statement to employ.