### PR TITLE
Disable DotNetProjectSystem by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All changes to the project will be documented in this file.
 
 ## [1.32.0] - _Not Yet Released_
 * Added new `/codestructure` endpoint which serves a replacement for the `/currentfilemembersastree` endpoint. The new endpoint has a cleaner design, properly supports all C# types and members, and supports more information, such as accessibility, static vs. instance, etc. (PR: [#1211](https://github.com/OmniSharp/omnisharp-roslyn/pull/1211))
+* The legacy project.json support is now disabled by default, allowing OmniSharp to start up a bit faster for common scenarios. If you wish to enable project.json support, add the following setting to your `omnisharp.json` file. (PR: [#1194](https://github.com/OmniSharp/omnisharp-roslyn/pull/1194))
+
+    ```JSON
+    {
+        "dotnet": {
+            "enabled": false
+        }
+    }
+    ```
 
 ## [1.31.1] - 2018-05-28
 * Fixed bug where diagnostics from loaded `.cake` files was shown in the current file. (PR: [#1201](https://github.com/OmniSharp/omnisharp-roslyn/pull/1201))

--- a/src/OmniSharp.Abstractions/Services/IProjectSystem.cs
+++ b/src/OmniSharp.Abstractions/Services/IProjectSystem.cs
@@ -10,6 +10,7 @@ namespace OmniSharp.Services
         string Key { get; }
         string Language { get; }
         IEnumerable<string> Extensions { get; }
+        bool EnabledByDefault { get; }
 
         /// <summary>
         /// Initialize the project system.

--- a/src/OmniSharp.Cake/CakeProjectSystem.cs
+++ b/src/OmniSharp.Cake/CakeProjectSystem.cs
@@ -38,9 +38,10 @@ namespace OmniSharp.Cake
 
         private CakeOptions _options;
 
-        public string Key => "Cake";
-        public string Language => Constants.LanguageNames.Cake;
-        public IEnumerable<string> Extensions => new[] { ".cake" };
+        public string Key { get; } = "Cake";
+        public string Language { get; } = Constants.LanguageNames.Cake;
+        public IEnumerable<string> Extensions { get; } = new[] { ".cake" };
+        public bool EnabledByDefault { get; } = true;
 
         [ImportingConstructor]
         public CakeProjectSystem(

--- a/src/OmniSharp.DotNet/DotNetProjectSystem.cs
+++ b/src/OmniSharp.DotNet/DotNetProjectSystem.cs
@@ -61,11 +61,10 @@ namespace OmniSharp.DotNet
             _projectStates = new ProjectStatesCache(loggerFactory, _eventEmitter);
         }
 
+        public string Key { get; } = "DotNet";
+        public string Language { get; } = LanguageNames.CSharp;
         public IEnumerable<string> Extensions { get; } = new string[] { ".cs" };
-
-        public string Key => "DotNet";
-
-        public string Language => LanguageNames.CSharp;
+        public bool EnabledByDefault { get; } = false;
 
         Task<object> IProjectSystem.GetWorkspaceModelAsync(WorkspaceInformationRequest request)
         {

--- a/src/OmniSharp.Host/WorkspaceInitializer.cs
+++ b/src/OmniSharp.Host/WorkspaceInitializer.cs
@@ -31,7 +31,7 @@ namespace OmniSharp
                 try
                 {
                     var projectConfiguration = configuration.GetSection(projectSystem.Key);
-                    var enabledProjectFlag = projectConfiguration.GetValue<bool>("enabled", defaultValue: true);
+                    var enabledProjectFlag = projectConfiguration.GetValue("enabled", defaultValue: projectSystem.EnabledByDefault);
                     if (enabledProjectFlag)
                     {
                         projectSystem.Initalize(projectConfiguration);

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -47,6 +47,7 @@ namespace OmniSharp.MSBuild
         public string Key { get; } = "MsBuild";
         public string Language { get; } = LanguageNames.CSharp;
         public IEnumerable<string> Extensions { get; } = new[] { ".cs" };
+        public bool EnabledByDefault { get; } = true;
 
         [ImportingConstructor]
         public ProjectSystem(

--- a/src/OmniSharp.Plugins/Plugin.cs
+++ b/src/OmniSharp.Plugins/Plugin.cs
@@ -7,11 +7,8 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using OmniSharp.Eventing;
 using OmniSharp.Models.WorkspaceInformation;
 using OmniSharp.Services;
-using OmniSharp.Stdio.Protocol;
-using OmniSharp.Stdio.Services;
 
 namespace OmniSharp.Plugins
 {
@@ -37,6 +34,7 @@ namespace OmniSharp.Plugins
         public string Key { get; }
         public string Language { get; }
         public IEnumerable<string> Extensions { get; }
+        public bool EnabledByDefault { get; } = true;
 
         public Task<TResponse> Handle<TRequest, TResponse>(string endpoint, TRequest request)
         {

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -77,9 +77,10 @@ namespace OmniSharp.Script
             });
         }
 
-        public string Key => "Script";
-        public string Language => LanguageNames.CSharp;
+        public string Key { get; } = "Script";
+        public string Language { get; } = LanguageNames.CSharp;
         public IEnumerable<string> Extensions { get; } = new[] { CsxExtension };
+        public bool EnabledByDefault { get; } = true;
 
         public void Initalize(IConfiguration configuration)
         {

--- a/tests/OmniSharp.DotNet.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.DotNet.Tests/WorkspaceInformationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.DotNet.Models;
 using OmniSharp.Models.WorkspaceInformation;
@@ -10,6 +11,11 @@ namespace OmniSharp.DotNet.Tests
 {
     public class WorkspaceInformationTests : AbstractTestFixture
     {
+        private static readonly Dictionary<string, string> s_configurationData = new Dictionary<string, string>
+        {
+            ["DotNet:Enabled"] = "true"
+        };
+
         public WorkspaceInformationTests(ITestOutputHelper output)
             : base(output)
         {
@@ -19,7 +25,7 @@ namespace OmniSharp.DotNet.Tests
         public async Task TestSimpleProject()
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("LegacyProjectJsonApp", legacyProject: true))
-            using (var host = CreateOmniSharpHost(testProject.Directory))
+            using (var host = CreateOmniSharpHost(testProject.Directory, s_configurationData))
             {
                 var workspaceInfo = await GetWorkspaceInfoAsync(host);
 
@@ -43,7 +49,7 @@ namespace OmniSharp.DotNet.Tests
         public async Task TestMSTestProject()
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("LegacyMSTestProject", legacyProject: true))
-            using (var host = CreateOmniSharpHost(testProject.Directory))
+            using (var host = CreateOmniSharpHost(testProject.Directory, s_configurationData))
             {
                 var workspaceInfo = await GetWorkspaceInfoAsync(host);
 
@@ -66,7 +72,7 @@ namespace OmniSharp.DotNet.Tests
         public async Task TestNUnitProject()
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("LegacyNUnitTestProject", legacyProject: true))
-            using (var host = CreateOmniSharpHost(testProject.Directory))
+            using (var host = CreateOmniSharpHost(testProject.Directory, s_configurationData))
             {
                 var workspaceInfo = await GetWorkspaceInfoAsync(host);
 
@@ -89,7 +95,7 @@ namespace OmniSharp.DotNet.Tests
         public async Task TestXunitProject()
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("LegacyXunitTestProject", legacyProject: true))
-            using (var host = CreateOmniSharpHost(testProject.Directory))
+            using (var host = CreateOmniSharpHost(testProject.Directory, s_configurationData))
             {
                 var workspaceInfo = await GetWorkspaceInfoAsync(host);
 

--- a/tests/OmniSharp.DotNetTest.Tests/AbstractGetTestStartInfoFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/AbstractGetTestStartInfoFacts.cs
@@ -11,13 +11,6 @@ namespace OmniSharp.DotNetTest.Tests
 {
     public abstract class AbstractGetTestStartInfoFacts : AbstractTestFixture
     {
-        protected const string LegacyXunitTestProject = "LegacyXunitTestProject";
-        protected const string LegacyNunitTestProject = "LegacyNUnitTestProject";
-        protected const string LegacyMSTestProject = "LegacyMSTestProject";
-        protected const string XunitTestProject = "XunitTestProject";
-        protected const string NunitTestProject = "NUnitTestProject";
-        protected const string MSTestProject = "MSTestProject";
-
         protected AbstractGetTestStartInfoFacts(ITestOutputHelper output)
             : base(output)
         {
@@ -28,14 +21,12 @@ namespace OmniSharp.DotNetTest.Tests
             return host.GetRequestHandler<GetTestStartInfoService>(OmniSharpEndpoints.V2.GetTestStartInfo);
         }
 
-        public abstract DotNetCliVersion DotNetCliVersion { get; }
-
         protected async Task GetDotNetTestStartInfoAsync(string projectName, string methodName, string testFramework)
         {
             var isLegacy = DotNetCliVersion == DotNetCliVersion.Legacy;
 
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync(projectName, legacyProject: isLegacy))
-            using (var host = CreateOmniSharpHost(testProject.Directory, dotNetCliVersion: DotNetCliVersion))
+            using (var host = CreateOmniSharpHost(testProject.Directory, ConfigurationData, DotNetCliVersion))
             {
                 var service = GetRequestHandler(host);
 

--- a/tests/OmniSharp.DotNetTest.Tests/AbstractRunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/AbstractRunTestFacts.cs
@@ -10,13 +10,6 @@ namespace OmniSharp.DotNetTest.Tests
 {
     public abstract class AbstractRunTestFacts : AbstractTestFixture
     {
-        protected const string LegacyXunitTestProject = "LegacyXunitTestProject";
-        protected const string LegacyNunitTestProject = "LegacyNUnitTestProject";
-        protected const string LegacyMSTestProject = "LegacyMSTestProject";
-        protected const string XunitTestProject = "XunitTestProject";
-        protected const string NUnitTestProject = "NUnitTestProject";
-        protected const string MSTestProject = "MSTestProject";
-
         public AbstractRunTestFacts(ITestOutputHelper testOutput)
             : base(testOutput)
         {
@@ -27,14 +20,12 @@ namespace OmniSharp.DotNetTest.Tests
             return host.GetRequestHandler<RunTestService>(OmniSharpEndpoints.V2.RunTest);
         }
 
-        public abstract DotNetCliVersion DotNetCliVersion { get; }
-
         protected async Task<RunTestResponse> RunDotNetTestAsync(string projectName, string methodName, string testFramework, bool shouldPass, bool expectResults = true)
         {
             var isLegacy = DotNetCliVersion == DotNetCliVersion.Legacy;
 
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync(projectName, legacyProject: isLegacy))
-            using (var host = CreateOmniSharpHost(testProject.Directory, dotNetCliVersion: DotNetCliVersion))
+            using (var host = CreateOmniSharpHost(testProject.Directory, ConfigurationData, DotNetCliVersion))
             {
                 var service = GetRequestHandler(host);
 

--- a/tests/OmniSharp.DotNetTest.Tests/AbstractTestFixture.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/AbstractTestFixture.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using TestUtility;
+using Xunit.Abstractions;
+
+namespace OmniSharp.DotNetTest.Tests
+{
+    public abstract class AbstractTestFixture : TestUtility.AbstractTestFixture
+    {
+        protected static readonly Dictionary<string, string> ConfigurationData = new Dictionary<string, string>
+        {
+            ["DotNet:Enabled"] = "true"
+        };
+
+        protected const string LegacyXunitTestProject = "LegacyXunitTestProject";
+        protected const string LegacyNunitTestProject = "LegacyNUnitTestProject";
+        protected const string LegacyMSTestProject = "LegacyMSTestProject";
+        protected const string XunitTestProject = "XunitTestProject";
+        protected const string NUnitTestProject = "NUnitTestProject";
+        protected const string MSTestProject = "MSTestProject";
+
+        protected AbstractTestFixture(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public abstract DotNetCliVersion DotNetCliVersion { get; }
+    }
+}

--- a/tests/OmniSharp.DotNetTest.Tests/AbstractTestFixture.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/AbstractTestFixture.cs
@@ -11,12 +11,12 @@ namespace OmniSharp.DotNetTest.Tests
             ["DotNet:Enabled"] = "true"
         };
 
-        protected const string LegacyXunitTestProject = "LegacyXunitTestProject";
-        protected const string LegacyNunitTestProject = "LegacyNUnitTestProject";
-        protected const string LegacyMSTestProject = "LegacyMSTestProject";
-        protected const string XunitTestProject = "XunitTestProject";
-        protected const string NUnitTestProject = "NUnitTestProject";
-        protected const string MSTestProject = "MSTestProject";
+        protected const string LegacyXunitTestProject = nameof(LegacyXunitTestProject);
+        protected const string LegacyNUnitTestProject = nameof(LegacyNUnitTestProject);
+        protected const string LegacyMSTestProject = nameof(LegacyMSTestProject);
+        protected const string XunitTestProject = nameof(XunitTestProject);
+        protected const string NUnitTestProject = nameof(NUnitTestProject);
+        protected const string MSTestProject = nameof(MSTestProject);
 
         protected AbstractTestFixture(ITestOutputHelper output)
             : base(output)

--- a/tests/OmniSharp.DotNetTest.Tests/GetTestStartInfoFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/GetTestStartInfoFacts.cs
@@ -29,7 +29,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task RunNunitTest()
         {
             await GetDotNetTestStartInfoAsync(
-                NunitTestProject,
+                NUnitTestProject,
                 methodName: "Main.Test.MainTest.Test",
                 testFramework: "nunit");
         }

--- a/tests/OmniSharp.DotNetTest.Tests/LegacyGetTestStartInfoFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/LegacyGetTestStartInfoFacts.cs
@@ -26,7 +26,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task RunNunitTest()
         {
             await GetDotNetTestStartInfoAsync(
-                LegacyNunitTestProject,
+                LegacyNUnitTestProject,
                 methodName: "Main.Test.MainTest.Test",
                 testFramework: "nunit");
         }

--- a/tests/OmniSharp.DotNetTest.Tests/LegacyRunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/LegacyRunTestFacts.cs
@@ -51,7 +51,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task RunNunitTest()
         {
             await RunDotNetTestAsync(
-                LegacyNunitTestProject,
+                LegacyNUnitTestProject,
                 methodName: "Main.Test.MainTest.Test",
                 testFramework: "nunit",
                 shouldPass: true);
@@ -61,7 +61,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task RunNunitDataDriveTest1()
         {
             await RunDotNetTestAsync(
-                LegacyNunitTestProject,
+                LegacyNUnitTestProject,
                 methodName: "Main.Test.MainTest.DataDrivenTest1",
                 testFramework: "nunit",
                 shouldPass: false);
@@ -71,7 +71,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task RunNunitDataDriveTest2()
         {
             await RunDotNetTestAsync(
-                LegacyNunitTestProject,
+                LegacyNUnitTestProject,
                 methodName: "Main.Test.MainTest.DataDrivenTest2",
                 testFramework: "nunit",
                 shouldPass: true);
@@ -81,7 +81,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task RunNunitSourceDataDrivenTest()
         {
             await RunDotNetTestAsync(
-                LegacyNunitTestProject,
+                LegacyNUnitTestProject,
                 methodName: "Main.Test.MainTest.SourceDataDrivenTest",
                 testFramework: "nunit",
                 shouldPass: true);

--- a/tests/OmniSharp.DotNetTest.Tests/TestDiscoveryFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/TestDiscoveryFacts.cs
@@ -13,14 +13,10 @@ namespace OmniSharp.DotNetTest.Tests
     public class TestDiscoveryFacts : AbstractTestFixture
     {
         private const string xunit = nameof(xunit);
-        private const string LegacyXunitTestProject = nameof(LegacyXunitTestProject);
         private const string XunitTestMethod = "XunitTestMethod";
-        private const string XunitTestProject = nameof(XunitTestProject);
 
         private const string nunit = nameof(nunit);
-        private const string LegacyNUnitTestProject = "LegacyNUnitTestProject";
         private const string NUnitTestMethod = "NUnitTestMethod";
-        private const string NUnitTestProject = nameof(NUnitTestProject);
 
         private const string TestProgram = "TestProgram.cs";
 

--- a/tests/OmniSharp.DotNetTest.Tests/TestDiscoveryFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/TestDiscoveryFacts.cs
@@ -32,6 +32,8 @@ namespace OmniSharp.DotNetTest.Tests
             this._testAssets = TestAssets.Instance;
         }
 
+        public override DotNetCliVersion DotNetCliVersion { get; } = 0;
+
         [Theory]
         [InlineData(XunitTestProject, TestProgram, 8, 20, true, xunit, XunitTestMethod, "Main.Test.MainTest.Test")]
         [InlineData(XunitTestProject, TestProgram, 16, 20, true, xunit, XunitTestMethod, "Main.Test.MainTest.DataDrivenTest1")]
@@ -48,7 +50,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task FindTestMethods(string projectName, string fileName, int line, int column, bool expectToFind, string expectedTestFramework, string expectedFeatureName, string expectedMethodName)
         {
             using (var testProject = await this._testAssets.GetTestProjectAsync(projectName))
-            using (var host = CreateOmniSharpHost(testProject.Directory))
+            using (var host = CreateOmniSharpHost(testProject.Directory, ConfigurationData, DotNetCliVersion.Current))
             {
                 var filePath = Path.Combine(testProject.Directory, fileName);
 
@@ -70,7 +72,7 @@ namespace OmniSharp.DotNetTest.Tests
         public async Task LegacyFindTestMethods(string projectName, string fileName, int line, int column, bool expectToFind, string expectedTestFramework, string expectedFeatureName, string expectedMethodName)
         {
             using (var testProject = await this._testAssets.GetTestProjectAsync(projectName, legacyProject: true))
-            using (var host = CreateOmniSharpHost(testProject.Directory))
+            using (var host = CreateOmniSharpHost(testProject.Directory, ConfigurationData, DotNetCliVersion.Legacy))
             {
                 var filePath = Path.Combine(testProject.Directory, fileName);
 

--- a/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
+++ b/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
@@ -74,9 +74,10 @@ namespace OmniSharp.Http.Tests
         [Export(typeof(IProjectSystem))]
         class FakeProjectSystem : IProjectSystem
         {
-            public string Key { get { return "Fake"; } }
-            public string Language { get { return LanguageNames.CSharp; } }
+            public string Key { get; } = "Fake";
+            public string Language { get; } = LanguageNames.CSharp;
             public IEnumerable<string> Extensions { get; } = new[] { ".cs" };
+            public bool EnabledByDefault { get; } = true;
 
             public Task<object> GetWorkspaceModelAsync(WorkspaceInformationRequest request)
             {


### PR DESCRIPTION
This change threads through a new `IProjectSystem.EnabledByDefault` property and sets it to false for the legacy project.json project system.