### PR TITLE
Downgrade the System.Threading.Tasks.Dataflow dependency to the version actually needed by MSBuild

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -47,7 +47,7 @@
     <SystemCollectionsImmutableVersion>1.4.0</SystemCollectionsImmutableVersion>
     <SystemCompositionVersion>1.0.31</SystemCompositionVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
-    <SystemThreadingTasksDataflowVersion>4.6.0</SystemThreadingTasksDataflowVersion>
+    <SystemThreadingTasksDataflowVersion>4.5.24</SystemThreadingTasksDataflowVersion>
     <SystemValueTupleVersion>4.3.0</SystemValueTupleVersion>
     <XunitRunnerVisualStudioVersion>2.3.1</XunitRunnerVisualStudioVersion>
     <XunitVersion>2.3.1</XunitVersion>


### PR DESCRIPTION
The net46 version of `Microsoft.Build` has an assembly reference to `System.Threading.Tasks.Dataflow` version `4.5.24.0`. However, we were incorrectly referencing the `4.6.0` of the `System.Threading.Tasks.Dataflow` NuGet package. That was due to the fact that the netstandard1.5 version of `Microsoft.Build` depends on version `4.6.0` of the same package. I suspect our dependency wasn't updated when I moved OmniSharp away from netstandard1.6 to net46 last year.

The issue here is that the embedded Mono won't locate the `System.Threading.Tasks.Dataflow` that `Microsoft.Build` requires. If the user happens to have Mono installed, it might find it there. However, it might not if the user is on OSX and has a different version of Mono installed than our embedded Mono. We can fix it by just referencing the right version that Microsoft.Build needs.