### PR TITLE
 construct scripting workspace information directly from the ProjectInfo

### DIFF
--- a/src/OmniSharp.Script/ScriptContext.cs
+++ b/src/OmniSharp.Script/ScriptContext.cs
@@ -7,11 +7,10 @@ namespace OmniSharp.Script
 {
     public class ScriptContext
     {
-        public ScriptContext(ScriptProjectProvider scriptProjectProvider, HashSet<MetadataReference> metadataReferences, HashSet<string> assemblyReferences, CompilationDependency[] compilationDependencies, Type globalsType)
+        public ScriptContext(ScriptProjectProvider scriptProjectProvider, HashSet<MetadataReference> metadataReferences, CompilationDependency[] compilationDependencies, Type globalsType)
         {
             ScriptProjectProvider = scriptProjectProvider;
             MetadataReferences = metadataReferences;
-            AssemblyReferences = assemblyReferences;
             CompilationDependencies = compilationDependencies;
             GlobalsType = globalsType;
         }
@@ -19,8 +18,6 @@ namespace OmniSharp.Script
         public ScriptProjectProvider ScriptProjectProvider { get; }
 
         public HashSet<MetadataReference> MetadataReferences { get; }
-
-        public HashSet<string> AssemblyReferences { get; }
 
         public CompilationDependency[] CompilationDependencies { get; }
 

--- a/src/OmniSharp.Script/ScriptContextModel.cs
+++ b/src/OmniSharp.Script/ScriptContextModel.cs
@@ -1,22 +1,32 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace OmniSharp.Script
 {
     public class ScriptContextModel
     {
-        public ScriptContextModel(string csxPath, ProjectInfo project, HashSet<string> implicitAssemblyReferences)
+        public ScriptContextModel(string csxPath, ProjectInfo project)
         {
             Path = csxPath;
-            ImplicitAssemblyReferences = implicitAssemblyReferences;
-            CommonUsings = ScriptProjectProvider.DefaultNamespaces;
+            AssemblyReferences = project.MetadataReferences.Select(a =>
+            {
+                if (a is PortableExecutableReference portableExecutableReference)
+                {
+                    return portableExecutableReference.FilePath ?? portableExecutableReference.Display;
+                }
+
+                return a.Display;
+            });
+            CommonUsings = ((CSharpCompilationOptions)(project.CompilationOptions)).Usings;
             GlobalsType = project.HostObjectType;
         }
 
         public string Path { get; }
 
-        public HashSet<string> ImplicitAssemblyReferences { get; }
+        public IEnumerable<string> AssemblyReferences { get; }
 
         public Type GlobalsType { get; }
 

--- a/src/OmniSharp.Script/ScriptContextProvider.cs
+++ b/src/OmniSharp.Script/ScriptContextProvider.cs
@@ -76,7 +76,6 @@ namespace OmniSharp.Script
             }
 
             var metadataReferences = new HashSet<MetadataReference>(MetadataReferenceEqualityComparer.Instance);
-            var assemblyReferences = new HashSet<string>();
 
             var isDesktopClr = true;
             // if we have no compilation dependencies
@@ -86,7 +85,7 @@ namespace OmniSharp.Script
             if (!compilationDependencies.Any())
             {
                 _logger.LogInformation("Unable to find dependency context for CSX files. Will default to non-context usage (Desktop CLR scripts).");
-                AddDefaultClrMetadataReferences(metadataReferences, assemblyReferences);
+                AddDefaultClrMetadataReferences(metadataReferences);
             }
             else
             {
@@ -98,7 +97,7 @@ namespace OmniSharp.Script
                     if (loadedFiles.Add(Path.GetFileName(compilationAssembly)))
                     {
                         _logger.LogDebug("Discovered script compilation assembly reference: " + compilationAssembly);
-                        AddMetadataReference(metadataReferences, assemblyReferences, compilationAssembly);
+                        AddMetadataReference(metadataReferences, compilationAssembly);
                     }
                 }
             }
@@ -107,22 +106,18 @@ namespace OmniSharp.Script
             foreach (var inheritedCompileLib in inheritedCompileLibraries)
             {
                 _logger.LogDebug("Adding implicit reference: " + inheritedCompileLib);
-                AddMetadataReference(metadataReferences, assemblyReferences, inheritedCompileLib.Location);
+                AddMetadataReference(metadataReferences, inheritedCompileLib.Location);
             }
 
             var scriptProjectProvider = new ScriptProjectProvider(scriptOptions, _env, _loggerFactory, isDesktopClr);
 
-            return new ScriptContext(scriptProjectProvider, metadataReferences, assemblyReferences, compilationDependencies, _defaultGlobalsType);
+            return new ScriptContext(scriptProjectProvider, metadataReferences, compilationDependencies, _defaultGlobalsType);
         }
 
-        private void AddDefaultClrMetadataReferences(HashSet<MetadataReference> commonReferences, HashSet<string> assemblyReferences)
+        private void AddDefaultClrMetadataReferences(HashSet<MetadataReference> commonReferences)
         {
             var references = DefaultMetadataReferenceHelper.GetDefaultMetadataReferenceLocations()
-                .Select(l =>
-                {
-                    assemblyReferences.Add(l);
-                    return _metadataFileReferenceCache.GetMetadataReference(l);
-                });
+                .Select(l => _metadataFileReferenceCache.GetMetadataReference(l));
 
             foreach (var reference in references)
             {
@@ -130,7 +125,7 @@ namespace OmniSharp.Script
             }
         }
 
-        private void AddMetadataReference(ISet<MetadataReference> referenceCollection, HashSet<string> assemblyReferences, string fileReference)
+        private void AddMetadataReference(ISet<MetadataReference> referenceCollection, string fileReference)
         {
             if (!File.Exists(fileReference))
             {
@@ -146,7 +141,6 @@ namespace OmniSharp.Script
             }
 
             referenceCollection.Add(metadataReference);
-            assemblyReferences.Add(fileReference);
             _logger.LogDebug($"Added reference to '{fileReference}'");
         }
     }

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -168,7 +168,7 @@ namespace OmniSharp.Script
                 return Task.FromResult<object>(null);
             }
 
-            return Task.FromResult<object>(new ScriptContextModel(filePath, projectInfo, _scriptContext.Value.AssemblyReferences));
+            return Task.FromResult<object>(new ScriptContextModel(filePath, projectInfo));
         }
 
         Task<object> IProjectSystem.GetWorkspaceModelAsync(WorkspaceInformationRequest request)
@@ -176,7 +176,7 @@ namespace OmniSharp.Script
             var scriptContextModels = new List<ScriptContextModel>();
             foreach (var project in _projects)
             {
-                scriptContextModels.Add(new ScriptContextModel(project.Key, project.Value, _scriptContext.Value.AssemblyReferences));
+                scriptContextModels.Add(new ScriptContextModel(project.Key, project.Value));
             }
             return Task.FromResult<object>(new ScriptContextModelCollection(scriptContextModels));
         }

--- a/test-assets/test-scripts/EmptyScript/.gitignore
+++ b/test-assets/test-scripts/EmptyScript/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything
+*
+# Except gitignore file
+!.gitignore

--- a/test-assets/test-scripts/SingleCsiScriptWithCustomRsp/main.csx
+++ b/test-assets/test-scripts/SingleCsiScriptWithCustomRsp/main.csx
@@ -1,0 +1,5 @@
+#r "System.Net.Http"
+
+using System.Net.Http;
+var client = new HttpClient();
+Console.WriteLine(client.GetAsync("https://google.com"));

--- a/test-assets/test-scripts/SingleCsiScriptWithCustomRsp/test.rsp
+++ b/test-assets/test-scripts/SingleCsiScriptWithCustomRsp/test.rsp
@@ -1,0 +1,2 @@
+/u:System.Web
+/r:System.Web

--- a/tests/TestUtility/TestAssets.TestProject.cs
+++ b/tests/TestUtility/TestAssets.TestProject.cs
@@ -32,7 +32,7 @@ namespace TestUtility
 
             public string AddDisposableFile(string fileName, string contents = null)
             {
-                var filePath = Path.Combine(BaseDirectory, fileName);
+                var filePath = Path.Combine(Directory, fileName);
                 File.WriteAllText(filePath, contents ?? string.Empty);
                 _disposableFiles.Add(filePath);
 
@@ -59,7 +59,7 @@ namespace TestUtility
                     foreach (var filePath in _disposableFiles)
                     {
                         RunWithRetry(() => File.Delete(filePath));
-                        if (System.IO.Directory.Exists(this.BaseDirectory))
+                        if (System.IO.File.Exists(filePath))
                         {
                             throw new InvalidOperationException($"{nameof(ITestProject)} file still exists: '{filePath}'");
                         }


### PR DESCRIPTION
This is a follow up to #1112 which we shipped but it didn't have a real test 😃

In this PR:
 - I fixed a "bug" where RSP based references/namespaces were not respected by the Workspace information endpoint in scripting (construct that info from `ProjectInfo` directly, which is most reliable way)
 - better late than never - added an integration test for the RSP based configuration of scripting project system
 - fixed some suspicious test code