### PR TITLE
Return the stdout messages to improve test logging

### DIFF
--- a/src/OmniSharp.DotNetTest/Models/DotNetTestResult.cs
+++ b/src/OmniSharp.DotNetTest/Models/DotNetTestResult.cs
@@ -6,6 +6,7 @@ namespace OmniSharp.DotNetTest.Models
         public string Outcome { get; set; }
         public string ErrorMessage { get; set; }
         public string ErrorStackTrace { get; set; }
-        public string[] StdOutMessages {get; set; }
+        public string[] StandardOutputMessages { get; set; }
+        public string[] StandardErrorMessages { get; set; }
     }
 }

--- a/src/OmniSharp.DotNetTest/Models/DotNetTestResult.cs
+++ b/src/OmniSharp.DotNetTest/Models/DotNetTestResult.cs
@@ -6,7 +6,7 @@ namespace OmniSharp.DotNetTest.Models
         public string Outcome { get; set; }
         public string ErrorMessage { get; set; }
         public string ErrorStackTrace { get; set; }
-        public string[] StandardOutputMessages { get; set; }
-        public string[] StandardErrorMessages { get; set; }
+        public string[] StandardOutput { get; set; }
+        public string[] StandardError { get; set; }
     }
 }

--- a/src/OmniSharp.DotNetTest/Models/DotNetTestResult.cs
+++ b/src/OmniSharp.DotNetTest/Models/DotNetTestResult.cs
@@ -6,5 +6,6 @@ namespace OmniSharp.DotNetTest.Models
         public string Outcome { get; set; }
         public string ErrorMessage { get; set; }
         public string ErrorStackTrace { get; set; }
+        public string[] StdOutMessages {get; set; }
     }
 }

--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -241,10 +241,10 @@ namespace OmniSharp.DotNetTest
                     Outcome = testResult.Outcome.ToString().ToLowerInvariant(),
                     ErrorMessage = testResult.ErrorMessage,
                     ErrorStackTrace = testResult.ErrorStackTrace,
-                    StandardOutputMessages = testResult.Messages
+                    StandardOutput = testResult.Messages
                                     .Where(message => message.Category == TestResultMessage.StandardOutCategory)
                                     .Select(message => message.Text).ToArray(),
-                    StandardErrorMessages = testResult.Messages.Where(message => message.Category == TestResultMessage.StandardErrorCategory)
+                    StandardError = testResult.Messages.Where(message => message.Category == TestResultMessage.StandardErrorCategory)
                     .Select(message => message.Text).ToArray()
                 });
 

--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -241,10 +241,11 @@ namespace OmniSharp.DotNetTest
                     Outcome = testResult.Outcome.ToString().ToLowerInvariant(),
                     ErrorMessage = testResult.ErrorMessage,
                     ErrorStackTrace = testResult.ErrorStackTrace,
-                    StdOutMessages = testResult.Messages
+                    StandardOutputMessages = testResult.Messages
                                     .Where(message => message.Category == TestResultMessage.StandardOutCategory)
-                                    .Select(message => message.Text).ToArray()
-
+                                    .Select(message => message.Text).ToArray(),
+                    StandardErrorMessages = testResult.Messages.Where(message => message.Category == TestResultMessage.StandardErrorCategory)
+                    .Select(message => message.Text).ToArray()
                 });
 
             return new RunTestResponse

--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -240,7 +240,11 @@ namespace OmniSharp.DotNetTest
                     MethodName = testResult.TestCase.FullyQualifiedName,
                     Outcome = testResult.Outcome.ToString().ToLowerInvariant(),
                     ErrorMessage = testResult.ErrorMessage,
-                    ErrorStackTrace = testResult.ErrorStackTrace
+                    ErrorStackTrace = testResult.ErrorStackTrace,
+                    StdOutMessages = testResult.Messages
+                                    .Where(message => message.Category == TestResultMessage.StandardOutCategory)
+                                    .Select(message => message.Text).ToArray()
+
                 });
 
             return new RunTestResponse

--- a/test-assets/test-projects/MSTestProject/TestProgram.cs
+++ b/test-assets/test-projects/MSTestProject/TestProgram.cs
@@ -27,6 +27,12 @@ namespace Main.Test
             Assert.IsTrue(i >= 0);
         }
 
+        [TestMethod]
+        public void FailingTest()
+        {
+            Assert.Equals(1, 2);
+        }
+
         private void UtilityFunction()
         {
             

--- a/test-assets/test-projects/MSTestProject/TestProgram.cs
+++ b/test-assets/test-projects/MSTestProject/TestProgram.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Main.Test
@@ -30,7 +31,15 @@ namespace Main.Test
         [TestMethod]
         public void FailingTest()
         {
-            Assert.Equals(1, 2);
+            Assert.AreEqual(1, 2);
+        }
+
+        [TestMethod]
+        public void CheckStandardOutput()
+        {
+            int a = 1, b = 1;
+            Console.WriteLine($"a = {a}, b = {b}");
+            Assert.AreEqual(a,b);
         }
 
         private void UtilityFunction()

--- a/test-assets/test-projects/NUnitTestProject/TestProgram.cs
+++ b/test-assets/test-projects/NUnitTestProject/TestProgram.cs
@@ -30,6 +30,12 @@ namespace Main.Test
             Assert.True(i > 0);
         }
 
+        [Test]
+        public void FailingTest()
+        {
+            Assert.Equals(1, 2);
+        }
+
         public void UtilityFunction()
         {
 

--- a/test-assets/test-projects/NUnitTestProject/TestProgram.cs
+++ b/test-assets/test-projects/NUnitTestProject/TestProgram.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using System;
 
 namespace Main.Test
 {
@@ -33,7 +34,15 @@ namespace Main.Test
         [Test]
         public void FailingTest()
         {
-            Assert.Equals(1, 2);
+            Assert.AreEqual(1, 2);
+        }
+
+        [Test]
+        public void CheckStandardOutput()
+        {
+            int a = 1, b = 1;
+            Console.WriteLine($"a = {a}, b = {b}");
+            Assert.AreEqual(a,b);
         }
 
         public void UtilityFunction()

--- a/test-assets/test-projects/XunitTestProject/TestProgram.cs
+++ b/test-assets/test-projects/XunitTestProject/TestProgram.cs
@@ -9,7 +9,7 @@ namespace Main.Test
         {
             Assert.True(true);
         }
-        
+
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
@@ -17,7 +17,7 @@ namespace Main.Test
         {
             Assert.True(i > 0);
         }
-        
+
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
@@ -25,10 +25,10 @@ namespace Main.Test
         {
             Assert.True(i >= 0);
         }
-        
+
         private void UtilityFunction()
         {
-            
+
         }
 
         [Fact(DisplayName = "My Test Name")]
@@ -47,6 +47,12 @@ namespace Main.Test
         public void TestWithSimilarNameFooBar()
         {
             Assert.True(true);
+        }
+
+        [Fact]
+        public void FailingTest()
+        {
+            Assert.Equal(1, 2);
         }
     }
 }

--- a/test-assets/test-projects/XunitTestProject/TestProgram.cs
+++ b/test-assets/test-projects/XunitTestProject/TestProgram.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 
 namespace Main.Test
@@ -53,6 +54,14 @@ namespace Main.Test
         public void FailingTest()
         {
             Assert.Equal(1, 2);
+        }
+
+        [Fact]
+        public void CheckStandardOutput()
+        {
+            int a = 1, b = 1;
+            Console.WriteLine($"a = {a}, b = {b}");
+            Assert.Equal(a,b);
         }
     }
 }

--- a/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
@@ -81,6 +81,19 @@ namespace OmniSharp.DotNetTest.Tests
         }
 
         [Fact]
+        public async Task RunXunitStandardOutputIsReturned()
+        {
+            var response = await RunDotNetTestAsync(
+                NUnitTestProject,
+                methodName: "Main.Test.MainTest.CheckStandardOutput",
+                testFramework: "xunit",
+                shouldPass: true);
+
+            Assert.Single(response.Results);
+            Assert.NotEmpty(response.Results[0].StandardOutput);
+        }
+
+        [Fact]
         public async Task RunNunitTest()
         {
             await RunDotNetTestAsync(
@@ -126,12 +139,25 @@ namespace OmniSharp.DotNetTest.Tests
             var response = await RunDotNetTestAsync(
                 NUnitTestProject,
                 methodName: "Main.Test.MainTest.FailingTest",
-                testFramework: "xunit",
+                testFramework: "nunit",
                 shouldPass: false);
 
             Assert.Single(response.Results);
             Assert.NotEmpty(response.Results[0].ErrorMessage);
             Assert.NotEmpty(response.Results[0].ErrorStackTrace);
+        }
+
+        [Fact]
+        public async Task RunNunitStandardOutputIsReturned()
+        {
+            var response = await RunDotNetTestAsync(
+                NUnitTestProject,
+                methodName: "Main.Test.MainTest.CheckStandardOutput",
+                testFramework: "nunit",
+                shouldPass: true);
+
+            Assert.Single(response.Results);
+            Assert.NotEmpty(response.Results[0].StandardOutput);
         }
 
         [Fact]
@@ -170,12 +196,25 @@ namespace OmniSharp.DotNetTest.Tests
             var response = await RunDotNetTestAsync(
                 MSTestProject,
                 methodName: "Main.Test.MainTest.FailingTest",
-                testFramework: "xunit",
+                testFramework: "mstest",
                 shouldPass: false);
 
             Assert.Single(response.Results);
             Assert.NotEmpty(response.Results[0].ErrorMessage);
             Assert.NotEmpty(response.Results[0].ErrorStackTrace);
+        }
+
+        [Fact]
+        public async Task RunMSTestStandardOutputIsReturned()
+        {
+            var response = await RunDotNetTestAsync(
+                MSTestProject,
+                methodName: "Main.Test.MainTest.CheckStandardOutput",
+                testFramework: "mstest",
+                shouldPass: true);
+
+            Assert.Single(response.Results);
+            Assert.NotEmpty(response.Results[0].StandardOutput);
         }
     }
 }

--- a/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
@@ -67,6 +67,20 @@ namespace OmniSharp.DotNetTest.Tests
         }
 
         [Fact]
+        public async Task RunXunitFailingTest()
+        {
+            var response = await RunDotNetTestAsync(
+                XunitTestProject,
+                methodName: "Main.Test.MainTest.FailingTest",
+                testFramework: "xunit",
+                shouldPass: false);
+
+            Assert.Single(response.Results);
+            Assert.NotEmpty(response.Results[0].ErrorMessage);
+            Assert.NotEmpty(response.Results[0].ErrorStackTrace);
+        }
+
+        [Fact]
         public async Task RunNunitTest()
         {
             await RunDotNetTestAsync(
@@ -107,6 +121,20 @@ namespace OmniSharp.DotNetTest.Tests
         }
 
         [Fact]
+        public async Task RunNunitFailingTest()
+        {
+            var response = await RunDotNetTestAsync(
+                NUnitTestProject,
+                methodName: "Main.Test.MainTest.FailingTest",
+                testFramework: "xunit",
+                shouldPass: false);
+
+            Assert.Single(response.Results);
+            Assert.NotEmpty(response.Results[0].ErrorMessage);
+            Assert.NotEmpty(response.Results[0].ErrorStackTrace);
+        }
+
+        [Fact]
         public async Task RunMSTestTest()
         {
             await RunDotNetTestAsync(
@@ -134,6 +162,20 @@ namespace OmniSharp.DotNetTest.Tests
                 methodName: "Main.Test.MainTest.DataDrivenTest2",
                 testFramework: "mstest",
                 shouldPass: true);
+        }
+
+        [Fact]
+        public async Task RunMSTestFailingTest()
+        {
+            var response = await RunDotNetTestAsync(
+                MSTestProject,
+                methodName: "Main.Test.MainTest.FailingTest",
+                testFramework: "xunit",
+                shouldPass: false);
+
+            Assert.Single(response.Results);
+            Assert.NotEmpty(response.Results[0].ErrorMessage);
+            Assert.NotEmpty(response.Results[0].ErrorStackTrace);
         }
     }
 }

--- a/tests/OmniSharp.DotNetTest.Tests/TestDiscoveryFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/TestDiscoveryFacts.cs
@@ -20,15 +20,15 @@ namespace OmniSharp.DotNetTest.Tests
         }
 
         [Theory]
-        [InlineData("XunitTestProject", "TestProgram.cs", 7, 20, true, "XunitTestMethod", "Main.Test.MainTest.Test")]
-        [InlineData("XunitTestProject", "TestProgram.cs", 15, 20, true, "XunitTestMethod", "Main.Test.MainTest.DataDrivenTest1")]
-        [InlineData("XunitTestProject", "TestProgram.cs", 23, 20, true, "XunitTestMethod", "Main.Test.MainTest.DataDrivenTest2")]
-        [InlineData("XunitTestProject", "TestProgram.cs", 28, 21, false, "", "")]
-        [InlineData("NUnitTestProject", "TestProgram.cs", 7, 20, true, "NUnitTestMethod", "Main.Test.MainTest.Test")]
-        [InlineData("NUnitTestProject", "TestProgram.cs", 14, 20, true, "NUnitTestMethod", "Main.Test.MainTest.DataDrivenTest1")]
-        [InlineData("NUnitTestProject", "TestProgram.cs", 21, 20, true, "NUnitTestMethod", "Main.Test.MainTest.DataDrivenTest2")]
-        [InlineData("NUnitTestProject", "TestProgram.cs", 27, 20, true, "NUnitTestMethod", "Main.Test.MainTest.SourceDataDrivenTest")]
-        [InlineData("NUnitTestProject", "TestProgram.cs", 32, 20, false, "", "")]
+        [InlineData("XunitTestProject", "TestProgram.cs", 8, 20, true, "XunitTestMethod", "Main.Test.MainTest.Test")]
+        [InlineData("XunitTestProject", "TestProgram.cs", 16, 20, true, "XunitTestMethod", "Main.Test.MainTest.DataDrivenTest1")]
+        [InlineData("XunitTestProject", "TestProgram.cs", 24, 20, true, "XunitTestMethod", "Main.Test.MainTest.DataDrivenTest2")]
+        [InlineData("XunitTestProject", "TestProgram.cs", 29, 21, false, "", "")]
+        [InlineData("NUnitTestProject", "TestProgram.cs", 8, 20, true, "NUnitTestMethod", "Main.Test.MainTest.Test")]
+        [InlineData("NUnitTestProject", "TestProgram.cs", 15, 20, true, "NUnitTestMethod", "Main.Test.MainTest.DataDrivenTest1")]
+        [InlineData("NUnitTestProject", "TestProgram.cs", 22, 20, true, "NUnitTestMethod", "Main.Test.MainTest.DataDrivenTest2")]
+        [InlineData("NUnitTestProject", "TestProgram.cs", 28, 20, true, "NUnitTestMethod", "Main.Test.MainTest.SourceDataDrivenTest")]
+        [InlineData("NUnitTestProject", "TestProgram.cs", 34, 20, true, "NUnitTestMethod", "Main.Test.MainTest.FailingTest")]
         public async Task FindTestMethods(string projectName, string fileName, int line, int column, bool found, string expectedFeatureName, string expectedMethodName)
         {
             using (var testProject = await this._testAssets.GetTestProjectAsync(projectName))

--- a/tests/OmniSharp.DotNetTest.Tests/TestDiscoveryFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/TestDiscoveryFacts.cs
@@ -23,12 +23,15 @@ namespace OmniSharp.DotNetTest.Tests
         [InlineData("XunitTestProject", "TestProgram.cs", 8, 20, true, "XunitTestMethod", "Main.Test.MainTest.Test")]
         [InlineData("XunitTestProject", "TestProgram.cs", 16, 20, true, "XunitTestMethod", "Main.Test.MainTest.DataDrivenTest1")]
         [InlineData("XunitTestProject", "TestProgram.cs", 24, 20, true, "XunitTestMethod", "Main.Test.MainTest.DataDrivenTest2")]
+        [InlineData("XunitTestProject", "TestProgram.cs", 53, 20, true, "XunitTestMethod", "Main.Test.MainTest.FailingTest")]
+        [InlineData("XunitTestProject", "TestProgram.cs", 59, 20, true, "XunitTestMethod", "Main.Test.MainTest.CheckStandardOutput")]
         [InlineData("XunitTestProject", "TestProgram.cs", 29, 21, false, "", "")]
         [InlineData("NUnitTestProject", "TestProgram.cs", 8, 20, true, "NUnitTestMethod", "Main.Test.MainTest.Test")]
         [InlineData("NUnitTestProject", "TestProgram.cs", 15, 20, true, "NUnitTestMethod", "Main.Test.MainTest.DataDrivenTest1")]
         [InlineData("NUnitTestProject", "TestProgram.cs", 22, 20, true, "NUnitTestMethod", "Main.Test.MainTest.DataDrivenTest2")]
         [InlineData("NUnitTestProject", "TestProgram.cs", 28, 20, true, "NUnitTestMethod", "Main.Test.MainTest.SourceDataDrivenTest")]
         [InlineData("NUnitTestProject", "TestProgram.cs", 34, 20, true, "NUnitTestMethod", "Main.Test.MainTest.FailingTest")]
+        [InlineData("NUnitTestProject", "TestProgram.cs", 47, 20, false, "", "")]
         public async Task FindTestMethods(string projectName, string fileName, int line, int column, bool found, string expectedFeatureName, string expectedMethodName)
         {
             using (var testProject = await this._testAssets.GetTestProjectAsync(projectName))


### PR DESCRIPTION
dotnet test also prints the stdout messages. So added a property to `DotNetTestResult` to return an array of these messages.

omnisharp-vscode side : https://github.com/OmniSharp/omnisharp-vscode/pull/2343

Please review : @rchande @DustinCampbell 