### PR TITLE
Add packaging scripts for embedded Mono and MSBuild bits

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -209,7 +209,6 @@ Task("InstallMonoAssets")
     DownloadFileAndUnzip($"{buildPlan.DownloadURL}/{buildPlan.MonoRuntimeMacOS}", env.Folders.MonoRuntimeMacOS);
     DownloadFileAndUnzip($"{buildPlan.DownloadURL}/{buildPlan.MonoRuntimeLinux32}", env.Folders.MonoRuntimeLinux32);
     DownloadFileAndUnzip($"{buildPlan.DownloadURL}/{buildPlan.MonoRuntimeLinux64}", env.Folders.MonoRuntimeLinux64);
-    DownloadFileAndUnzip($"{buildPlan.DownloadURL}/{buildPlan.MonoFramework}", env.Folders.MonoFramework);
     DownloadFileAndUnzip($"{buildPlan.DownloadURL}/{buildPlan.MonoMSBuildRuntime}", env.Folders.MonoMSBuildRuntime);
     DownloadFileAndUnzip($"{buildPlan.DownloadURL}/{buildPlan.MonoMSBuildLib}", env.Folders.MonoMSBuildLib);
 
@@ -221,7 +220,6 @@ Task("InstallMonoAssets")
 
     var frameworkFolder = CombinePaths(env.Folders.Mono, "framework");
     DirectoryHelper.ForceCreate(frameworkFolder);
-    DirectoryHelper.Copy(env.Folders.MonoFramework, frameworkFolder);
 
     Run("chmod", $"+x '{CombinePaths(env.Folders.Mono, "bin", monoRuntimeFile)}'");
     Run("chmod", $"+x '{CombinePaths(env.Folders.Mono, "run")}'");
@@ -712,8 +710,6 @@ string PublishMonoBuildForPlatform(string project, MonoRuntime monoRuntime, Buil
 
     Run("chmod", $"+x '{CombinePaths(outputFolder, "bin", monoRuntime.RuntimeFile)}'");
     Run("chmod", $"+x '{CombinePaths(outputFolder, "run")}'");
-
-    DirectoryHelper.Copy(env.Folders.MonoFramework, CombinePaths(outputFolder, "framework"));
 
     var sourceFolder = CombinePaths(env.Folders.ArtifactsPublish, project, "mono");
     var omnisharpFolder = CombinePaths(outputFolder, "omnisharp");

--- a/build.json
+++ b/build.json
@@ -8,12 +8,11 @@
   "LegacyDotNetVersion": "1.0.0-preview2-1-003177",
   "RequiredMonoVersion": "5.8.0.0",
   "DownloadURL": "https://omnisharpdownload.blob.core.windows.net/ext",
-  "MonoRuntimeMacOS": "mono.osx-5.12.0.226.zip",
-  "MonoRuntimeLinux32": "mono.linux-x86-5.12.0.226.zip",
-  "MonoRuntimeLinux64": "mono.linux-x86_64-5.12.0.226.zip",
-  "MonoFramework": "framework-5.12.0.226.zip",
-  "MonoMSBuildRuntime": "Microsoft.Build.Runtime.Mono-5.12.0.226.zip",
-  "MonoMSBuildLib": "Microsoft.Build.Lib.Mono-5.12.0.226.zip",
+  "MonoRuntimeMacOS": "mono.macOS-5.12.0.301.zip",
+  "MonoRuntimeLinux32": "mono.linux-x86-5.12.0.301.zip",
+  "MonoRuntimeLinux64": "mono.linux-x86_64-5.12.0.301.zip",
+  "MonoMSBuildRuntime": "Microsoft.Build.Runtime.Mono-5.12.0.301.zip",
+  "MonoMSBuildLib": "Microsoft.Build.Lib.Mono-5.12.0.301.zip",
   "HostProjects": [
     "OmniSharp.Stdio.Driver",
     "OmniSharp.Http.Driver"

--- a/mono-packaging/copy-mono.sh
+++ b/mono-packaging/copy-mono.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+
+# Copies Mono assets needed to run OmniSharp.
+
+# Arguments:
+#   $1: output directory
+
+output_path=$1
+
+if [ "$output_path" = "" ]; then
+    output_path=`pwd -P`
+    echo "No output directory specified. Using $output_path"
+fi
+
+script_path="$(cd "$(dirname "$0")" && pwd -P)"
+
+target_path=""
+
+_create_target_path() {
+    _cleanup_target_path
+
+    target_path=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
+    echo "Using temporary path: $target_path"
+}
+
+# deletes the temp directory
+_cleanup_target_path() {
+    if [ -d "$target_path" ]; then
+        rm -rf "$target_path"
+        echo "Deleted temp directory: $target_path"
+    fi
+}
+
+trap _cleanup_target_path EXIT
+
+readonly OS_MAC="macOS"
+readonly OS_Linux32="linux-x86"
+readonly OS_Linux64="linux-x86_64"
+
+os=""
+
+case `uname` in
+    "Darwin")
+        os=$OS_MAC
+        ;;
+    "Linux")
+        case `uname -m` in
+            "x86" | "i386" | "i686")
+                os=$OS_Linux32
+                ;;
+            "x86_64")
+                os=$OS_Linux64
+                ;;
+        esac
+        ;;
+    *)
+        echo "This operating system is not supported."
+        exit 1
+        ;;
+esac
+
+mono_version=`mono --version | head -n 1 | sed 's/[^0-9.]*\([0-9.]*\).*/\1/'`
+
+gac_assemblies=(
+    "Microsoft.Build.Engine/4.0.0.0__b03f5f7f11d50a3a/Microsoft.Build.Engine.dll"
+    "Microsoft.Build.Tasks.v4.0/4.0.0.0__b03f5f7f11d50a3a/Microsoft.Build.Tasks.v4.0.dll"
+    "Microsoft.Build.Utilities.v4.0/4.0.0.0__b03f5f7f11d50a3a/Microsoft.Build.Utilities.v4.0.dll"
+    "Mono.Data.Tds/4.0.0.0__0738eb9f132ed756/Mono.Data.Tds.dll"
+    "Mono.Posix/4.0.0.0__0738eb9f132ed756/Mono.Posix.dll"
+    "Mono.Security/4.0.0.0__0738eb9f132ed756/Mono.Security.dll"
+    "System/4.0.0.0__b77a5c561934e089/System.dll"
+    "System.ComponentModel.Composition/4.0.0.0__b77a5c561934e089/System.ComponentModel.Composition.dll"
+    "System.ComponentModel.DataAnnotations/4.0.0.0__31bf3856ad364e35/System.ComponentModel.DataAnnotations.dll"
+    "System.Configuration/4.0.0.0__b03f5f7f11d50a3a/System.Configuration.dll"
+    "System.Core/4.0.0.0__b77a5c561934e089/System.Core.dll"
+    "System.Data/4.0.0.0__b77a5c561934e089/System.Data.dll"
+    "System.EnterpriseServices/4.0.0.0__b03f5f7f11d50a3a/System.EnterpriseServices.dll"
+    "System.IO.Compression/4.0.0.0__b77a5c561934e089/System.IO.Compression.dll"
+    "System.IO.Compression.FileSystem/4.0.0.0__b77a5c561934e089/System.IO.Compression.FileSystem.dll"
+    "System.Net.Http/4.0.0.0__b03f5f7f11d50a3a/System.Net.Http.dll"
+    "System.Numerics/4.0.0.0__b77a5c561934e089/System.Numerics.dll"
+    "System.Numerics.Vectors/4.0.0.0__b03f5f7f11d50a3a/System.Numerics.Vectors.dll"
+    "System.Runtime.Serialization/4.0.0.0__b77a5c561934e089/System.Runtime.Serialization.dll"
+    "System.Security/4.0.0.0__b03f5f7f11d50a3a/System.Security.dll"
+    "System.ServiceModel.Internals/0.0.0.0__b77a5c561934e089/System.ServiceModel.Internals.dll"
+    "System.Threading.Tasks.Dataflow/4.0.0.0__b77a5c561934e089/System.Threading.Tasks.Dataflow.dll"
+    "System.Transactions/4.0.0.0__b77a5c561934e089/System.Transactions.dll"
+    "System.Xaml/4.0.0.0__b77a5c561934e089/System.Xaml.dll"
+    "System.Xml/4.0.0.0__b77a5c561934e089/System.Xml.dll"
+    "System.Xml.Linq/4.0.0.0__b77a5c561934e089/System.Xml.Linq.dll"
+)
+
+framework_facades=(
+    "netstandard.dll"
+    "System.AppContext.dll"
+    "System.Collections.dll"
+    "System.Collections.Concurrent.dll"
+    "System.ComponentModel.dll"
+    "System.ComponentModel.Annotations.dll"
+    "System.ComponentModel.EventBasedAsync.dll"
+    "System.ComponentModel.Primitives.dll"
+    "System.ComponentModel.TypeConverter.dll"
+    "System.Console.dll"
+    "System.Diagnostics.Contracts.dll"
+    "System.Diagnostics.Debug.dll"
+    "System.Diagnostics.Tools.dll"
+    "System.Diagnostics.Tracing.dll"
+    "System.Dynamic.Runtime.dll"
+    "System.Globalization.dll"
+    "System.IO.dll"
+    "System.IO.FileSystem.dll"
+    "System.IO.FileSystem.Primitives.dll"
+    "System.Linq.dll"
+    "System.Linq.Expressions.dll"
+    "System.Linq.Parallel.dll"
+    "System.ObjectModel.dll"
+    "System.Reflection.dll"
+    "System.Reflection.Extensions.dll"
+    "System.Reflection.Primitives.dll"
+    "System.Resources.ResourceManager.dll"
+    "System.Runtime.dll"
+    "System.Runtime.Extensions.dll"
+    "System.Runtime.InteropServices.dll"
+    "System.Runtime.InteropServices.RuntimeInformation.dll"
+    "System.Runtime.Numerics.dll"
+    "System.Security.Cryptography.Encoding.dll"
+    "System.Security.Cryptography.Primitives.dll"
+    "System.Security.Cryptography.X509Certificates.dll"
+    "System.Text.Encoding.dll"
+    "System.Text.Encoding.Extensions.dll"
+    "System.Text.RegularExpressions.dll"
+    "System.Threading.dll"
+    "System.Threading.Tasks.dll"
+    "System.Threading.Tasks.Parallel.dll"
+    "System.Threading.Thread.dll"
+    "System.Xml.ReaderWriter.dll"
+    "System.Xml.XDocument.dll"
+)
+
+_verify_file() {
+    local file_path=$1
+
+    if [ ! -f "$file_path" ]; then
+        echo "File does not exist: $file_path"
+        exit 1
+    fi
+}
+
+_copy_file() {
+    local file_path=$1
+    local target_path=$2
+
+    _verify_file $file_path
+
+    mkdir -p "$(dirname "$target_path")"
+
+    cp "$file_path" "$target_path"
+}
+
+_create_archive() {
+    local name=$1
+
+    pushd "$target_path"
+    zip -r "$output_path/$name" .
+    popd
+}
+
+_copy_runtime_assets() {
+    local mono_runtime_path=""
+    local mono_lib_path=""
+    local mono_etc_path=""
+    local libMonoPosixHelper_name=""
+
+    if [ "$os" = "$OS_MAC" ]; then
+        mono_base_path=/Library/Frameworks/Mono.framework/Versions/Current
+
+        mono_runtime_path=$mono_base_path/bin/mono-sgen64
+        mono_lib_path=$mono_base_path/lib
+        mono_etc_path=$mono_base_path/etc/mono
+        libMonoPosixHelper_name=libMonoPosixHelper.dylib
+    else # Linux
+        mono_runtime_path=/usr/bin/mono-sgen
+        mono_lib_path=/usr/lib
+        mono_etc_path=/etc/mono
+        libMonoPosixHelper_name=libMonoPosixHelper.so
+    fi
+
+    local mono_libMonoPosixHelper_path=$mono_lib_path/$libMonoPosixHelper_name
+    local mono_config_path=$mono_etc_path/config
+    local mono_machine_config_path=$mono_etc_path/4.5/machine.config
+
+    _verify_file "$mono_runtime_path"
+    _verify_file "$mono_libMonoPosixHelper_path"
+    _verify_file "$mono_config_path"
+    _verify_file "$mono_machine_config_path"
+
+    if [ -d "$target_path" ]; then
+        rm -rf "$target_path"
+    fi
+
+    target_bin_path=$target_path/bin
+    target_lib_path=$target_path/lib
+    target_etc_path=$target_path/etc
+
+    mkdir -p "$target_bin_path"
+    mkdir -p "$target_lib_path"
+    mkdir -p "$target_etc_path"
+    mkdir -p "$target_etc_path/mono/4.5"
+
+    target_runtime_path=$target_bin_path/mono
+    target_libMonoPosixHelper_path=$target_lib_path/$libMonoPosixHelper_name
+    target_config_path=$target_etc_path/config
+    target_machine_config_path=$target_etc_path/mono/4.5/machine.config
+
+    cp "$mono_runtime_path" "$target_runtime_path"
+    cp "$mono_libMonoPosixHelper_path" "$target_libMonoPosixHelper_path"
+    cp "$mono_config_path" "$target_config_path"
+    cp "$mono_machine_config_path" "$target_machine_config_path"
+
+    # copy run script
+    cp "$script_path/run" "$target_path/run"
+    chmod 755 "$target_path/run"
+}
+
+_copy_framework_assets() {
+    local mono_gac_path=""
+    local mono_45_path=""
+    local mono_45_facades_path=""
+
+    if [ "$os" = "$OS_MAC" ]; then
+        mono_base_path=/Library/Frameworks/Mono.framework/Versions/Current
+
+        mono_gac_path=$mono_base_path/lib/mono/gac
+        mono_45_path=$mono_base_path/lib/mono/4.5
+        mono_45_facades_path=$mono_base_path/lib/mono/4.5/Facades
+    else # Linux
+        mono_gac_path=/usr/lib/mono/gac
+        mono_45_path=/usr/lib/mono/4.5
+        mono_45_facades_path=/usr/lib/mono/4.5/Facades
+    fi
+
+    target_gac_path=$target_path/lib/mono/gac
+    target_45_path=$target_path/lib/mono/4.5
+    target_45_facades_path=$target_45_path/Facades
+
+    mkdir -p "$target_gac_path"
+    mkdir -p "$target_45_facades_path"
+    
+    _copy_file "$mono_45_path/mscorlib.dll" "$target_45_path/mscorlib.dll"
+
+    for file in "${gac_assemblies[@]}"; do
+        _copy_file "$mono_gac_path/$file" "$target_gac_path/$file"
+    done
+
+    for file in "${framework_facades[@]}"; do
+        _copy_file "$mono_45_facades_path/$file" "$target_45_facades_path/$file"
+    done
+}
+
+_create_target_path
+_copy_runtime_assets
+_copy_framework_assets
+_create_archive "mono.$os-$mono_version.zip"

--- a/mono-packaging/copy-msbuild.sh
+++ b/mono-packaging/copy-msbuild.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+# Copies Mono MSBuild assets needed by OmniSharp.
+
+# Arguments:
+#   $1: output directory
+
+output_path=$1
+
+if [ "$output_path" = "" ]; then
+    output_path=`pwd -P`
+    echo "No output directory specified. Using $output_path"
+fi
+
+script_path="$(cd "$(dirname "$0")" && pwd -P)"
+
+target_path=""
+
+_create_target_path() {
+    _cleanup_target_path
+
+    target_path=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
+    echo "Using temporary path: $target_path"
+}
+
+# deletes the temp directory
+_cleanup_target_path() {
+    if [ -d "$target_path" ]; then
+        rm -rf "$target_path"
+        echo "Deleted temp directory: $target_path"
+    fi
+}
+
+trap _cleanup_target_path EXIT
+
+isMac=false
+
+case `uname` in
+    "Darwin")
+        isMac=true
+        ;;
+    "Linux")
+        isMac=false
+        ;;
+    *)
+        echo "This operating system is not supported."
+        exit 1
+        ;;
+esac
+
+mono_version=`mono --version | head -n 1 | sed 's/[^0-9.]*\([0-9.]*\).*/\1/'`
+
+msbuild_libraries=(
+    "Microsoft.Build.dll"
+    "Microsoft.Build.Framework.dll"
+    "Microsoft.Build.Tasks.Core.dll"
+    "Microsoft.Build.Utilities.Core.dll"
+)
+
+msbuild_runtime=(
+    "Microsoft.Common.CrossTargeting.targets"
+    "Microsoft.Common.CurrentVersion.targets"
+    "Microsoft.Common.Mono.targets"
+    "Microsoft.Common.overridetasks"
+    "Microsoft.Common.targets"
+    "Microsoft.Common.tasks"
+    "Microsoft.CSharp.CrossTargeting.targets"
+    "Microsoft.CSharp.CurrentVersion.targets"
+    "Microsoft.CSharp.Mono.targets"
+    "Microsoft.CSharp.targets"
+    "Microsoft.Data.Entity.targets"
+    "Microsoft.NETFramework.CurrentVersion.props"
+    "Microsoft.NETFramework.CurrentVersion.targets"
+    "Microsoft.NETFramework.props"
+    "Microsoft.NETFramework.targets"
+    "Microsoft.ServiceModel.targets"
+    "Microsoft.VisualBasic.CrossTargeting.targets"
+    "Microsoft.VisualBasic.CurrentVersion.targets"
+    "Microsoft.VisualBasic.targets"
+    "Microsoft.WinFx.targets"
+    "Microsoft.WorkflowBuildExtensions.targets"
+    "Microsoft.Xaml.targets"
+    "MSBuild.dll"
+    "MSBuild.dll.config"
+)
+
+_verify_file() {
+    local file_path=$1
+
+    if [ ! -f "$file_path" ]; then
+        echo "File does not exist: $file_path"
+        exit 1
+    fi
+}
+
+_copy_file() {
+    local file_path=$1
+    local target_path=$2
+
+    _verify_file $file_path
+
+    mkdir -p "$(dirname "$target_path")"
+
+    cp "$file_path" "$target_path"
+}
+
+_create_archive() {
+    local name=$1
+
+    pushd "$target_path"
+    zip -r "$output_path/$name" .
+    popd
+}
+
+_copy_msbuild_library_assets() {
+    local mono_msbuild_bin_path=""
+
+    if [ $isMac = true ]; then
+        mono_base_path=/Library/Frameworks/Mono.framework/Versions/Current
+
+        mono_msbuild_path=$mono_base_path/lib/mono/msbuild
+    else
+        mono_msbuild_path=/usr/lib/mono/msbuild
+    fi
+
+    for file in "${msbuild_libraries[@]}"; do
+        _copy_file "$mono_msbuild_path/15.0/bin/$file" "$target_path/$file"
+    done
+}
+
+_copy_msbuild_runtime_assets() {
+    local mono_msbuild_path=""
+    local mono_xbuild_path=""
+
+    if [ $isMac = true ]; then
+        mono_base_path=/Library/Frameworks/Mono.framework/Versions/Current
+
+        mono_msbuild_path=$mono_base_path/lib/mono/msbuild
+        mono_xbuild_path=$mono_base_path/lib/mono/xbuild
+    else
+        mono_msbuild_path=/usr/lib/mono/msbuild
+        mono_xbuild_path=/usr/lib/mono/xbuild
+    fi
+
+    _copy_file "$mono_xbuild_path/15.0/Microsoft.Common.props" "$target_path/15.0/Microsoft.Common.props"
+
+    for file in "${msbuild_runtime[@]}"; do
+        _copy_file "$mono_msbuild_path/15.0/bin/$file" "$target_path/$file"
+    done
+}
+
+_create_target_path
+_copy_msbuild_library_assets
+_create_archive "Microsoft.Build.Lib.Mono-$mono_version.zip"
+
+_create_target_path
+_copy_msbuild_runtime_assets
+_create_archive "Microsoft.Build.Runtime.Mono-$mono_version.zip"

--- a/mono-packaging/run
+++ b/mono-packaging/run
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+base_dir="$(cd "$(dirname "$0")" && pwd -P)"
+bin_dir=${base_dir}/bin
+etc_dir=${base_dir}/etc
+omnisharp_dir=${base_dir}/omnisharp
+
+mono_cmd=${bin_dir}/mono
+omnisharp_cmd=${omnisharp_dir}/OmniSharp.exe
+config_file=${etc_dir}/config
+
+chmod 755 ${mono_cmd}
+
+no_omnisharp=false
+
+if [ "$1" = "--no-omnisharp" ]; then
+    shift
+    no_omnisharp=true
+fi
+
+export MONO_CFG_DIR=${etc_dir}
+export MONO_ENV_OPTIONS="--assembly-loader=strict --config ${config_file}"
+
+if [ "$no_omnisharp" = true ]; then
+    "${mono_cmd}" "$@"
+else
+    "${mono_cmd}" "${omnisharp_cmd}" "$@"
+fi

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -152,7 +152,6 @@ public class Folders
     public string MonoRuntimeMacOS { get; }
     public string MonoRuntimeLinux32 { get; }
     public string MonoRuntimeLinux64 { get; }
-    public string MonoFramework { get; }
     public string MonoMSBuildRuntime { get; }
     public string MonoMSBuildLib { get; }
 
@@ -179,7 +178,6 @@ public class Folders
         this.MonoRuntimeMacOS = PathHelper.Combine(this.Tools, "Mono.Runtime.MacOS");
         this.MonoRuntimeLinux32 = PathHelper.Combine(this.Tools, "Mono.Runtime.Linux-x86");
         this.MonoRuntimeLinux64 = PathHelper.Combine(this.Tools, "Mono.Runtime.Linux-x64");
-        this.MonoFramework = PathHelper.Combine(this.Tools, "Mono.Framework");
         this.MonoMSBuildRuntime = PathHelper.Combine(this.Tools, "Microsoft.Build.Runtime.Mono");
         this.MonoMSBuildLib = PathHelper.Combine(this.Tools, "Microsoft.Build.Lib.Mono");
     }
@@ -235,9 +233,9 @@ public class BuildEnvironment
 
         this.MonoRuntimes = new []
         {
-            new MonoRuntime("osx", this.Folders.MonoRuntimeMacOS, "mono.osx"),
-            new MonoRuntime("linux-x86", this.Folders.MonoRuntimeLinux32, "mono.linux-x86"),
-            new MonoRuntime("linux-x64", this.Folders.MonoRuntimeLinux64, "mono.linux-x86_64")
+            new MonoRuntime("osx", this.Folders.MonoRuntimeMacOS, "mono"),
+            new MonoRuntime("linux-x86", this.Folders.MonoRuntimeLinux32, "mono"),
+            new MonoRuntime("linux-x64", this.Folders.MonoRuntimeLinux64, "mono")
         };
 
         if (Platform.Current.IsMacOS)
@@ -272,7 +270,6 @@ public class BuildPlan
     public string MonoRuntimeMacOS { get; set; }
     public string MonoRuntimeLinux32 { get; set; }
     public string MonoRuntimeLinux64 { get; set; }
-    public string MonoFramework { get; set; }
     public string MonoMSBuildRuntime { get; set; }
     public string MonoMSBuildLib { get; set; }
     public string[] HostProjects { get; set; }


### PR DESCRIPTION
This change adds two scripts, `copy-mono.sh` and `copy-msbuild.sh`, that can be used to create embedded Mono and MSBuild packages for the operating system that they're run on (macOS, linux-x64 and linux-x86).

Note that I've gone ahead and included the binary that was causing trouble with the `McMaster.Extensions.CommandLineUtils` package.