### PR TITLE
Added tests for CSX project system

### DIFF
--- a/OmniSharp.sln
+++ b/OmniSharp.sln
@@ -68,6 +68,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.Http.Driver", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.Stdio.Driver", "src\OmniSharp.Stdio.Driver\OmniSharp.Stdio.Driver.csproj", "{D2A78CEE-B278-476F-AF34-A7D6F792F973}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OmniSharp.Script.Tests", "tests\OmniSharp.Script.Tests\OmniSharp.Script.Tests.csproj", "{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -390,6 +392,18 @@ Global
 		{D2A78CEE-B278-476F-AF34-A7D6F792F973}.Release|x64.Build.0 = Release|Any CPU
 		{D2A78CEE-B278-476F-AF34-A7D6F792F973}.Release|x86.ActiveCfg = Release|Any CPU
 		{D2A78CEE-B278-476F-AF34-A7D6F792F973}.Release|x86.Build.0 = Release|Any CPU
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}.Debug|x64.Build.0 = Debug|Any CPU
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}.Debug|x86.Build.0 = Debug|Any CPU
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}.Release|x64.ActiveCfg = Release|Any CPU
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}.Release|x64.Build.0 = Release|Any CPU
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}.Release|x86.ActiveCfg = Release|Any CPU
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -421,6 +435,7 @@ Global
 		{17DAECA3-AE28-4B40-AA52-1EF618346A85} = {35E025BF-BBB2-4FAC-9F4B-37CBA083EE47}
 		{BC640CBF-F6E2-42EA-9D61-FB6E515AEA44} = {2C348365-A9D8-459E-9276-56FC46AAEE31}
 		{D2A78CEE-B278-476F-AF34-A7D6F792F973} = {2C348365-A9D8-459E-9276-56FC46AAEE31}
+		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F} = {35E025BF-BBB2-4FAC-9F4B-37CBA083EE47}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4DD725CE-B49A-4151-8B77-BB33FE88E46E}

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -232,7 +232,11 @@ namespace OmniSharp.Script
                 .Where(a => a != null)
                 .Select(a => a.Location)
                 .Distinct()
-                .Select(l => _metadataFileReferenceCache.GetMetadataReference(l));
+                .Select(l =>
+                {
+                    _assemblyReferences.Add(l);
+                    return _metadataFileReferenceCache.GetMetadataReference(l);
+                });
 
             foreach (var reference in references)
             {

--- a/test-assets/test-scripts/DotnetCoreScriptSimple/main.csx
+++ b/test-assets/test-scripts/DotnetCoreScriptSimple/main.csx
@@ -1,0 +1,2 @@
+#! "netcoreapp2.0"
+Console.WriteLine("Hello world!");

--- a/test-assets/test-scripts/DotnetCoreScriptWithNuget/main.csx
+++ b/test-assets/test-scripts/DotnetCoreScriptWithNuget/main.csx
@@ -2,4 +2,4 @@
 #r "nuget: Newtonsoft.Json,11.0.2"
 
 using Newtonsoft.Json;
-Console.WriteLine("Hello world!");
+Console.WriteLine("Hello world!: " + typeof(JsonConvert));

--- a/test-assets/test-scripts/DotnetCoreScriptWithNuget/main.csx
+++ b/test-assets/test-scripts/DotnetCoreScriptWithNuget/main.csx
@@ -1,0 +1,5 @@
+#! "netcoreapp2.0"
+#r "nuget: Newtonsoft.Json,11.0.2"
+
+using Newtonsoft.Json;
+Console.WriteLine("Hello world!");

--- a/test-assets/test-scripts/SingleCsiScript/main.csx
+++ b/test-assets/test-scripts/SingleCsiScript/main.csx
@@ -1,0 +1,5 @@
+#r "System.Net.Http"
+
+using System.Net.Http;
+var client = new HttpClient();
+Console.WriteLine(client.GetAsync("https://google.com"));

--- a/test-assets/test-scripts/TwoCsiScripts/main.csx
+++ b/test-assets/test-scripts/TwoCsiScripts/main.csx
@@ -1,0 +1,6 @@
+#load "users.csx"
+#r "System.Net.Http"
+
+using System.Net.Http;
+var client = new HttpClient();
+Console.WriteLine(client.GetAsync("https://google.com"));

--- a/test-assets/test-scripts/TwoCsiScripts/users.csx
+++ b/test-assets/test-scripts/TwoCsiScripts/users.csx
@@ -1,0 +1,5 @@
+public class User
+{
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+}

--- a/tests/OmniSharp.Script.Tests/OmniSharp.Script.Tests.csproj
+++ b/tests/OmniSharp.Script.Tests/OmniSharp.Script.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\app.config" Link="app.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OmniSharp.Script\OmniSharp.Script.csproj" />
+    <ProjectReference Include="..\TestUtility\TestUtility.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OmniSharp.Script.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.Script.Tests/WorkspaceInformationTests.cs
@@ -1,0 +1,57 @@
+﻿using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+using OmniSharp.Models.WorkspaceInformation;
+using TestUtility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OmniSharp.Script.Tests
+{
+    public class WorkspaceInformationTests : AbstractTestFixture
+    {
+        public WorkspaceInformationTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task SingleCsiScript()
+        {
+            using (var testProject = TestAssets.Instance.GetTestScript("SingleCsiScript"))
+            using (var host = CreateOmniSharpHost(testProject.Directory))
+            {
+                var workspaceInfo = await GetWorkspaceInfoAsync(host);
+
+                var scriptProjects = workspaceInfo.Projects.ToArray();
+                Assert.Single(scriptProjects);
+
+                var project = scriptProjects[0];
+                Assert.Equal("main.csx", Path.GetFileName(project.Path));
+
+                // should have reference to mscorlib
+                Assert.Contains(project.ImplicitAssemblyReferences, a => a == Assembly.Load(new AssemblyName("mscorlib"))?.Location);
+
+                // default globals object
+                Assert.Equal(typeof(CommandLineScriptGlobals), project.GlobalsType);
+            }
+        }
+
+        private static async Task<ScriptContextModelCollection> GetWorkspaceInfoAsync(OmniSharpTestHost host)
+        {
+            var service = host.GetWorkspaceInformationService();
+
+            var request = new WorkspaceInformationRequest
+            {
+                ExcludeSourceFiles = false
+            };
+
+            var response = await service.Handle(request);
+
+            return (ScriptContextModelCollection)response["Script"];
+        }
+    }
+
+}

--- a/tests/OmniSharp.Script.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.Script.Tests/WorkspaceInformationTests.cs
@@ -32,12 +32,38 @@ namespace OmniSharp.Script.Tests
                 Assert.Equal("main.csx", Path.GetFileName(project.Path));
 
                 // should have reference to mscorlib
-                Assert.Contains(project.ImplicitAssemblyReferences, a => a == Assembly.Load(new AssemblyName("mscorlib"))?.Location);
+                Assert.Contains(project.ImplicitAssemblyReferences, a => a == GetMsCorlibPath());
 
                 // default globals object
                 Assert.Equal(typeof(CommandLineScriptGlobals), project.GlobalsType);
             }
         }
+
+        [Fact]
+        public async Task TwoCsiScripts()
+        {
+            using (var testProject = TestAssets.Instance.GetTestScript("TwoCsiScripts"))
+            using (var host = CreateOmniSharpHost(testProject.Directory))
+            {
+                var workspaceInfo = await GetWorkspaceInfoAsync(host);
+
+                var scriptProjects = workspaceInfo.Projects.ToArray();
+                Assert.Equal(2, scriptProjects.Length);
+
+                Assert.Equal("main.csx", Path.GetFileName(scriptProjects[0].Path));
+                Assert.Equal("users.csx", Path.GetFileName(scriptProjects[1].Path));
+
+                // should have reference to mscorlib
+                Assert.Contains(scriptProjects[0].ImplicitAssemblyReferences, a => a == GetMsCorlibPath());
+                Assert.Contains(scriptProjects[1].ImplicitAssemblyReferences, a => a == GetMsCorlibPath());
+
+                // default globals object
+                Assert.Equal(typeof(CommandLineScriptGlobals), scriptProjects[0].GlobalsType);
+                Assert.Equal(typeof(CommandLineScriptGlobals), scriptProjects[1].GlobalsType);
+            }
+        }
+
+        private string GetMsCorlibPath() => Assembly.Load(new AssemblyName("mscorlib"))?.Location;
 
         private static async Task<ScriptContextModelCollection> GetWorkspaceInfoAsync(OmniSharpTestHost host)
         {

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -35,7 +35,7 @@ namespace TestUtility
             typeof(DotNetProjectSystem).GetTypeInfo().Assembly, // OmniSharp.DotNet
             typeof(RunTestRequest).GetTypeInfo().Assembly, // OmniSharp.DotNetTest
             typeof(ProjectSystem).GetTypeInfo().Assembly, // OmniSharp.MSBuild
-            typeof(ScriptProjectSystem).GetTypeInfo().Assembly, // OmniSharp.DotNet
+            typeof(ScriptProjectSystem).GetTypeInfo().Assembly, // OmniSharp.Script
             typeof(OmniSharpWorkspace).GetTypeInfo().Assembly, // OmniSharp.Roslyn
             typeof(RoslynFeaturesHostServicesProvider).GetTypeInfo().Assembly, // OmniSharp.Roslyn.CSharp
             typeof(CakeProjectSystem).GetTypeInfo().Assembly, // OmniSharp.Cake

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -16,6 +16,7 @@ using OmniSharp.Mef;
 using OmniSharp.Models.WorkspaceInformation;
 using OmniSharp.MSBuild;
 using OmniSharp.Roslyn.CSharp.Services;
+using OmniSharp.Script;
 using OmniSharp.Services;
 using OmniSharp.Utilities;
 using TestUtility.Logging;
@@ -34,6 +35,7 @@ namespace TestUtility
             typeof(DotNetProjectSystem).GetTypeInfo().Assembly, // OmniSharp.DotNet
             typeof(RunTestRequest).GetTypeInfo().Assembly, // OmniSharp.DotNetTest
             typeof(ProjectSystem).GetTypeInfo().Assembly, // OmniSharp.MSBuild
+            typeof(ScriptProjectSystem).GetTypeInfo().Assembly, // OmniSharp.DotNet
             typeof(OmniSharpWorkspace).GetTypeInfo().Assembly, // OmniSharp.Roslyn
             typeof(RoslynFeaturesHostServicesProvider).GetTypeInfo().Assembly, // OmniSharp.Roslyn.CSharp
             typeof(CakeProjectSystem).GetTypeInfo().Assembly, // OmniSharp.Cake

--- a/tests/TestUtility/TestAssets.cs
+++ b/tests/TestUtility/TestAssets.cs
@@ -16,7 +16,6 @@ namespace TestUtility
         public string TestBinariesFolder { get; }
         public string TestScriptsFolder { get; }
 
-
         private TestAssets()
         {
             RootFolder = FindRootFolder();

--- a/tests/TestUtility/TestAssets.cs
+++ b/tests/TestUtility/TestAssets.cs
@@ -14,6 +14,8 @@ namespace TestUtility
         public string LegacyTestProjectsFolder { get; }
         public string TestProjectsFolder { get; }
         public string TestBinariesFolder { get; }
+        public string TestScriptsFolder { get; }
+
 
         private TestAssets()
         {
@@ -22,6 +24,7 @@ namespace TestUtility
             TestAssetsFolder = Path.Combine(RootFolder, "test-assets");
             LegacyTestProjectsFolder = Path.Combine(TestAssetsFolder, "legacy-test-projects");
             TestProjectsFolder = Path.Combine(TestAssetsFolder, "test-projects");
+            TestScriptsFolder = Path.Combine(TestAssetsFolder, "test-scripts");
             TestBinariesFolder = Path.Combine(TestAssetsFolder, "binaries");
         }
 
@@ -73,6 +76,12 @@ namespace TestUtility
             using (var sourceStream = File.OpenRead(file.FullName))
             using (var destStream = File.Create(destFileName))
                 await sourceStream.CopyToAsync(destStream);
+        }
+
+        public ITestProject GetTestScript(string folderName)
+        {
+            var sourceDirectory = Path.Combine(TestScriptsFolder, folderName);
+            return new TestProject(folderName, TestScriptsFolder, sourceDirectory, shadowCopied: false);
         }
 
         public async Task<ITestProject> GetTestProjectAsync(string name, bool shadowCopy = true, bool legacyProject = false)


### PR DESCRIPTION
This PR - as suggested by @rchande on Slack 😀- adds several tests for the CSX project system (a simple CSI script, 2 CSI scripts together, a simple .NET Core script, a .NET Core script with a Nuget reference). 

The tests mimic some of the project tests done by the MsBuild project system - the workspace gets initialized, and then we use `WorkspaceInformationRequest` to retrieve the project system info about what OmniSharp has found there.

This gives us a long, long overdue (I know 😓) "first level" of an automated check - in case some change in the future breaks the project system. 
Irrespective of this PR, I'd still like to add an integration test in the VS Code extension repo.