### PR TITLE
Debug only when test manager is connected

### DIFF
--- a/src/OmniSharp.DotNetTest/Services/DebugTestService.cs
+++ b/src/OmniSharp.DotNetTest/Services/DebugTestService.cs
@@ -1,4 +1,5 @@
-﻿using System.Composition;
+﻿using System;
+using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -31,9 +32,14 @@ namespace OmniSharp.DotNetTest.Services
         public Task<DebugTestGetStartInfoResponse> Handle(DebugTestGetStartInfoRequest request)
         {
             var testManager = CreateTestManager(request.FileName);
-            _debugSessionManager.StartSession(testManager);
+            if (testManager.IsConnected)
+            {
+                //only if the test manager connected successfully, shall we proceed with the request
+                _debugSessionManager.StartSession(testManager);
+                return _debugSessionManager.DebugGetStartInfoAsync(request.MethodName, request.TestFrameworkName, request.TargetFrameworkVersion, CancellationToken.None);
+            }
 
-            return _debugSessionManager.DebugGetStartInfoAsync(request.MethodName, request.TestFrameworkName, request.TargetFrameworkVersion, CancellationToken.None);
+            throw new InvalidOperationException("The debugger could not be started");
         }
 
         public Task<DebugTestLaunchResponse> Handle(DebugTestLaunchRequest request)


### PR DESCRIPTION
Fixes: https://github.com/OmniSharp/omnisharp-vscode/issues/2400

If there is a Build failure the test manager fails to connect and the required variables for the debug process are not initialized. However since there is no check that the TestManager is connected or not, we go ahead with the debug request and the system fails with the exception `_writer is null`. However, since we entered the `StartSession` method, the required variables are set and it appears to omnisharp-roslyn that a debug session has started whereas there is no such session. Hence any subsequent debug request is rejected with the error - `Debug session started`.

Hence the fix is to verify whether the testManager is connected before we call the StartSession ,else fail with the relevant exception.