### PR TITLE
in scripting, load inherited assemblies from the current AppDomain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to the project will be documented in this file.
 ## [1.31.0] - _Not Yet Released_
 * Update to Roslyn 2.8.0 packages, adding support for C# 7.3. (PR: [#1182](https://github.com/OmniSharp/omnisharp-roslyn/pull/1182))
 * MSBuild project system no longer stops when a project fails to load. (PR: [#1181](https://github.com/OmniSharp/omnisharp-roslyn/pull/1181)) 
+* Fixed a 1.30.0 regression that prevented script project system from working on Unix-based systems (PR: [#1185](https://github.com/OmniSharp/omnisharp-roslyn/pull/1185))
 
 ## [1.30.0] - 2018-4-30
 * Updated to Roslyn 2.7.0 packages (PR: [#1132](https://github.com/OmniSharp/omnisharp-roslyn/pull/1132))


### PR DESCRIPTION
Fixes #1184 

Rather than trying to resolve them from `OmniSharp.deps.json` with `Microsoft.Extensions.DependencyModel`, we just grab them from the current AppDomain. This is much simpler and much more reliable, because we have seen now that it's possible for `Microsoft.Extensions.DependencyModel` to throw on non-Windows platforms.

This is impossible to test from unit tests. In fact we have a unit test that check the correct behavior of the script host object (which is really the case here) but as mentioned in #1184, the problem only manifested itself in certain situation.