### PR TITLE
Fix enum members missing in code structure response

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Structure/CodeStructureService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Structure/CodeStructureService.cs
@@ -83,6 +83,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
                 case EnumDeclarationSyntax enumDeclaration:
                     yield return CreateCodeElement(enumDeclaration, text, semanticModel);
                     break;
+                case EnumMemberDeclarationSyntax enumMemberDeclarationSyntax:
+                    yield return CreateCodeElement(enumMemberDeclarationSyntax, text, semanticModel);
+                    break;
                 case NamespaceDeclarationSyntax namespaceDeclaration:
                     yield return CreateCodeElement(namespaceDeclaration, text, semanticModel);
                     break;
@@ -177,6 +180,27 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
                     builder.AddChild(childElement);
                 }
             }
+
+            return builder.ToCodeElement();
+        }
+
+        private CodeElement CreateCodeElement(EnumMemberDeclarationSyntax enumDeclaration, SourceText text, SemanticModel semanticModel)
+        {
+            var symbol = semanticModel.GetDeclaredSymbol(enumDeclaration);
+            if (symbol == null)
+            {
+                return null;
+            }
+
+            var builder = new CodeElement.Builder
+            {
+                Kind = symbol.GetKindString(),
+                Name = symbol.ToDisplayString(SymbolDisplayFormats.ShortTypeFormat),
+                DisplayName = symbol.ToDisplayString(SymbolDisplayFormats.TypeFormat),
+            };
+
+            AddRanges(builder, enumDeclaration.AttributeLists.Span, enumDeclaration.Span, enumDeclaration.Identifier.Span, text);
+            AddSymbolProperties(symbol, builder);
 
             return builder.ToCodeElement();
         }
@@ -305,7 +329,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
                     return default;
             }
         }
-        
+
         private static void AddRanges(CodeElement.Builder builder, TextSpan attributesSpan, TextSpan fullSpan, TextSpan nameSpan, SourceText text)
         {
             if (attributesSpan != default)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Structure/CodeStructureService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Structure/CodeStructureService.cs
@@ -83,9 +83,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
                 case EnumDeclarationSyntax enumDeclaration:
                     yield return CreateCodeElement(enumDeclaration, text, semanticModel);
                     break;
-                case EnumMemberDeclarationSyntax enumMemberDeclarationSyntax:
-                    yield return CreateCodeElement(enumMemberDeclarationSyntax, text, semanticModel);
-                    break;
                 case NamespaceDeclarationSyntax namespaceDeclaration:
                     yield return CreateCodeElement(namespaceDeclaration, text, semanticModel);
                     break;
@@ -101,6 +98,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
                         yield return CreateCodeElement(variableDeclarator, baseFieldDeclaration, text, semanticModel);
                     }
 
+                    break;
+                case EnumMemberDeclarationSyntax enumMemberDeclarationSyntax:
+                    yield return CreateCodeElement(enumMemberDeclarationSyntax, text, semanticModel);
                     break;
             }
         }
@@ -180,27 +180,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
                     builder.AddChild(childElement);
                 }
             }
-
-            return builder.ToCodeElement();
-        }
-
-        private CodeElement CreateCodeElement(EnumMemberDeclarationSyntax enumMemberDeclaration, SourceText text, SemanticModel semanticModel)
-        {
-            var symbol = semanticModel.GetDeclaredSymbol(enumMemberDeclaration);
-            if (symbol == null)
-            {
-                return null;
-            }
-
-            var builder = new CodeElement.Builder
-            {
-                Kind = symbol.GetKindString(),
-                Name = symbol.ToDisplayString(SymbolDisplayFormats.ShortTypeFormat),
-                DisplayName = symbol.ToDisplayString(SymbolDisplayFormats.TypeFormat),
-            };
-
-            AddRanges(builder, enumMemberDeclaration.AttributeLists.Span, enumMemberDeclaration.Span, enumMemberDeclaration.Identifier.Span, text);
-            AddSymbolProperties(symbol, builder);
 
             return builder.ToCodeElement();
         }
@@ -291,6 +270,27 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
             };
 
             AddRanges(builder, baseFieldDeclaration.AttributeLists.Span, variableDeclarator.Span, variableDeclarator.Identifier.Span, text);
+            AddSymbolProperties(symbol, builder);
+
+            return builder.ToCodeElement();
+        }
+
+        private CodeElement CreateCodeElement(EnumMemberDeclarationSyntax enumMemberDeclaration, SourceText text, SemanticModel semanticModel)
+        {
+            var symbol = semanticModel.GetDeclaredSymbol(enumMemberDeclaration);
+            if (symbol == null)
+            {
+                return null;
+            }
+
+            var builder = new CodeElement.Builder
+            {
+                Kind = symbol.GetKindString(),
+                Name = symbol.ToDisplayString(SymbolDisplayFormats.ShortMemberFormat),
+                DisplayName = symbol.ToDisplayString(SymbolDisplayFormats.MemberFormat),
+            };
+
+            AddRanges(builder, enumMemberDeclaration.AttributeLists.Span, enumMemberDeclaration.Span, enumMemberDeclaration.Identifier.Span, text);
             AddSymbolProperties(symbol, builder);
 
             return builder.ToCodeElement();

--- a/src/OmniSharp.Roslyn.CSharp/Services/Structure/CodeStructureService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Structure/CodeStructureService.cs
@@ -184,9 +184,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
             return builder.ToCodeElement();
         }
 
-        private CodeElement CreateCodeElement(EnumMemberDeclarationSyntax enumDeclaration, SourceText text, SemanticModel semanticModel)
+        private CodeElement CreateCodeElement(EnumMemberDeclarationSyntax enumMemberDeclaration, SourceText text, SemanticModel semanticModel)
         {
-            var symbol = semanticModel.GetDeclaredSymbol(enumDeclaration);
+            var symbol = semanticModel.GetDeclaredSymbol(enumMemberDeclaration);
             if (symbol == null)
             {
                 return null;
@@ -199,7 +199,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
                 DisplayName = symbol.ToDisplayString(SymbolDisplayFormats.TypeFormat),
             };
 
-            AddRanges(builder, enumDeclaration.AttributeLists.Span, enumDeclaration.Span, enumDeclaration.Identifier.Span, text);
+            AddRanges(builder, enumMemberDeclaration.AttributeLists.Span, enumMemberDeclaration.Span, enumMemberDeclaration.Identifier.Span, text);
             AddSymbolProperties(symbol, builder);
 
             return builder.ToCodeElement();

--- a/tests/OmniSharp.Cake.Tests/CodeStructureFacts.cs
+++ b/tests/OmniSharp.Cake.Tests/CodeStructureFacts.cs
@@ -42,6 +42,9 @@ struct S { }
             AssertElement(response.Elements[0], SymbolKinds.Class, "C", "C");
             AssertElement(response.Elements[1], SymbolKinds.Delegate, "D", "D");
             AssertElement(response.Elements[2], SymbolKinds.Enum, "E", "E");
+            AssertElement(response.Elements[2].Children[0], SymbolKinds.EnumMember, "One", "One");
+            AssertElement(response.Elements[2].Children[1], SymbolKinds.EnumMember, "Two", "Two");
+            AssertElement(response.Elements[2].Children[2], SymbolKinds.EnumMember, "Three", "Three");
             AssertElement(response.Elements[3], SymbolKinds.Interface, "I", "I");
             AssertElement(response.Elements[4], SymbolKinds.Struct, "S", "S");
         }


### PR DESCRIPTION
Noticed today enum members were missing from code outline / codeLens / find reference doesn't work on enum members, and I am sure it used to work in the past. 

Looks like CodeCheckService omitted to handle "EnumMemberDeclarationSyntax" and never created code elements for enum members. I added additional checks in the existing CodeStructure test to assure enum members are there.

After the changes enum members reappeared in code outline / code lens:

![2018-09-04_23-12-45](https://user-images.githubusercontent.com/5102661/45058406-e9460d80-b098-11e8-9f9d-4aa6d699bc30.png)
![2018-09-04_23-13-28](https://user-images.githubusercontent.com/5102661/45058408-eba86780-b098-11e8-8176-c36c32984568.png)
