### PR TITLE
Remove MSBuildSDKsPath hack that blocks MSBuild SDK resolvers

### DIFF
--- a/build.json
+++ b/build.json
@@ -8,12 +8,12 @@
   "LegacyDotNetVersion": "1.0.0-preview2-1-003177",
   "RequiredMonoVersion": "5.8.0.0",
   "DownloadURL": "https://omnisharpdownload.blob.core.windows.net/ext",
-  "MonoRuntimeMacOS": "mono.osx-5.10.1.20.zip",
-  "MonoRuntimeLinux32": "mono.linux-x86-5.10.1.20.zip",
-  "MonoRuntimeLinux64": "mono.linux-x86_64-5.10.1.20.zip",
-  "MonoFramework": "framework-5.10.1.20.zip",
-  "MonoMSBuildRuntime": "Microsoft.Build.Runtime.Mono-mono-5.10.1.20.zip",
-  "MonoMSBuildLib": "Microsoft.Build.Lib.Mono-mono-5.10.1.20.zip",
+  "MonoRuntimeMacOS": "mono.osx-5.12.0.226.zip",
+  "MonoRuntimeLinux32": "mono.linux-x86-5.12.0.226.zip",
+  "MonoRuntimeLinux64": "mono.linux-x86_64-5.12.0.226.zip",
+  "MonoFramework": "framework-5.12.0.226.zip",
+  "MonoMSBuildRuntime": "Microsoft.Build.Runtime.Mono-5.12.0.226.zip",
+  "MonoMSBuildLib": "Microsoft.Build.Lib.Mono-5.12.0.226.zip",
   "HostProjects": [
     "OmniSharp.Stdio.Driver",
     "OmniSharp.Http.Driver"

--- a/src/OmniSharp.Abstractions/Services/IDotNetCliService.cs
+++ b/src/OmniSharp.Abstractions/Services/IDotNetCliService.cs
@@ -1,0 +1,59 @@
+﻿using NuGet.Versioning;
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace OmniSharp.Services
+{
+    public interface IDotNetCliService
+    {
+        /// <summary>
+        /// The path used to launch the .NET CLI. By default, this is "dotnet".
+        /// </summary>
+        string DotNetPath { get; }
+
+        /// <summary>
+        /// Launches "dotnet --info" in the given wotking directory and returns a
+        /// <see cref="DotNetInfo"/> representing the returned information text.
+        /// </summary>
+        DotNetInfo GetInfo(string workingDirectory = null);
+
+        /// <summary>
+        /// Launches "dotnet --version" in the given working directory and returns a
+        /// <see cref="SemanticVersion"/> representing the returned version text.
+        /// </summary>
+        SemanticVersion GetVersion(string workingDirectory = null);
+
+        /// <summary>
+        /// Launches "dotnet --version" in the given working directory and determines
+        /// whether the result represents a "legacy" .NET CLI. If true, this .NET
+        /// CLI supports project.json development; otherwise, it supports .csproj
+        /// development.
+        /// </summary>
+        bool IsLegacy(string workingDirectory = null);
+
+        /// <summary>
+        /// Determines whether the specified version is from a "legacy"
+        /// .NET CLI. If true, this .NET CLI supports project.json development;
+        /// otherwise, it supports .csproj development.
+        /// </summary>
+        bool IsLegacy(SemanticVersion version);
+
+        /// <summary>
+        /// Launches "dotnet restore" in the given working directory.
+        /// </summary>
+        /// <param name="workingDirectory">The working directory to launch "dotnet restore" within.</param>
+        /// <param name="arguments">Additional arguments to pass to "dotnet restore"</param>
+        /// <param name="onFailure">A callback that will be invoked if "dotnet restore" does not
+        /// return a success code.</param>
+        Task RestoreAsync(string workingDirectory, string arguments = null, Action onFailure = null);
+
+        /// <summary>
+        /// Launches "dotnet" in the given working directory with the specified arguments.
+        /// </summary>
+        /// <param name="arguments"></param>
+        /// <param name="workingDirectory"></param>
+        /// <returns></returns>
+        Process Start(string arguments, string workingDirectory);
+    }
+}

--- a/src/OmniSharp.DotNet/DotNetProjectSystem.cs
+++ b/src/OmniSharp.DotNet/DotNetProjectSystem.cs
@@ -30,7 +30,7 @@ namespace OmniSharp.DotNet
 
         private readonly IOmniSharpEnvironment _environment;
         private readonly OmniSharpWorkspace _workspace;
-        private readonly DotNetCliService _dotNetCliService;
+        private readonly IDotNetCliService _dotNetCliService;
         private readonly MetadataFileReferenceCache _metadataFileReferenceCache;
         private readonly IEventEmitter _eventEmitter;
         private readonly IFileSystemWatcher _fileSystemWatcher;
@@ -44,7 +44,7 @@ namespace OmniSharp.DotNet
         public DotNetProjectSystem(
             IOmniSharpEnvironment environment,
             OmniSharpWorkspace workspace,
-            DotNetCliService dotNetCliService,
+            IDotNetCliService dotNetCliService,
             MetadataFileReferenceCache metadataFileReferenceCache,
             IEventEmitter eventEmitter,
             IFileSystemWatcher fileSystemWatcher,

--- a/src/OmniSharp.DotNetTest/Legacy/LegacyTestManager.cs
+++ b/src/OmniSharp.DotNetTest/Legacy/LegacyTestManager.cs
@@ -29,7 +29,7 @@ namespace OmniSharp.DotNetTest.Legacy
         private const string TestExecution_GetTestRunnerProcessStartInfo = "TestExecution.GetTestRunnerProcessStartInfo";
         private const string TestExecution_TestResult = "TestExecution.TestResult";
 
-        public LegacyTestManager(Project project, string workingDirectory, DotNetCliService dotNetCli, SemanticVersion dotNetCliVersion, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
+        public LegacyTestManager(Project project, string workingDirectory, IDotNetCliService dotNetCli, SemanticVersion dotNetCliVersion, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
             : base(project, workingDirectory, dotNetCli, dotNetCliVersion, eventEmitter, loggerFactory.CreateLogger<LegacyTestManager>())
         {
         }

--- a/src/OmniSharp.DotNetTest/Services/BaseTestService.cs
+++ b/src/OmniSharp.DotNetTest/Services/BaseTestService.cs
@@ -7,11 +7,11 @@ namespace OmniSharp.DotNetTest.Services
     internal abstract class BaseTestService
     {
         protected readonly OmniSharpWorkspace Workspace;
-        protected readonly DotNetCliService DotNetCli;
+        protected readonly IDotNetCliService DotNetCli;
         protected readonly IEventEmitter EventEmitter;
         protected readonly ILoggerFactory LoggerFactory;
 
-        protected BaseTestService(OmniSharpWorkspace workspace, DotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
+        protected BaseTestService(OmniSharpWorkspace workspace, IDotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
         {
             Workspace = workspace;
             DotNetCli = dotNetCli;

--- a/src/OmniSharp.DotNetTest/Services/BaseTestService`2.cs
+++ b/src/OmniSharp.DotNetTest/Services/BaseTestService`2.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.DotNetTest.Services
     internal abstract class BaseTestService<TRequest, TResponse> : BaseTestService, IRequestHandler<TRequest, TResponse>
         where TRequest: Request
     {
-        protected BaseTestService(OmniSharpWorkspace workspace, DotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
+        protected BaseTestService(OmniSharpWorkspace workspace, IDotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
             : base(workspace, dotNetCli, eventEmitter, loggerFactory)
         {
         }

--- a/src/OmniSharp.DotNetTest/Services/DebugTestClassService.cs
+++ b/src/OmniSharp.DotNetTest/Services/DebugTestClassService.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Composition;
+﻿using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -18,7 +17,7 @@ namespace OmniSharp.DotNetTest.Services
         private DebugSessionManager _debugSessionManager;
 
         [ImportingConstructor]
-        public DebugTestClassService(DebugSessionManager debugSessionManager, OmniSharpWorkspace workspace, DotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
+        public DebugTestClassService(DebugSessionManager debugSessionManager, OmniSharpWorkspace workspace, IDotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
             : base(workspace, dotNetCli, eventEmitter, loggerFactory)
         {
             _debugSessionManager = debugSessionManager;

--- a/src/OmniSharp.DotNetTest/Services/DebugTestService.cs
+++ b/src/OmniSharp.DotNetTest/Services/DebugTestService.cs
@@ -22,7 +22,7 @@ namespace OmniSharp.DotNetTest.Services
         private DebugSessionManager _debugSessionManager;
 
         [ImportingConstructor]
-        public DebugTestService(DebugSessionManager debugSessionManager, OmniSharpWorkspace workspace, DotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
+        public DebugTestService(DebugSessionManager debugSessionManager, OmniSharpWorkspace workspace, IDotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
             : base(workspace, dotNetCli, eventEmitter, loggerFactory)
         {
             _debugSessionManager = debugSessionManager;

--- a/src/OmniSharp.DotNetTest/Services/GetTestStartInfoService.cs
+++ b/src/OmniSharp.DotNetTest/Services/GetTestStartInfoService.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.DotNetTest.Services
     internal class GetTestStartInfoService : BaseTestService<GetTestStartInfoRequest, GetTestStartInfoResponse>
     {
         [ImportingConstructor]
-        public GetTestStartInfoService(OmniSharpWorkspace workspace, DotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
+        public GetTestStartInfoService(OmniSharpWorkspace workspace, IDotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
             : base(workspace, dotNetCli, eventEmitter, loggerFactory)
         {
         }

--- a/src/OmniSharp.DotNetTest/Services/RunTestService.cs
+++ b/src/OmniSharp.DotNetTest/Services/RunTestService.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.DotNetTest.Services
     internal class RunTestService : BaseTestService<RunTestRequest, RunTestResponse>
     {
         [ImportingConstructor]
-        public RunTestService(OmniSharpWorkspace workspace, DotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
+        public RunTestService(OmniSharpWorkspace workspace, IDotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
             : base(workspace, dotNetCli, eventEmitter, loggerFactory)
         {
         }

--- a/src/OmniSharp.DotNetTest/Services/RunTestsInClassService.cs
+++ b/src/OmniSharp.DotNetTest/Services/RunTestsInClassService.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Composition;
+﻿using System.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using OmniSharp.DotNetTest.Models;
@@ -13,7 +12,7 @@ namespace OmniSharp.DotNetTest.Services
     internal class RunTestsInClassService : BaseTestService<RunTestsInClassRequest, RunTestResponse>
     {
         [ImportingConstructor]
-        public RunTestsInClassService(OmniSharpWorkspace workspace, DotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
+        public RunTestsInClassService(OmniSharpWorkspace workspace, IDotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
             : base(workspace, dotNetCli, eventEmitter, loggerFactory)
         {
         }

--- a/src/OmniSharp.DotNetTest/TestManager.cs
+++ b/src/OmniSharp.DotNetTest/TestManager.cs
@@ -24,7 +24,7 @@ namespace OmniSharp.DotNetTest
     internal abstract class TestManager : DisposableObject
     {
         protected readonly Project Project;
-        protected readonly DotNetCliService DotNetCli;
+        protected readonly IDotNetCliService DotNetCli;
         protected readonly SemanticVersion DotNetCliVersion;
         protected readonly IEventEmitter EventEmitter;
         protected readonly ILogger Logger;
@@ -41,7 +41,7 @@ namespace OmniSharp.DotNetTest
 
         public bool IsConnected => _isConnected;
 
-        protected TestManager(Project project, string workingDirectory, DotNetCliService dotNetCli, SemanticVersion dotNetCliVersion, IEventEmitter eventEmitter, ILogger logger)
+        protected TestManager(Project project, string workingDirectory, IDotNetCliService dotNetCli, SemanticVersion dotNetCliVersion, IEventEmitter eventEmitter, ILogger logger)
         {
             Project = project ?? throw new ArgumentNullException(nameof(project));
             WorkingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
@@ -51,14 +51,14 @@ namespace OmniSharp.DotNetTest
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public static TestManager Start(Project project, DotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
+        public static TestManager Start(Project project, IDotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
         {
             var manager = Create(project, dotNetCli, eventEmitter, loggerFactory);
             manager.Connect();
             return manager;
         }
 
-        public static TestManager Create(Project project, DotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
+        public static TestManager Create(Project project, IDotNetCliService dotNetCli, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
         {
             var workingDirectory = Path.GetDirectoryName(project.FilePath);
 

--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -21,7 +21,7 @@ namespace OmniSharp.DotNetTest
 {
     internal class VSTestManager : TestManager
     {
-        public VSTestManager(Project project, string workingDirectory, DotNetCliService dotNetCli, SemanticVersion dotNetCliVersion, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
+        public VSTestManager(Project project, string workingDirectory, IDotNetCliService dotNetCli, SemanticVersion dotNetCliVersion, IEventEmitter eventEmitter, ILoggerFactory loggerFactory)
             : base(project, workingDirectory, dotNetCli, dotNetCliVersion, eventEmitter, loggerFactory.CreateLogger<VSTestManager>())
         {
         }

--- a/src/OmniSharp.Http/Startup.cs
+++ b/src/OmniSharp.Http/Startup.cs
@@ -28,8 +28,8 @@ namespace OmniSharp.Http
 
         public IServiceProvider ConfigureServices(IServiceCollection services)
         {
-            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_configuration, services);
-            _compositionHost = new CompositionHostBuilder(serviceProvider, _environment, _eventEmitter)
+            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_configuration, _eventEmitter, services);
+            _compositionHost = new CompositionHostBuilder(serviceProvider, _environment)
                 .WithOmniSharpAssemblies()
                 .Build();
 

--- a/src/OmniSharp.Http/Startup.cs
+++ b/src/OmniSharp.Http/Startup.cs
@@ -28,8 +28,8 @@ namespace OmniSharp.Http
 
         public IServiceProvider ConfigureServices(IServiceCollection services)
         {
-            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_configuration, _eventEmitter, services);
-            _compositionHost = new CompositionHostBuilder(serviceProvider, _environment)
+            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_environment, _configuration, _eventEmitter, services);
+            _compositionHost = new CompositionHostBuilder(serviceProvider)
                 .WithOmniSharpAssemblies()
                 .Build();
 

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -86,13 +86,12 @@ namespace OmniSharp.LanguageServerProtocol
             _logger = _loggerFactory.CreateLogger<LanguageServerHost>();
 
             _configuration = new ConfigurationBuilder(_environment).Build();
-            _serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_configuration, _services);
+            _serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_configuration, new LanguageServerEventEmitter(_server), _services);
 
-            var eventEmitter = new LanguageServerEventEmitter(_server);
             var plugins = _application.CreatePluginAssemblies();
 
             var assemblyLoader = _serviceProvider.GetRequiredService<IAssemblyLoader>();
-            var compositionHostBuilder = new CompositionHostBuilder(_serviceProvider, _environment, eventEmitter)
+            var compositionHostBuilder = new CompositionHostBuilder(_serviceProvider, _environment)
                 .WithOmniSharpAssemblies()
                 .WithAssemblies(typeof(LanguageServerHost).Assembly)
                 .WithAssemblies(assemblyLoader.LoadByAssemblyNameOrPath(plugins.AssemblyNames).ToArray());

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -86,12 +86,13 @@ namespace OmniSharp.LanguageServerProtocol
             _logger = _loggerFactory.CreateLogger<LanguageServerHost>();
 
             _configuration = new ConfigurationBuilder(_environment).Build();
-            _serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_configuration, new LanguageServerEventEmitter(_server), _services);
+            var eventEmitter = new LanguageServerEventEmitter(_server);
+            _serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_environment, _configuration, eventEmitter, _services);
 
             var plugins = _application.CreatePluginAssemblies();
 
             var assemblyLoader = _serviceProvider.GetRequiredService<IAssemblyLoader>();
-            var compositionHostBuilder = new CompositionHostBuilder(_serviceProvider, _environment)
+            var compositionHostBuilder = new CompositionHostBuilder(_serviceProvider)
                 .WithOmniSharpAssemblies()
                 .WithAssemblies(typeof(LanguageServerHost).Assembly)
                 .WithAssemblies(assemblyLoader.LoadByAssemblyNameOrPath(plugins.AssemblyNames).ToArray());

--- a/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
+++ b/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
@@ -8,6 +8,13 @@ namespace OmniSharp.Options
         public string Platform { get; set; }
         public bool EnablePackageAutoRestore { get; set; }
 
+        /// <summary>
+        /// When set to true, the MSBuild project system will attempt to resolve the path to the MSBuild
+        /// SDKs for a project by running 'dotnet --info' and retrieving the path. This is only needed
+        /// for older versions of the .NET Core SDK.
+        /// </summary>
+        public bool UseLegacySdkResolver { get; set; }
+
         public string MSBuildExtensionsPath { get; set; }
         public string TargetFrameworkRootPath { get; set; }
         public string MSBuildSDKsPath { get; set; }

--- a/src/OmniSharp.MSBuild/PackageDependencyChecker.cs
+++ b/src/OmniSharp.MSBuild/PackageDependencyChecker.cs
@@ -17,10 +17,10 @@ namespace OmniSharp.MSBuild
     {
         private readonly ILogger _logger;
         private readonly IEventEmitter _eventEmitter;
-        private readonly DotNetCliService _dotNetCli;
+        private readonly IDotNetCliService _dotNetCli;
         private readonly MSBuildOptions _options;
 
-        public PackageDependencyChecker(ILoggerFactory loggerFactory, IEventEmitter eventEmitter, DotNetCliService dotNetCli, MSBuildOptions options)
+        public PackageDependencyChecker(ILoggerFactory loggerFactory, IEventEmitter eventEmitter, IDotNetCliService dotNetCli, MSBuildOptions options)
         {
             _logger = loggerFactory.CreateLogger<PackageDependencyChecker>();
             _eventEmitter = eventEmitter;

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -81,6 +81,9 @@ namespace OmniSharp.MSBuild
             _options = new MSBuildOptions();
             ConfigurationBinder.Bind(configuration, _options);
 
+            _sdksPathResolver.Enabled = _options.UseLegacySdkResolver;
+            _sdksPathResolver.OverridePath = _options.MSBuildSDKsPath;
+
             if (_environment.LogLevel < LogLevel.Information)
             {
                 var buildEnvironmentInfo = MSBuildHelpers.GetBuildEnvironmentInfo();

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -26,7 +26,7 @@ namespace OmniSharp.MSBuild
         private readonly IOmniSharpEnvironment _environment;
         private readonly OmniSharpWorkspace _workspace;
         private readonly ImmutableDictionary<string, string> _propertyOverrides;
-        private readonly DotNetCliService _dotNetCli;
+        private readonly IDotNetCliService _dotNetCli;
         private readonly SdksPathResolver _sdksPathResolver;
         private readonly MetadataFileReferenceCache _metadataFileReferenceCache;
         private readonly IEventEmitter _eventEmitter;
@@ -53,7 +53,7 @@ namespace OmniSharp.MSBuild
             IOmniSharpEnvironment environment,
             OmniSharpWorkspace workspace,
             IMSBuildLocator msbuildLocator,
-            DotNetCliService dotNetCliService,
+            IDotNetCliService dotNetCliService,
             SdksPathResolver sdksPathResolver,
             MetadataFileReferenceCache metadataFileReferenceCache,
             IEventEmitter eventEmitter,

--- a/src/OmniSharp.MSBuild/SdksPathResolver.cs
+++ b/src/OmniSharp.MSBuild/SdksPathResolver.cs
@@ -12,14 +12,14 @@ namespace OmniSharp.MSBuild
         private const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
         private const string Sdks = nameof(Sdks);
 
-        private readonly DotNetCliService _dotNetCli;
+        private readonly IDotNetCliService _dotNetCli;
         private readonly ILogger _logger;
 
         public bool Enabled { get; set; } = false;
         public string OverridePath { get; set; }
 
         [ImportingConstructor]
-        public SdksPathResolver(DotNetCliService dotNetCli, ILoggerFactory loggerFactory)
+        public SdksPathResolver(IDotNetCliService dotNetCli, ILoggerFactory loggerFactory)
         {
             _dotNetCli = dotNetCli;
             _logger = loggerFactory.CreateLogger<SdksPathResolver>();

--- a/src/OmniSharp.MSBuild/SdksPathResolver.cs
+++ b/src/OmniSharp.MSBuild/SdksPathResolver.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Composition;
 using System.IO;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Services;
 
 namespace OmniSharp.MSBuild
@@ -12,11 +13,16 @@ namespace OmniSharp.MSBuild
         private const string Sdks = nameof(Sdks);
 
         private readonly DotNetCliService _dotNetCli;
+        private readonly ILogger _logger;
+
+        public bool Enabled { get; set; } = false;
+        public string OverridePath { get; set; }
 
         [ImportingConstructor]
-        public SdksPathResolver(DotNetCliService dotNetCli)
+        public SdksPathResolver(DotNetCliService dotNetCli, ILoggerFactory loggerFactory)
         {
             _dotNetCli = dotNetCli;
+            _logger = loggerFactory.CreateLogger<SdksPathResolver>();
         }
 
         public bool TryGetSdksPath(string projectFilePath, out string sdksPath)
@@ -44,13 +50,22 @@ namespace OmniSharp.MSBuild
 
         public IDisposable SetSdksPathEnvironmentVariable(string projectFilePath)
         {
-            if (!TryGetSdksPath(projectFilePath, out var sdksPath))
+            if (!Enabled)
+            {
+                return NullDisposable.Instance;
+            }
+
+            var sdksPath = OverridePath;
+            if (string.IsNullOrWhiteSpace(sdksPath) &&
+                !TryGetSdksPath(projectFilePath, out sdksPath))
             {
                 return NullDisposable.Instance;
             }
 
             var oldMSBuildSDKsPath = Environment.GetEnvironmentVariable(MSBuildSDKsPath);
             Environment.SetEnvironmentVariable(MSBuildSDKsPath, sdksPath);
+
+            _logger.LogDebug($"Set {MSBuildSDKsPath} environment variable to: {sdksPath}");
 
             return new ResetSdksPathEnvironmentVariable(oldMSBuildSDKsPath);
         }

--- a/src/OmniSharp.Stdio.Driver/Program.cs
+++ b/src/OmniSharp.Stdio.Driver/Program.cs
@@ -50,15 +50,16 @@ namespace OmniSharp.Stdio.Driver
                     Configuration.ZeroBasedIndices = application.ZeroBasedIndices;
                     var configuration = new ConfigurationBuilder(environment).Build();
                     var writer = new SharedTextWriter(output);
-                    var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(configuration, new StdioEventEmitter(writer));
+                    var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(environment, configuration, new StdioEventEmitter(writer));
                     var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
                     var plugins = application.CreatePluginAssemblies();
 
 
                     var assemblyLoader = serviceProvider.GetRequiredService<IAssemblyLoader>();
-                    var compositionHostBuilder = new CompositionHostBuilder(serviceProvider, environment)
+                    var compositionHostBuilder = new CompositionHostBuilder(serviceProvider)
                         .WithOmniSharpAssemblies()
                         .WithAssemblies(assemblyLoader.LoadByAssemblyNameOrPath(plugins.AssemblyNames).ToArray());
+
                     using (var host = new Host(input, writer, environment, configuration, serviceProvider, compositionHostBuilder, loggerFactory, cancellation))
                     {
                         host.Start();

--- a/src/OmniSharp.Stdio.Driver/Program.cs
+++ b/src/OmniSharp.Stdio.Driver/Program.cs
@@ -47,16 +47,16 @@ namespace OmniSharp.Stdio.Driver
                     var output = Console.Out;
 
                     var environment = application.CreateEnvironment();
-                    OmniSharp.Configuration.ZeroBasedIndices = application.ZeroBasedIndices;
+                    Configuration.ZeroBasedIndices = application.ZeroBasedIndices;
                     var configuration = new ConfigurationBuilder(environment).Build();
-                    var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(configuration);
+                    var writer = new SharedTextWriter(output);
+                    var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(configuration, new StdioEventEmitter(writer));
                     var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
                     var plugins = application.CreatePluginAssemblies();
 
-                    var writer = new SharedTextWriter(output);
 
                     var assemblyLoader = serviceProvider.GetRequiredService<IAssemblyLoader>();
-                    var compositionHostBuilder = new CompositionHostBuilder(serviceProvider, environment, new StdioEventEmitter(writer))
+                    var compositionHostBuilder = new CompositionHostBuilder(serviceProvider, environment)
                         .WithOmniSharpAssemblies()
                         .WithAssemblies(assemblyLoader.LoadByAssemblyNameOrPath(plugins.AssemblyNames).ToArray());
                     using (var host = new Host(input, writer, environment, configuration, serviceProvider, compositionHostBuilder, loggerFactory, cancellation))

--- a/tests/OmniSharp.DotNetTest.Tests/AbstractGetTestStartInfoFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/AbstractGetTestStartInfoFacts.cs
@@ -48,7 +48,7 @@ namespace OmniSharp.DotNetTest.Tests
 
                 var response = await service.Handle(request);
 
-                var dotNetCli = host.GetExport<DotNetCliService>();
+                var dotNetCli = host.GetExport<IDotNetCliService>();
 
                 Assert.Equal(dotNetCli.DotNetPath, response.Executable);
             }

--- a/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
+++ b/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
@@ -119,7 +119,7 @@ namespace OmniSharp.Http.Tests
             var environment = new OmniSharpEnvironment();
             var sharedTextWriter = new TestSharedTextWriter(this.TestOutput);
             var serviceProvider = new TestServiceProvider(environment, this.LoggerFactory, sharedTextWriter, new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build(), NullEventEmitter.Instance);
-            var compositionHost = new CompositionHostBuilder(serviceProvider, environment)
+            var compositionHost = new CompositionHostBuilder(serviceProvider)
                 .WithAssemblies(assemblies)
                 .Build();
 

--- a/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
+++ b/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
@@ -118,8 +118,8 @@ namespace OmniSharp.Http.Tests
         {
             var environment = new OmniSharpEnvironment();
             var sharedTextWriter = new TestSharedTextWriter(this.TestOutput);
-            var serviceProvider = new TestServiceProvider(environment, this.LoggerFactory, sharedTextWriter, new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build());
-            var compositionHost = new CompositionHostBuilder(serviceProvider, environment, NullEventEmitter.Instance)
+            var serviceProvider = new TestServiceProvider(environment, this.LoggerFactory, sharedTextWriter, new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build(), NullEventEmitter.Instance);
+            var compositionHost = new CompositionHostBuilder(serviceProvider, environment)
                 .WithAssemblies(assemblies)
                 .Build();
 

--- a/tests/OmniSharp.Stdio.Tests/StdioServerFacts.cs
+++ b/tests/OmniSharp.Stdio.Tests/StdioServerFacts.cs
@@ -17,14 +17,14 @@ namespace OmniSharp.Stdio.Tests
         private Host BuildTestServerAndStart(TextReader reader, ISharedTextWriter writer, Action<Host> programDelegate = null)
         {
             var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build();
-            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(configuration, NullEventEmitter.Instance);
-            var omniSharpEnvironment = new OmniSharpEnvironment();
+            var environment = new OmniSharpEnvironment();
+            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(environment, configuration, NullEventEmitter.Instance);
             var cancelationTokenSource = new CancellationTokenSource();
             var host = new Host(reader, writer,
-                omniSharpEnvironment,
+                environment,
                 configuration,
                 serviceProvider,
-                new CompositionHostBuilder(serviceProvider, omniSharpEnvironment),
+                new CompositionHostBuilder(serviceProvider),
                 serviceProvider.GetRequiredService<ILoggerFactory>(),
                 cancelationTokenSource);
 

--- a/tests/OmniSharp.Stdio.Tests/StdioServerFacts.cs
+++ b/tests/OmniSharp.Stdio.Tests/StdioServerFacts.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Threading;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using OmniSharp.Endpoint;
 using OmniSharp.Eventing;
 using OmniSharp.Services;
 using OmniSharp.Stdio.Protocol;
@@ -21,14 +17,14 @@ namespace OmniSharp.Stdio.Tests
         private Host BuildTestServerAndStart(TextReader reader, ISharedTextWriter writer, Action<Host> programDelegate = null)
         {
             var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build();
-            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(configuration);
+            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(configuration, NullEventEmitter.Instance);
             var omniSharpEnvironment = new OmniSharpEnvironment();
             var cancelationTokenSource = new CancellationTokenSource();
             var host = new Host(reader, writer,
                 omniSharpEnvironment,
                 configuration,
                 serviceProvider,
-                new CompositionHostBuilder(serviceProvider, omniSharpEnvironment, NullEventEmitter.Instance),
+                new CompositionHostBuilder(serviceProvider, omniSharpEnvironment),
                 serviceProvider.GetRequiredService<ILoggerFactory>(),
                 cancelationTokenSource);
 

--- a/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
+++ b/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
@@ -17,7 +17,7 @@ namespace OmniSharp.Tests
         {
             using (var host = CreateOmniSharpHost(dotNetCliVersion: DotNetCliVersion.Legacy))
             {
-                var dotNetCli = host.GetExport<DotNetCliService>();
+                var dotNetCli = host.GetExport<IDotNetCliService>();
 
                 var version = dotNetCli.GetVersion();
 
@@ -33,7 +33,7 @@ namespace OmniSharp.Tests
         {
             using (var host = CreateOmniSharpHost(dotNetCliVersion: DotNetCliVersion.Legacy))
             {
-                var dotNetCli = host.GetExport<DotNetCliService>();
+                var dotNetCli = host.GetExport<IDotNetCliService>();
 
                 var info = dotNetCli.GetInfo();
 
@@ -49,7 +49,7 @@ namespace OmniSharp.Tests
         {
             using (var host = CreateOmniSharpHost(dotNetCliVersion: DotNetCliVersion.Current))
             {
-                var dotNetCli = host.GetExport<DotNetCliService>();
+                var dotNetCli = host.GetExport<IDotNetCliService>();
 
                 var version = dotNetCli.GetVersion();
 
@@ -65,7 +65,7 @@ namespace OmniSharp.Tests
         {
             using (var host = CreateOmniSharpHost(dotNetCliVersion: DotNetCliVersion.Current))
             {
-                var dotNetCli = host.GetExport<DotNetCliService>();
+                var dotNetCli = host.GetExport<IDotNetCliService>();
 
                 var info = dotNetCli.GetInfo();
 

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -112,7 +112,7 @@ namespace TestUtility
 
             var serviceProvider = new TestServiceProvider(environment, loggerFactory, sharedTextWriter, configuration, NullEventEmitter.Instance, dotNetCliService);
 
-            var compositionHost = new CompositionHostBuilder(serviceProvider, environment)
+            var compositionHost = new CompositionHostBuilder(serviceProvider)
                 .WithAssemblies(s_lazyAssemblies.Value)
                 .Build();
 

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -105,8 +105,13 @@ namespace TestUtility
             // This property will cause the MSBuild project loader to set the
             // MSBuildSDKsPath environment variable to the correct path "Sdks" folder
             // within the appropriate .NET Core SDK.
-            builder.Properties[$"MSBuild:{nameof(MSBuildOptions.UseLegacySdkResolver)}"] = true;
-            builder.Properties[$"MSBuild:{nameof(MSBuildOptions.MSBuildSDKsPath)}"] = Path.Combine(info.BasePath, "Sdks");
+            var msbuildProperties = new Dictionary<string, string>()
+            {
+                [$"MSBuild:{nameof(MSBuildOptions.UseLegacySdkResolver)}"] = "true",
+                [$"MSBuild:{nameof(MSBuildOptions.MSBuildSDKsPath)}"] = Path.Combine(info.BasePath, "Sdks")
+            };
+
+            builder.AddInMemoryCollection(msbuildProperties);
 
             var configuration = builder.Build();
 

--- a/tests/TestUtility/TestServiceProvider.cs
+++ b/tests/TestUtility/TestServiceProvider.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OmniSharp;
+using OmniSharp.Eventing;
 using OmniSharp.MSBuild.Discovery;
 using OmniSharp.Options;
 using OmniSharp.Services;
@@ -23,7 +24,9 @@ namespace TestUtility
             IOmniSharpEnvironment environment,
             ILoggerFactory loggerFactory,
             ISharedTextWriter sharedTextWriter,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            IEventEmitter eventEmitter,
+            IDotNetCliService dotNetCliService = null)
         {
             _logger = loggerFactory.CreateLogger<TestServiceProvider>();
 
@@ -37,6 +40,7 @@ namespace TestUtility
             var assemblyLoader = new AssemblyLoader(loggerFactory);
             var msbuildLocator = MSBuildLocator.CreateStandAlone(loggerFactory, assemblyLoader, allowMonoPaths: false);
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
+            dotNetCliService = dotNetCliService ?? new DotNetCliService(loggerFactory, eventEmitter);
 
             _services[typeof(ILoggerFactory)] = loggerFactory;
             _services[typeof(IOmniSharpEnvironment)] = environment;
@@ -44,6 +48,8 @@ namespace TestUtility
             _services[typeof(IMemoryCache)] = memoryCache;
             _services[typeof(ISharedTextWriter)] = sharedTextWriter;
             _services[typeof(IMSBuildLocator)] = msbuildLocator;
+            _services[typeof(IEventEmitter)] = eventEmitter;
+            _services[typeof(IDotNetCliService)] = dotNetCliService;
         }
 
         ~TestServiceProvider()


### PR DESCRIPTION
Fixes #1190

This change ended up being a bit larger than I'd intended. If you're reviewing, I recommend walking through each commit at a time.

At it's core, this change removes an old hack that set the `MSBuildSDKsPath` environment variable to a path that was computed by launching `dotnet` in the project folder. This hack is an override that blocks MSBuild's SDK resolvers, which is the system that *should* be used to locate the SDK(s) for a project. However, when we tried removing this hack in the past, we were bit by the fact that the base MSBuild SDK resolve doesn't work with .NET Core SDKs <= 1.0.3. So, we added the hack back. Since there weren't really any custom MSBuild SDK resolvers out there, the override really didn't have much of an impact.

Now that MSBuild has shipped the NuGet-based SDK resolver that can download SDKs from NuGet, our override hack is a significant problem. So, I've removed the hack and the base SDK resolver is used instead. If anybody wants to the old behavior (because they're using an old .NET Core SDK), they can set the following option in an `omnisharp.json` file:

```JSON
{
    "MSBuild": {
        "UseLegacySdkResolver": true
    }
}
```

Unfortunately, removing the hack forced several other changes, primarily to get tests working without the hack. I had to rationalize the `IDotNetCliService` and elevated `IOmniSharpEnvironment` and `IEventEmitter` to required services. Finally, because the base SDK resolver is a netstandard2.0 library, I needed to package `netstandard.dll` with our standalone Mono install. As part of this, I went ahead and updated the Mono and MSBuild bits for Mono as well.

Note that there is further work to package the NuGet MSBuild SDK resolver with our standalone MSBuild bits. However, that's a change for another day. For now, custom MSBuild SDKs should work if the user has a newer VS or Mono installed.

cc @nguerrera.