### PR TITLE
Fix MiscFile system creating new project for each file

### DIFF
--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -97,7 +97,7 @@ namespace OmniSharp
             if (GetDocument(filePath) != null)
                 return null; //if the workspace already knows about this document then it is not a miscellaneous document
 
-            var projectInfo = miscDocumentsProjectInfos.GetOrAdd(language, CreateMiscFilesProject(language));
+            var projectInfo = miscDocumentsProjectInfos.GetOrAdd(language, (lang) => CreateMiscFilesProject(lang));
             var documentId = AddDocument(projectInfo.Id, filePath);
             return documentId;
         }


### PR DESCRIPTION
Looks like https://github.com/OmniSharp/omnisharp-roslyn/pull/1252 had an intent to create one project for misc files per language, but bug caused it to create new project for each file, causing a skyrocket of memory consumption in larger projects. This should fix the issue