### PR TITLE
Fix potential null-ref in MSBuild discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to the project will be documented in this file.
 ## [1.31.0] - _Not Yet Released_
 * Update to Roslyn 2.8.0 packages, adding support for C# 7.3. (PR: [#1182](https://github.com/OmniSharp/omnisharp-roslyn/pull/1182))
 * MSBuild project system no longer stops when a project fails to load. (PR: [#1181](https://github.com/OmniSharp/omnisharp-roslyn/pull/1181)) 
+* Fixed null-reference exception that could be thrown during MSBuild discovery. ([#1188](https://github.com/OmniSharp/omnisharp-roslyn/issues/1188), PR: [#1189](https://github.com/OmniSharp/omnisharp-roslyn/issues/1188))
 
 ## [1.30.1] - 2018-05-11
 * Fixed a 1.30.0 regression that prevented the script project system from working on Unix-based systems (PR: [#1185](https://github.com/OmniSharp/omnisharp-roslyn/pull/1185))

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/DevConsoleInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/DevConsoleInstanceProvider.cs
@@ -36,7 +36,7 @@ namespace OmniSharp.MSBuild.Discovery.Providers
             var versionString = Environment.GetEnvironmentVariable("VSCMD_VER");
             Version.TryParse(versionString, out var version);
 
-            if (version == null)
+            if (version == null && versionString != null)
             {
                 var dashIndex = versionString.IndexOf('-');
 


### PR DESCRIPTION
Fixes #1188

This fixes a null-reference extension that can be thrown if the "VSINSTALLDIR" environment variable exists but "VSCMD_VER" does not.