### PR TITLE
Handle CSProj files that are not C# projects that 

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;


### PR DESCRIPTION
The proposed changes allow OmniSharp not to stop processing projects when it encounters a file with CSProj extension that is not a C# project. At the moment I'm working with a repo where out of 736 CSProj files 229 are of this sort. They typically are TypeScript projects, projects that copy files into final release folder and project files used only as data inputs for test cases. With my changes, OmniSharp invoked from VSCode was able to successfully process all valid C# projects while ignoring the rest.