### PR TITLE
Fix zero/one-based range and point models

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/BaseCodeActionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/BaseCodeActionService.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions;
 using OmniSharp.Mef;
 using OmniSharp.Models.V2.CodeActions;
 using OmniSharp.Roslyn.CSharp.Services.CodeActions;
@@ -88,12 +89,10 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
         {
             if (request.Selection != null)
             {
-                return TextSpan.FromBounds(
-                    sourceText.Lines.GetPosition(new LinePosition(request.Selection.Start.Line, request.Selection.Start.Column)),
-                    sourceText.Lines.GetPosition(new LinePosition(request.Selection.End.Line, request.Selection.End.Column)));
+                return sourceText.GetSpanFromRange(request.Selection);
             }
 
-            var position = sourceText.Lines.GetPosition(new LinePosition(request.Line, request.Column));
+            var position = sourceText.GetPositionFromLineAndOffset(request.Line, request.Column);
             return new TextSpan(position, length: 0);
         }
 
@@ -152,8 +151,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
 
         private List<CodeFixProvider> GetSortedCodeFixProviders()
         {
-            List<ProviderNode<CodeFixProvider>> nodesList = new List<ProviderNode<CodeFixProvider>>();
-            List<CodeFixProvider> providerList = new List<CodeFixProvider>();
+            var nodesList = new List<ProviderNode<CodeFixProvider>>();
+            var providerList = new List<CodeFixProvider>();
+
             foreach (var provider in this.Providers)
             {
                 foreach (var codeFixProvider in provider.CodeFixProviders)
@@ -168,13 +168,15 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
             {
                 return providerList;
             }
+
             return graph.TopologicalSort();
         }
 
         private List<CodeRefactoringProvider> GetSortedCodeRefactoringProviders()
         {
-            List<ProviderNode<CodeRefactoringProvider>> nodesList = new List<ProviderNode<CodeRefactoringProvider>>();
-            List<CodeRefactoringProvider> providerList = new List<CodeRefactoringProvider>();
+            var nodesList = new List<ProviderNode<CodeRefactoringProvider>>();
+            var providerList = new List<CodeRefactoringProvider>();
+
             foreach (var provider in this.Providers)
             {
                 foreach (var codeRefactoringProvider in provider.CodeRefactoringProviders)
@@ -189,6 +191,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
             {
                 return providerList;
             }
+
             return graph.TopologicalSort();
         }
 

--- a/src/OmniSharp.Roslyn/Extensions/TextExtensions.cs
+++ b/src/OmniSharp.Roslyn/Extensions/TextExtensions.cs
@@ -12,11 +12,10 @@ namespace OmniSharp.Extensions
         {
             var line = text.Lines.GetLineFromPosition(position);
 
-            // Note: OmniSharp text coordinates are 1-based by default.
             return new Point
             {
-                Line = line.LineNumber + 1,
-                Column = position - line.Start + 1
+                Line = line.LineNumber,
+                Column = position - line.Start
             };
         }
 

--- a/src/OmniSharp.Roslyn/Extensions/TextExtensions.cs
+++ b/src/OmniSharp.Roslyn/Extensions/TextExtensions.cs
@@ -20,6 +20,18 @@ namespace OmniSharp.Extensions
         }
 
         /// <summary>
+        /// Converts a line number and offset to a zero-based position within a <see cref="SourceText"/>.
+        /// </summary>
+        public static int GetPositionFromLineAndOffset(this SourceText text, int lineNumber, int offset)
+            => text.Lines[lineNumber].Start + offset;
+
+        /// <summary>
+        /// Converts an OmniSharp <see cref="Point"/> to a zero-based position within a <see cref="SourceText"/>.
+        /// </summary>
+        public static int GetPositionFromPoint(this SourceText text, Point point)
+            => text.GetPositionFromLineAndOffset(point.Line, point.Column);
+
+        /// <summary>
         /// Converts a <see cref="TextSpan"/> in a <see cref="SourceText"/> to an OmniSharp <see cref="Range"/>.
         /// </summary>
         public static Range GetRangeFromSpan(this SourceText text, TextSpan span)
@@ -28,5 +40,13 @@ namespace OmniSharp.Extensions
                 Start = text.GetPointFromPosition(span.Start),
                 End = text.GetPointFromPosition(span.End)
             };
+
+        /// <summary>
+        /// Converts an OmniSharp <see cref="Range"/> to a <see cref="TextSpan"/> within a <see cref="SourceText"/>.
+        /// </summary>
+        public static TextSpan GetSpanFromRange(this SourceText text, Range range)
+            => TextSpan.FromBounds(
+                start: text.GetPositionFromPoint(range.Start),
+                end: text.GetPositionFromPoint(range.End));
     }
 }

--- a/tests/OmniSharp.Tests/ZeroBasedIndexConverterFacts.cs
+++ b/tests/OmniSharp.Tests/ZeroBasedIndexConverterFacts.cs
@@ -1,5 +1,10 @@
 using Newtonsoft.Json;
 using OmniSharp.Models;
+using OmniSharp.Models.ChangeBuffer;
+using OmniSharp.Models.CodeAction;
+using OmniSharp.Models.Highlight;
+using OmniSharp.Models.Navigate;
+using OmniSharp.Models.V2;
 using Xunit;
 
 namespace OmniSharp.Tests
@@ -40,7 +45,6 @@ namespace OmniSharp.Tests
             };
 
             var output = JsonConvert.SerializeObject(request);
-
             var input = JsonConvert.DeserializeObject<Request>(output);
 
             Assert.Equal(request.Line, input.Line);
@@ -63,6 +67,376 @@ namespace OmniSharp.Tests
 
             Assert.Equal(request.Line, input.Line);
             Assert.Equal(request.Column, input.Column);
+        }
+
+        [Fact]
+        public void Point_OneBased()
+        {
+            Configuration.ZeroBasedIndices = false;
+
+            const string input = @"
+{
+  ""line"": 1,
+  ""column"": 1
+}
+";
+
+            var point = JsonConvert.DeserializeObject<Point>(input);
+
+            Assert.Equal(0, point.Line);
+            Assert.Equal(0, point.Column);
+        }
+
+        [Fact]
+        public void Point_ZeroBased()
+        {
+            Configuration.ZeroBasedIndices = true;
+
+            const string input = @"
+{
+  ""line"": 1,
+  ""column"": 1
+}
+";
+
+            var point = JsonConvert.DeserializeObject<Point>(input);
+
+            Assert.Equal(1, point.Line);
+            Assert.Equal(1, point.Column);
+        }
+
+        [Fact]
+        public void Range_OneBased()
+        {
+            Configuration.ZeroBasedIndices = false;
+
+            const string input = @"
+{
+  ""start"": {
+    ""line"": 1,
+    ""column"": 1
+  },
+  ""end"": {
+    ""line"": 19,
+    ""column"": 23
+  }
+}
+";
+
+            var range = JsonConvert.DeserializeObject<Range>(input);
+
+            Assert.Equal(0, range.Start.Line);
+            Assert.Equal(0, range.Start.Column);
+            Assert.Equal(18, range.End.Line);
+            Assert.Equal(22, range.End.Column);
+        }
+
+        [Fact]
+        public void Range_ZeroBased()
+        {
+            Configuration.ZeroBasedIndices = true;
+
+            const string input = @"
+{
+  ""start"": {
+    ""line"": 1,
+    ""column"": 1
+  },
+  ""end"": {
+    ""line"": 19,
+    ""column"": 23
+  }
+}
+";
+
+            var range = JsonConvert.DeserializeObject<Range>(input);
+
+            Assert.Equal(1, range.Start.Line);
+            Assert.Equal(1, range.Start.Column);
+            Assert.Equal(19, range.End.Line);
+            Assert.Equal(23, range.End.Column);
+        }
+
+        [Fact]
+        public void HighlightSpan_OneBased()
+        {
+            Configuration.ZeroBasedIndices = false;
+
+            const string input = @"
+{
+  ""startLine"": 1,
+  ""startColumn"": 1,
+  ""endLine"": 19,
+  ""endColumn"": 23
+}
+";
+
+            var highlightSpan = JsonConvert.DeserializeObject<HighlightSpan>(input);
+
+            Assert.Equal(0, highlightSpan.StartLine);
+            Assert.Equal(0, highlightSpan.StartColumn);
+            Assert.Equal(18, highlightSpan.EndLine);
+            Assert.Equal(22, highlightSpan.EndColumn);
+        }
+
+        [Fact]
+        public void HighlightSpan_ZeroBased()
+        {
+            Configuration.ZeroBasedIndices = true;
+
+            const string input = @"
+{
+  ""startLine"": 1,
+  ""startColumn"": 1,
+  ""endLine"": 19,
+  ""endColumn"": 23
+}
+";
+
+            var highlightSpan = JsonConvert.DeserializeObject<HighlightSpan>(input);
+
+            Assert.Equal(1, highlightSpan.StartLine);
+            Assert.Equal(1, highlightSpan.StartColumn);
+            Assert.Equal(19, highlightSpan.EndLine);
+            Assert.Equal(23, highlightSpan.EndColumn);
+        }
+
+        [Fact]
+        public void ChangeBufferRequest_OneBased()
+        {
+            Configuration.ZeroBasedIndices = false;
+
+            const string input = @"
+{
+  ""startLine"": 1,
+  ""startColumn"": 1,
+  ""endLine"": 19,
+  ""endColumn"": 23
+}
+";
+
+            var changeBufferRequest = JsonConvert.DeserializeObject<ChangeBufferRequest>(input);
+
+            Assert.Equal(0, changeBufferRequest.StartLine);
+            Assert.Equal(0, changeBufferRequest.StartColumn);
+            Assert.Equal(18, changeBufferRequest.EndLine);
+            Assert.Equal(22, changeBufferRequest.EndColumn);
+        }
+
+        [Fact]
+        public void ChangeBufferRequest_ZeroBased()
+        {
+            Configuration.ZeroBasedIndices = true;
+
+            const string input = @"
+{
+  ""startLine"": 1,
+  ""startColumn"": 1,
+  ""endLine"": 19,
+  ""endColumn"": 23
+}
+";
+
+            var changeBufferRequest = JsonConvert.DeserializeObject<ChangeBufferRequest>(input);
+
+            Assert.Equal(1, changeBufferRequest.StartLine);
+            Assert.Equal(1, changeBufferRequest.StartColumn);
+            Assert.Equal(19, changeBufferRequest.EndLine);
+            Assert.Equal(23, changeBufferRequest.EndColumn);
+        }
+
+        [Fact]
+        public void GetCodeActionRequest_OneBased()
+        {
+            Configuration.ZeroBasedIndices = false;
+
+            const string input = @"
+{
+  ""selectionStartLine"": 1,
+  ""selectionStartColumn"": 1,
+  ""selectionEndLine"": 19,
+  ""selectionEndColumn"": 23
+}
+";
+
+            var codeActionRequest = JsonConvert.DeserializeObject<GetCodeActionRequest>(input);
+
+            Assert.Equal(0, codeActionRequest.SelectionStartLine);
+            Assert.Equal(0, codeActionRequest.SelectionStartColumn);
+            Assert.Equal(18, codeActionRequest.SelectionEndLine);
+            Assert.Equal(22, codeActionRequest.SelectionEndColumn);
+        }
+
+        [Fact]
+        public void GetCodeActionRequest_ZeroBased()
+        {
+            Configuration.ZeroBasedIndices = true;
+
+            const string input = @"
+{
+  ""selectionStartLine"": 1,
+  ""selectionStartColumn"": 1,
+  ""selectionEndLine"": 19,
+  ""selectionEndColumn"": 23
+}
+";
+
+            var codeActionRequest = JsonConvert.DeserializeObject<GetCodeActionRequest>(input);
+
+            Assert.Equal(1, codeActionRequest.SelectionStartLine);
+            Assert.Equal(1, codeActionRequest.SelectionStartColumn);
+            Assert.Equal(19, codeActionRequest.SelectionEndLine);
+            Assert.Equal(23, codeActionRequest.SelectionEndColumn);
+        }
+
+        [Fact]
+        public void NavigateResponse_OneBased()
+        {
+            Configuration.ZeroBasedIndices = false;
+
+            var input = new NavigateResponse()
+            {
+                Line = 0,
+                Column = 0
+            };
+
+            var json = JsonConvert.SerializeObject(input, Formatting.Indented);
+
+            const string output = @"
+{
+  ""Line"": 1,
+  ""Column"": 1
+}
+";
+
+            Assert.Equal(output.Trim(), json);
+        }
+
+        [Fact]
+        public void NavigateResponse_ZeroBased()
+        {
+            Configuration.ZeroBasedIndices = true;
+
+            var input = new NavigateResponse()
+            {
+                Line = 0,
+                Column = 0
+            };
+
+            var json = JsonConvert.SerializeObject(input, Formatting.Indented);
+
+            var output = @"
+{
+  ""Line"": 0,
+  ""Column"": 0
+}
+".Trim();
+
+            Assert.Equal(output, json);
+        }
+
+        [Fact]
+        public void LinePositionSpanTextChange_OneBased()
+        {
+            Configuration.ZeroBasedIndices = false;
+
+            const string input = @"
+{
+  ""startLine"": 1,
+  ""startColumn"": 1,
+  ""endLine"": 19,
+  ""endColumn"": 23
+}
+";
+
+            var linePositionSpanTextChange = JsonConvert.DeserializeObject<LinePositionSpanTextChange>(input);
+
+            Assert.Equal(0, linePositionSpanTextChange.StartLine);
+            Assert.Equal(0, linePositionSpanTextChange.StartColumn);
+            Assert.Equal(18, linePositionSpanTextChange.EndLine);
+            Assert.Equal(22, linePositionSpanTextChange.EndColumn);
+        }
+
+        [Fact]
+        public void LinePositionSpanTextChange_ZeroBased()
+        {
+            Configuration.ZeroBasedIndices = true;
+
+            const string input = @"
+{
+  ""startLine"": 1,
+  ""startColumn"": 1,
+  ""endLine"": 19,
+  ""endColumn"": 23
+}
+";
+
+            var linePositionSpanTextChange = JsonConvert.DeserializeObject<LinePositionSpanTextChange>(input);
+
+            Assert.Equal(1, linePositionSpanTextChange.StartLine);
+            Assert.Equal(1, linePositionSpanTextChange.StartColumn);
+            Assert.Equal(19, linePositionSpanTextChange.EndLine);
+            Assert.Equal(23, linePositionSpanTextChange.EndColumn);
+        }
+
+        [Fact]
+        public void QuickFix_OneBased()
+        {
+            Configuration.ZeroBasedIndices = false;
+
+            var input = new QuickFix()
+            {
+                Line = 0,
+                Column = 0,
+                EndLine = 19,
+                EndColumn = 23
+            };
+
+            var json = JsonConvert.SerializeObject(input, Formatting.Indented);
+
+            const string output = @"
+{
+  ""FileName"": null,
+  ""Line"": 1,
+  ""Column"": 1,
+  ""EndLine"": 20,
+  ""EndColumn"": 24,
+  ""Text"": null,
+  ""Projects"": []
+}
+";
+
+            Assert.Equal(output.Trim(), json);
+        }
+
+        [Fact]
+        public void QuickFix_ZeroBased()
+        {
+            Configuration.ZeroBasedIndices = true;
+
+            var input = new QuickFix()
+            {
+                Line = 0,
+                Column = 0,
+                EndLine = 19,
+                EndColumn = 23
+            };
+
+            var json = JsonConvert.SerializeObject(input, Formatting.Indented);
+
+            const string output = @"
+{
+  ""FileName"": null,
+  ""Line"": 0,
+  ""Column"": 0,
+  ""EndLine"": 19,
+  ""EndColumn"": 23,
+  ""Text"": null,
+  ""Projects"": []
+}
+";
+
+            Assert.Equal(output.Trim(), json);
         }
     }
 }

--- a/tests/TestUtility/TextPoint.cs
+++ b/tests/TestUtility/TextPoint.cs
@@ -17,8 +17,7 @@ namespace TestUtility
         }
 
         public Point ToPoint()
-            // Note that OmniSharp is 1-based by default, so make sure we convert here.
-            => new Point { Line = this.Line + 1, Column = this.Offset + 1 };
+            => new Point { Line = this.Line, Column = this.Offset };
 
         public int CompareTo(TextPoint other)
         {


### PR DESCRIPTION
I apparently lost my mind the other day and added code to increment zero-based indeces to one-based indeces in the `OmniSharp.Models.V2.Point` type. Thankfully, @mholo65 found this while battling some other code and pointed it out. I've fixed this, added a few more helper extension methods for converting lines, offsets, spans, ranges and points, and added several tests for the `ZeroBasedIndexConverter` using specific OmniSharp protocol types.