### PR TITLE
revert from McMaster.Extensions.CommandLineUtils to Microsoft.Extensions.CommandLineUtils

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -14,7 +14,6 @@
     <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.6.1" />
     <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.6.2" />
 
-    <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
 
     <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
     <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
@@ -34,6 +33,7 @@
     <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
 
     <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
     <PackageReference Update="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />

--- a/src/OmniSharp.Host/CommandLineApplication.cs
+++ b/src/OmniSharp.Host/CommandLineApplication.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Internal;
 
@@ -13,7 +13,7 @@ namespace OmniSharp
 {
     public class CommandLineApplication
     {
-        protected readonly McMaster.Extensions.CommandLineUtils.CommandLineApplication Application;
+        protected readonly Microsoft.Extensions.CommandLineUtils.CommandLineApplication Application;
         private readonly CommandOption _hostPid;
         private readonly CommandOption _zeroBasedIndices;
         private readonly CommandOption _plugin;
@@ -24,7 +24,7 @@ namespace OmniSharp
 
         public CommandLineApplication()
         {
-            Application = new McMaster.Extensions.CommandLineUtils.CommandLineApplication(throwOnUnexpectedArg: false);
+            Application = new Microsoft.Extensions.CommandLineUtils.CommandLineApplication(throwOnUnexpectedArg: false);
             Application.HelpOption("-? | -h | --help");
 
             _applicationRoot = Application.Option("-s | --source", "Solution or directory for OmniSharp to point at (defaults to current directory).", CommandOptionType.SingleValue);

--- a/src/OmniSharp.Host/Internal/CommandOptionExtensions.cs
+++ b/src/OmniSharp.Host/Internal/CommandOptionExtensions.cs
@@ -1,6 +1,6 @@
 using System;
 using System.ComponentModel;
-using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.CommandLineUtils;
 
 namespace OmniSharp.Internal
 {

--- a/src/OmniSharp.Host/OmniSharp.Host.csproj
+++ b/src/OmniSharp.Host/OmniSharp.Host.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />

--- a/src/OmniSharp.Http/HttpCommandLineApplication.cs
+++ b/src/OmniSharp.Http/HttpCommandLineApplication.cs
@@ -1,4 +1,4 @@
-using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.CommandLineUtils;
 using OmniSharp.Internal;
 
 namespace OmniSharp.Http

--- a/src/OmniSharp.Stdio/StdioCommandLineApplication.cs
+++ b/src/OmniSharp.Stdio/StdioCommandLineApplication.cs
@@ -1,4 +1,4 @@
-using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.CommandLineUtils;
 using OmniSharp.Internal;
 
 namespace OmniSharp.Stdio


### PR DESCRIPTION
This should fix #1256 (at least on my local box it works on the embedded Mono).
We do not take advantage of any features of `McMaster.Extensions.CommandLineUtils` over the old `Microsoft.Extensions.CommandLineUtils` so it might be a bit excessive to have to update the embedded Mono to include more stuff just for the sake of a library upgrade.