### PR TITLE
Add MSBuild event sink API for project loaded notification

### DIFF
--- a/src/OmniSharp.Host/AssemblyInfo.cs
+++ b/src/OmniSharp.Host/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("OmniSharp.Http.Tests")]
+[assembly: InternalsVisibleTo("OmniSharp.MSBuild.Tests")]
 [assembly: InternalsVisibleTo("OmniSharp.Roslyn.CSharp.Tests")]
 [assembly: InternalsVisibleTo("TestUtility")]

--- a/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
@@ -1,13 +1,52 @@
-﻿namespace OmniSharp.MSBuild.Discovery
+﻿using Microsoft.Extensions.Logging;
+
+namespace OmniSharp.MSBuild.Discovery
 {
     internal static class Extensions
     {
+        public static void RegisterDefaultInstance(this IMSBuildLocator msbuildLocator, ILogger logger)
+        {
+            MSBuildInstance instanceToRegister = null;
+            var invalidVSFound = false;
+
+            foreach (var instance in msbuildLocator.GetInstances())
+            {
+                if (instance.IsInvalidVisualStudio())
+                {
+                    invalidVSFound = true;
+                }
+                else
+                {
+                    instanceToRegister = instance;
+                    break;
+                }
+            }
+
+
+            if (instanceToRegister != null)
+            {
+                // Did we end up choosing the standalone MSBuild because there was an invalid Visual Studio?
+                // If so, provide a helpful message to the user.
+                if (invalidVSFound && instanceToRegister.DiscoveryType == DiscoveryType.StandAlone)
+                {
+                    logger.LogWarning(@"It looks like you have Visual Studio 2017 RTM installed.
+Try updating Visual Studio 2017 to the most recent release to enable better MSBuild support.");
+                }
+
+                msbuildLocator.RegisterInstance(instanceToRegister);
+            }
+            else
+            {
+                logger.LogError("Could not locate MSBuild instance to register with OmniSharp");
+            }
+        }
+
+
         public static bool IsInvalidVisualStudio(this MSBuildInstance instance)
             // MSBuild from Visual Studio 2017 RTM cannot be used.
             => instance.Version.Major == 15
             && instance.Version.Minor == 0
             && (instance.DiscoveryType == DiscoveryType.DeveloperConsole
                 || instance.DiscoveryType == DiscoveryType.VisualStudioSetup);
-
     }
 }

--- a/src/OmniSharp.Host/WorkspaceInitializer.cs
+++ b/src/OmniSharp.Host/WorkspaceInitializer.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Composition.Hosting;
-using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using OmniSharp.Mef;
 using OmniSharp.Options;
 using OmniSharp.Roslyn;
 using OmniSharp.Roslyn.Options;
@@ -16,14 +14,14 @@ namespace OmniSharp
 {
     public class WorkspaceInitializer
     {
-        public static void Initialize(
-            IServiceProvider serviceProvider,
-            CompositionHost compositionHost,
-            IConfiguration configuration,
-            ILogger logger)
+        public static void Initialize(IServiceProvider serviceProvider, CompositionHost compositionHost)
         {
+            var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger<WorkspaceInitializer>();
+
             var workspace = compositionHost.GetExport<OmniSharpWorkspace>();
             var options = serviceProvider.GetRequiredService<IOptionsMonitor<OmniSharpOptions>>();
+            var configuration = serviceProvider.GetRequiredService<IConfigurationRoot>();
 
             var projectEventForwarder = compositionHost.GetExport<ProjectEventForwarder>();
             projectEventForwarder.Initialize();

--- a/src/OmniSharp.Http/Startup.cs
+++ b/src/OmniSharp.Http/Startup.cs
@@ -16,19 +16,19 @@ namespace OmniSharp.Http
     {
         private readonly IOmniSharpEnvironment _environment;
         private readonly IEventEmitter _eventEmitter;
-        private readonly IConfigurationRoot _configuration;
         private CompositionHost _compositionHost;
 
         public Startup(IOmniSharpEnvironment environment, IEventEmitter eventEmitter, ISharedTextWriter writer)
         {
             _environment = environment;
             _eventEmitter = eventEmitter;
-            _configuration = new ConfigurationBuilder(environment).Build();
         }
 
         public IServiceProvider ConfigureServices(IServiceCollection services)
         {
-            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_environment, _configuration, _eventEmitter, services);
+            var configuration = new ConfigurationBuilder(_environment).Build();
+            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_environment, configuration, _eventEmitter, services);
+
             _compositionHost = new CompositionHostBuilder(serviceProvider)
                 .WithOmniSharpAssemblies()
                 .Build();
@@ -65,7 +65,7 @@ namespace OmniSharp.Http
             app.UseMiddleware<StatusMiddleware>(workspace);
             app.UseMiddleware<StopServerMiddleware>();
 
-            WorkspaceInitializer.Initialize(serviceProvider, _compositionHost, _configuration, logger);
+            WorkspaceInitializer.Initialize(serviceProvider, _compositionHost);
 
             logger.LogInformation($"Omnisharp server running on port '{httpEnvironment.Port}' at location '{_environment.TargetDirectory}' on host {_environment.HostProcessId}.");
         }

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -28,7 +28,6 @@ namespace OmniSharp.LanguageServerProtocol
         private readonly LanguageServerLoggerFactory _loggerFactory;
         private readonly CommandLineApplication _application;
         private readonly CancellationTokenSource _cancellationTokenSource;
-        private IConfiguration _configuration;
         private IServiceProvider _serviceProvider;
         private RequestHandlers _handlers;
         private OmniSharpEnvironment _environment;
@@ -85,9 +84,9 @@ namespace OmniSharp.LanguageServerProtocol
             _loggerFactory.AddProvider(_server, _environment);
             _logger = _loggerFactory.CreateLogger<LanguageServerHost>();
 
-            _configuration = new ConfigurationBuilder(_environment).Build();
+            var configurationRoot = new ConfigurationBuilder(_environment).Build();
             var eventEmitter = new LanguageServerEventEmitter(_server);
-            _serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_environment, _configuration, eventEmitter, _services);
+            _serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_environment, configurationRoot, eventEmitter, _services);
 
             var plugins = _application.CreatePluginAssemblies();
 
@@ -184,11 +183,11 @@ namespace OmniSharp.LanguageServerProtocol
             });
 
             var logger = _loggerFactory.CreateLogger(typeof(LanguageServerHost));
-            WorkspaceInitializer.Initialize(_serviceProvider, _compositionHost, _configuration, logger);
+            WorkspaceInitializer.Initialize(_serviceProvider, _compositionHost);
 
             // Kick on diagnostics
             var diagnosticHandler = _handlers.GetAll()
-                .OfType<Mef.IRequestHandler<DiagnosticsRequest, DiagnosticsResponse>>();
+                .OfType<IRequestHandler<DiagnosticsRequest, DiagnosticsResponse>>();
 
             foreach (var handler in diagnosticHandler)
                 await handler.Handle(new DiagnosticsRequest());

--- a/src/OmniSharp.MSBuild/Logging/MSBuildDiagnostic.cs
+++ b/src/OmniSharp.MSBuild/Logging/MSBuildDiagnostic.cs
@@ -1,6 +1,6 @@
 ﻿namespace OmniSharp.MSBuild.Logging
 {
-    internal class MSBuildDiagnostic
+    public class MSBuildDiagnostic
     {
         public MSBuildDiagnosticSeverity Severity { get; }
         public string Message { get; }

--- a/src/OmniSharp.MSBuild/Logging/MSBuildDiagnostic.cs
+++ b/src/OmniSharp.MSBuild/Logging/MSBuildDiagnostic.cs
@@ -1,6 +1,6 @@
 ﻿namespace OmniSharp.MSBuild.Logging
 {
-    public class MSBuildDiagnostic
+    internal class MSBuildDiagnostic
     {
         public MSBuildDiagnosticSeverity Severity { get; }
         public string Message { get; }

--- a/src/OmniSharp.MSBuild/Logging/MSBuildDiagnosticSeverity.cs
+++ b/src/OmniSharp.MSBuild/Logging/MSBuildDiagnosticSeverity.cs
@@ -1,6 +1,6 @@
 ﻿namespace OmniSharp.MSBuild.Logging
 {
-    internal enum MSBuildDiagnosticSeverity
+    public enum MSBuildDiagnosticSeverity
     {
         Error,
         Warning

--- a/src/OmniSharp.MSBuild/Logging/MSBuildDiagnosticSeverity.cs
+++ b/src/OmniSharp.MSBuild/Logging/MSBuildDiagnosticSeverity.cs
@@ -1,6 +1,6 @@
 ﻿namespace OmniSharp.MSBuild.Logging
 {
-    public enum MSBuildDiagnosticSeverity
+    internal enum MSBuildDiagnosticSeverity
     {
         Error,
         Warning

--- a/src/OmniSharp.MSBuild/MSBuildHelpers.cs
+++ b/src/OmniSharp.MSBuild/MSBuildHelpers.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
-using Microsoft.Build.Evaluation;
-using Microsoft.Build.Execution;
 using OmniSharp.Utilities;
 
 namespace OmniSharp.MSBuild
 {
-    public static class MSBuildHelpers
+    internal static class MSBuildHelpers
     {
         private static Assembly s_MicrosoftBuildAssembly;
 

--- a/src/OmniSharp.MSBuild/Models/Events/MSBuildDiagnosticsMessage.cs
+++ b/src/OmniSharp.MSBuild/Models/Events/MSBuildDiagnosticsMessage.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.MSBuild.Models.Events
         public int EndLine { get; set; }
         public int EndColumn { get; set; }
 
-        public static MSBuildDiagnosticsMessage FromDiagnostic(MSBuildDiagnostic diagnostic)
+        internal static MSBuildDiagnosticsMessage FromDiagnostic(MSBuildDiagnostic diagnostic)
             => new MSBuildDiagnosticsMessage()
             {
                 LogLevel = diagnostic.Severity.ToString(),

--- a/src/OmniSharp.MSBuild/Models/MSBuildProjectInfo.cs
+++ b/src/OmniSharp.MSBuild/Models/MSBuildProjectInfo.cs
@@ -16,6 +16,9 @@ namespace OmniSharp.MSBuild.Models
         public IList<string> SourceFiles { get; set; }
         public IList<TargetFramework> TargetFrameworks { get; set; }
         public string OutputPath { get; set; }
+        public string IntermediateOutputPath { get; set; }
+        public string Configuration { get; set; }
+        public string Platform { get; set; }
         public bool IsExe { get; set; }
         public bool IsUnityProject { get; set; }
 
@@ -45,6 +48,9 @@ namespace OmniSharp.MSBuild.Models
             TargetFrameworks = targetFrameworks;
 
             OutputPath = projectFileInfo.OutputPath;
+            IntermediateOutputPath = projectFileInfo.IntermediateOutputPath;
+            Configuration = projectFileInfo.Configuration;
+            Platform = projectFileInfo.Platform;
             IsExe = projectFileInfo.OutputKind == OutputKind.ConsoleApplication ||
                 projectFileInfo.OutputKind == OutputKind.WindowsApplication;
             IsUnityProject = projectFileInfo.IsUnityProject();

--- a/src/OmniSharp.MSBuild/Notification/IMSBuildEventSink.cs
+++ b/src/OmniSharp.MSBuild/Notification/IMSBuildEventSink.cs
@@ -1,0 +1,7 @@
+﻿namespace OmniSharp.MSBuild.Notification
+{
+    public interface IMSBuildEventSink
+    {
+        void ProjectLoaded(ProjectLoadedEventArgs e);
+    }
+}

--- a/src/OmniSharp.MSBuild/Notification/ProjectLoadedEventArgs.cs
+++ b/src/OmniSharp.MSBuild/Notification/ProjectLoadedEventArgs.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using OmniSharp.MSBuild.Logging;
+using MSB = Microsoft.Build;
+
+namespace OmniSharp.MSBuild.Notification
+{
+    public class ProjectLoadedEventArgs
+    {
+        public ProjectId Id { get; }
+        public MSB.Execution.ProjectInstance ProjectInstance { get; }
+        public ImmutableArray<MSBuildDiagnostic> Diagnostics { get; }
+        public bool IsReload { get; }
+
+        public ProjectLoadedEventArgs(
+            ProjectId id,
+            MSB.Execution.ProjectInstance projectInstance,
+            ImmutableArray<MSBuildDiagnostic> diagnostics,
+            bool isReload)
+        {
+            Id = id;
+            ProjectInstance = projectInstance;
+            Diagnostics = diagnostics;
+            IsReload = isReload;
+        }
+    }
+}

--- a/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
+++ b/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
@@ -1,6 +1,6 @@
 namespace OmniSharp.Options
 {
-    public class MSBuildOptions
+    internal class MSBuildOptions
     {
         public string ToolsVersion { get; set; }
         public string VisualStudioVersion { get; set; }

--- a/src/OmniSharp.MSBuild/ProjectFile/PackageReference.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PackageReference.cs
@@ -3,7 +3,7 @@ using NuGet.Packaging.Core;
 
 namespace OmniSharp.MSBuild.ProjectFile
 {
-    public class PackageReference : IEquatable<PackageReference>
+    internal class PackageReference : IEquatable<PackageReference>
     {
         public PackageDependency Dependency { get; }
         public bool IsImplicitlyDefined { get; }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
@@ -21,9 +21,12 @@ namespace OmniSharp.MSBuild.ProjectFile
 
             public string AssemblyName { get; }
             public string TargetPath { get; }
-            public string OutputPath { get;  }
+            public string OutputPath { get; }
+            public string IntermediateOutputPath { get; }
             public string ProjectAssetsFile { get; }
 
+            public string Configuration { get; }
+            public string Platform { get; }
             public FrameworkName TargetFramework { get; }
             public ImmutableArray<string> TargetFrameworks { get; }
 
@@ -59,7 +62,9 @@ namespace OmniSharp.MSBuild.ProjectFile
 
             private ProjectData(
                 Guid guid, string name,
-                string assemblyName, string targetPath, string outputPath, string projectAssetsFile,
+                string assemblyName, string targetPath, string outputPath, string intermediateOutputPath,
+                string projectAssetsFile,
+                string configuration, string platform,
                 FrameworkName targetFramework,
                 ImmutableArray<string> targetFrameworks,
                 OutputKind outputKind,
@@ -78,8 +83,11 @@ namespace OmniSharp.MSBuild.ProjectFile
                 AssemblyName = assemblyName;
                 TargetPath = targetPath;
                 OutputPath = outputPath;
+                IntermediateOutputPath = intermediateOutputPath;
                 ProjectAssetsFile = projectAssetsFile;
 
+                Configuration = configuration;
+                Platform = platform;
                 TargetFramework = targetFramework;
                 TargetFrameworks = targetFrameworks.EmptyIfDefault();
 
@@ -96,7 +104,9 @@ namespace OmniSharp.MSBuild.ProjectFile
 
             private ProjectData(
                 Guid guid, string name,
-                string assemblyName, string targetPath, string outputPath, string projectAssetsFile,
+                string assemblyName, string targetPath, string outputPath, string intermediateOutputPath,
+                string projectAssetsFile,
+                string configuration, string platform,
                 FrameworkName targetFramework,
                 ImmutableArray<string> targetFrameworks,
                 OutputKind outputKind,
@@ -112,8 +122,8 @@ namespace OmniSharp.MSBuild.ProjectFile
                 ImmutableArray<string> references,
                 ImmutableArray<PackageReference> packageReferences,
                 ImmutableArray<string> analyzers)
-                : this(guid, name, assemblyName, targetPath, outputPath, projectAssetsFile,
-                      targetFramework, targetFrameworks, outputKind, languageVersion, allowUnsafeCode,
+                : this(guid, name, assemblyName, targetPath, outputPath, intermediateOutputPath, projectAssetsFile,
+                      configuration, platform, targetFramework, targetFrameworks, outputKind, languageVersion, allowUnsafeCode,
                       documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, signAssembly, assemblyOriginatorKeyFile)
             {
                 SourceFiles = sourceFiles.EmptyIfDefault();
@@ -130,7 +140,10 @@ namespace OmniSharp.MSBuild.ProjectFile
                 var assemblyName = project.GetPropertyValue(PropertyNames.AssemblyName);
                 var targetPath = project.GetPropertyValue(PropertyNames.TargetPath);
                 var outputPath = project.GetPropertyValue(PropertyNames.OutputPath);
+                var intermediateOutputPath = project.GetPropertyValue(PropertyNames.IntermediateOutputPath);
                 var projectAssetsFile = project.GetPropertyValue(PropertyNames.ProjectAssetsFile);
+                var configuration = project.GetPropertyValue(PropertyNames.Configuration);
+                var platform = project.GetPropertyValue(PropertyNames.Platform);
 
                 var targetFramework = new FrameworkName(project.GetPropertyValue(PropertyNames.TargetFrameworkMoniker));
 
@@ -152,8 +165,8 @@ namespace OmniSharp.MSBuild.ProjectFile
                 var assemblyOriginatorKeyFile = project.GetPropertyValue(PropertyNames.AssemblyOriginatorKeyFile);
 
                 return new ProjectData(
-                    guid, name, assemblyName, targetPath, outputPath, projectAssetsFile,
-                    targetFramework, targetFrameworks, outputKind, languageVersion, allowUnsafeCode,
+                    guid, name, assemblyName, targetPath, outputPath, intermediateOutputPath, projectAssetsFile,
+                    configuration, platform, targetFramework, targetFrameworks, outputKind, languageVersion, allowUnsafeCode,
                     documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, signAssembly, assemblyOriginatorKeyFile);
             }
 
@@ -164,7 +177,10 @@ namespace OmniSharp.MSBuild.ProjectFile
                 var assemblyName = projectInstance.GetPropertyValue(PropertyNames.AssemblyName);
                 var targetPath = projectInstance.GetPropertyValue(PropertyNames.TargetPath);
                 var outputPath = projectInstance.GetPropertyValue(PropertyNames.OutputPath);
+                var intermediateOutputPath = projectInstance.GetPropertyValue(PropertyNames.IntermediateOutputPath);
                 var projectAssetsFile = projectInstance.GetPropertyValue(PropertyNames.ProjectAssetsFile);
+                var configuration = projectInstance.GetPropertyValue(PropertyNames.Configuration);
+                var platform = projectInstance.GetPropertyValue(PropertyNames.Platform);
 
                 var targetFramework = new FrameworkName(projectInstance.GetPropertyValue(PropertyNames.TargetFrameworkMoniker));
 
@@ -223,8 +239,8 @@ namespace OmniSharp.MSBuild.ProjectFile
                 var analyzers = GetFullPaths(projectInstance.GetItems(ItemNames.Analyzer));
 
                 return new ProjectData(guid, name,
-                    assemblyName, targetPath, outputPath, projectAssetsFile,
-                    targetFramework, targetFrameworks,
+                    assemblyName, targetPath, outputPath, intermediateOutputPath, projectAssetsFile,
+                    configuration, platform, targetFramework, targetFrameworks,
                     outputKind, languageVersion, allowUnsafeCode, documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds,
                     signAssembly, assemblyOriginatorKeyFile,
                     sourceFiles, projectReferences, references.ToImmutable(), packageReferences, analyzers);

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -24,8 +24,11 @@ namespace OmniSharp.MSBuild.ProjectFile
         public string AssemblyName => _data.AssemblyName;
         public string TargetPath => _data.TargetPath;
         public string OutputPath => _data.OutputPath;
+        public string IntermediateOutputPath => _data.IntermediateOutputPath;
         public string ProjectAssetsFile => _data.ProjectAssetsFile;
 
+        public string Configuration => _data.Configuration;
+        public string Platform => _data.Platform;
         public FrameworkName TargetFramework => _data.TargetFramework;
         public ImmutableArray<string> TargetFrameworks => _data.TargetFrameworks;
 

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -6,6 +6,7 @@ using System.Runtime.Versioning;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using OmniSharp.MSBuild.Logging;
+using OmniSharp.MSBuild.Notification;
 
 namespace OmniSharp.MSBuild.ProjectFile
 {
@@ -76,38 +77,40 @@ namespace OmniSharp.MSBuild.ProjectFile
             return new ProjectFileInfo(id, filePath, data);
         }
 
-        public static (ProjectFileInfo projectFileInfo, ImmutableArray<MSBuildDiagnostic> diagnostics) Load(string filePath, ProjectLoader loader)
+        public static (ProjectFileInfo, ImmutableArray<MSBuildDiagnostic>, ProjectLoadedEventArgs) Load(string filePath, ProjectLoader loader)
         {
             if (!File.Exists(filePath))
             {
-                return (null, ImmutableArray<MSBuildDiagnostic>.Empty);
+                return (null, ImmutableArray<MSBuildDiagnostic>.Empty, null);
             }
 
             var (projectInstance, diagnostics) = loader.BuildProject(filePath);
             if (projectInstance == null)
             {
-                return (null, diagnostics);
+                return (null, diagnostics, null);
             }
 
             var id = ProjectId.CreateNewId(debugName: filePath);
             var data = ProjectData.Create(projectInstance);
             var projectFileInfo = new ProjectFileInfo(id, filePath, data);
+            var eventArgs = new ProjectLoadedEventArgs(id, projectInstance, diagnostics, isReload: false);
 
-            return (projectFileInfo, diagnostics);
+            return (projectFileInfo, diagnostics, eventArgs);
         }
 
-        public (ProjectFileInfo projectFileInfo, ImmutableArray<MSBuildDiagnostic> diagnostics) Reload(ProjectLoader loader)
+        public (ProjectFileInfo, ImmutableArray<MSBuildDiagnostic>, ProjectLoadedEventArgs) Reload(ProjectLoader loader)
         {
             var (projectInstance, diagnostics) = loader.BuildProject(FilePath);
             if (projectInstance == null)
             {
-                return (null, diagnostics);
+                return (null, diagnostics, null);
             }
 
             var data = ProjectData.Create(projectInstance);
             var projectFileInfo = new ProjectFileInfo(Id, FilePath, data);
+            var eventArgs = new ProjectLoadedEventArgs(Id, projectInstance, diagnostics, isReload: true);
 
-            return (projectFileInfo, diagnostics);
+            return (projectFileInfo, diagnostics, eventArgs);
         }
 
         public bool IsUnityProject()

--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
@@ -15,6 +15,7 @@
         public const string DefineConstants = nameof(DefineConstants);
         public const string DesignTimeBuild = nameof(DesignTimeBuild);
         public const string DocumentationFile = nameof(DocumentationFile);
+        public const string IntermediateOutputPath = nameof(IntermediateOutputPath);
         public const string LangVersion = nameof(LangVersion);
         public const string OutputType = nameof(OutputType);
         public const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -14,6 +14,7 @@ using OmniSharp.Mef;
 using OmniSharp.Models.WorkspaceInformation;
 using OmniSharp.MSBuild.Discovery;
 using OmniSharp.MSBuild.Models;
+using OmniSharp.MSBuild.Notification;
 using OmniSharp.MSBuild.ProjectFile;
 using OmniSharp.MSBuild.SolutionParsing;
 using OmniSharp.Options;
@@ -35,6 +36,7 @@ namespace OmniSharp.MSBuild
         private readonly FileSystemHelper _fileSystemHelper;
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger _logger;
+        private readonly ImmutableArray<IMSBuildEventSink> _eventSinks;
 
         private readonly object _gate = new object();
         private readonly Queue<ProjectFileInfo> _projectsToProcess;
@@ -61,7 +63,8 @@ namespace OmniSharp.MSBuild
             IEventEmitter eventEmitter,
             IFileSystemWatcher fileSystemWatcher,
             FileSystemHelper fileSystemHelper,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            [ImportMany] IEnumerable<IMSBuildEventSink> eventSinks)
         {
             _environment = environment;
             _workspace = workspace;
@@ -73,6 +76,7 @@ namespace OmniSharp.MSBuild
             _fileSystemWatcher = fileSystemWatcher;
             _fileSystemHelper = fileSystemHelper;
             _loggerFactory = loggerFactory;
+            _eventSinks = eventSinks.ToImmutableArray();
 
             _projectsToProcess = new Queue<ProjectFileInfo>();
             _logger = loggerFactory.CreateLogger<ProjectSystem>();
@@ -94,7 +98,7 @@ namespace OmniSharp.MSBuild
 
             _packageDependencyChecker = new PackageDependencyChecker(_loggerFactory, _eventEmitter, _dotNetCli, _options);
             _loader = new ProjectLoader(_options, _environment.TargetDirectory, _propertyOverrides, _loggerFactory, _sdksPathResolver);
-            _manager = new ProjectManager(_loggerFactory, _eventEmitter, _fileSystemWatcher, _metadataFileReferenceCache, _packageDependencyChecker, _loader, _workspace);
+            _manager = new ProjectManager(_loggerFactory, _eventEmitter, _fileSystemWatcher, _metadataFileReferenceCache, _packageDependencyChecker, _loader, _workspace, _eventSinks);
 
             var initialProjectPaths = GetInitialProjectPaths();
 

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -22,7 +22,7 @@ using OmniSharp.Services;
 namespace OmniSharp.MSBuild
 {
     [ExportProjectSystem(ProjectSystemNames.MSBuildProjectSystem), Shared]
-    public class ProjectSystem : IProjectSystem
+    internal class ProjectSystem : IProjectSystem
     {
         private readonly IOmniSharpEnvironment _environment;
         private readonly OmniSharpWorkspace _workspace;

--- a/src/OmniSharp.MSBuild/SdksPathResolver.cs
+++ b/src/OmniSharp.MSBuild/SdksPathResolver.cs
@@ -7,7 +7,7 @@ using OmniSharp.Services;
 namespace OmniSharp.MSBuild
 {
     [Export, Shared]
-    public class SdksPathResolver
+    internal class SdksPathResolver
     {
         private const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
         private const string Sdks = nameof(Sdks);

--- a/src/OmniSharp.MSBuild/SolutionSelector.cs
+++ b/src/OmniSharp.MSBuild/SolutionSelector.cs
@@ -2,7 +2,7 @@ using System.Linq;
 
 namespace OmniSharp.MSBuild
 {
-    public static class SolutionSelector
+    internal static class SolutionSelector
     {
         public static Result Pick(string[] solutionFilePaths, string path)
         {

--- a/src/OmniSharp.Stdio.Driver/Program.cs
+++ b/src/OmniSharp.Stdio.Driver/Program.cs
@@ -54,13 +54,12 @@ namespace OmniSharp.Stdio.Driver
                     var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
                     var plugins = application.CreatePluginAssemblies();
 
-
                     var assemblyLoader = serviceProvider.GetRequiredService<IAssemblyLoader>();
                     var compositionHostBuilder = new CompositionHostBuilder(serviceProvider)
                         .WithOmniSharpAssemblies()
                         .WithAssemblies(assemblyLoader.LoadByAssemblyNameOrPath(plugins.AssemblyNames).ToArray());
 
-                    using (var host = new Host(input, writer, environment, configuration, serviceProvider, compositionHostBuilder, loggerFactory, cancellation))
+                    using (var host = new Host(input, writer, environment, serviceProvider, compositionHostBuilder, loggerFactory, cancellation))
                     {
                         host.Start();
                         cancellation.Token.WaitHandle.WaitOne();

--- a/src/OmniSharp.Stdio/Host.cs
+++ b/src/OmniSharp.Stdio/Host.cs
@@ -24,7 +24,6 @@ namespace OmniSharp.Stdio
 {
     internal class Host : IDisposable
     {
-        private readonly IConfiguration _configuration;
         private readonly TextReader _input;
         private readonly ISharedTextWriter _writer;
         private readonly IServiceProvider _serviceProvider;
@@ -37,14 +36,13 @@ namespace OmniSharp.Stdio
         private readonly CachedStringBuilder _cachedStringBuilder;
 
         public Host(
-            TextReader input, ISharedTextWriter writer, IOmniSharpEnvironment environment, IConfiguration configuration,
+            TextReader input, ISharedTextWriter writer, IOmniSharpEnvironment environment,
             IServiceProvider serviceProvider, CompositionHostBuilder compositionHostBuilder, ILoggerFactory loggerFactory, CancellationTokenSource cancellationTokenSource)
         {
             _cancellationTokenSource = cancellationTokenSource;
             _input = input;
             _writer = writer;
             _environment = environment;
-            _configuration = configuration;
             _serviceProvider = serviceProvider;
             _loggerFactory = loggerFactory.AddStdio(_writer, (category, level) => HostHelpers.LogFilter(category, level, _environment));
             _logger = loggerFactory.CreateLogger<Host>();
@@ -136,7 +134,7 @@ namespace OmniSharp.Stdio
 
         public void Start()
         {
-            WorkspaceInitializer.Initialize(_serviceProvider, _compositionHost, _configuration, _logger);
+            WorkspaceInitializer.Initialize(_serviceProvider, _compositionHost);
 
             Task.Factory.StartNew(async () =>
             {

--- a/tests/OmniSharp.DotNet.Tests/ProjectSearcherTests.cs
+++ b/tests/OmniSharp.DotNet.Tests/ProjectSearcherTests.cs
@@ -28,7 +28,7 @@ namespace OmniSharp.DotNet.Tests
                 directoryPath = directoryPath.Substring(baseDirectory.Length);
             }
 
-            directoryPath = directoryPath.Replace(Path.DirectorySeparatorChar, '/');
+            directoryPath = directoryPath.EnsureForwardSlashes();
 
             if (directoryPath.Length > 0 && directoryPath[0] == '/')
             {

--- a/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
+++ b/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
@@ -94,10 +94,10 @@ namespace OmniSharp.Http.Tests
 
         private class PlugInHost : DisposableObject
         {
-            private readonly TestServiceProvider _serviceProvider;
+            private readonly IServiceProvider _serviceProvider;
             public CompositionHost CompositionHost { get; }
 
-            public PlugInHost(TestServiceProvider serviceProvider, CompositionHost compositionHost)
+            public PlugInHost(IServiceProvider serviceProvider, CompositionHost compositionHost)
             {
                 this._serviceProvider = serviceProvider;
                 this.CompositionHost = compositionHost;
@@ -105,7 +105,7 @@ namespace OmniSharp.Http.Tests
 
             protected override void DisposeCore(bool disposing)
             {
-                this._serviceProvider.Dispose();
+                (this._serviceProvider as IDisposable)?.Dispose();
                 this.CompositionHost.Dispose();
             }
         }
@@ -117,9 +117,7 @@ namespace OmniSharp.Http.Tests
 
         private PlugInHost CreatePlugInHost(params Assembly[] assemblies)
         {
-            var environment = new OmniSharpEnvironment();
-            var sharedTextWriter = new TestSharedTextWriter(this.TestOutput);
-            var serviceProvider = new TestServiceProvider(environment, this.LoggerFactory, sharedTextWriter, new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build(), NullEventEmitter.Instance);
+            var serviceProvider = TestServiceProvider.Create(this.TestOutput, new OmniSharpEnvironment());
             var compositionHost = new CompositionHostBuilder(serviceProvider)
                 .WithAssemblies(assemblies)
                 .Build();

--- a/tests/OmniSharp.MSBuild.Tests/AbstractMSBuildTestFixture.cs
+++ b/tests/OmniSharp.MSBuild.Tests/AbstractMSBuildTestFixture.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Composition.Hosting.Core;
+using Microsoft.Extensions.Logging;
+using OmniSharp.MSBuild.Discovery;
+using OmniSharp.Services;
+using TestUtility;
+using Xunit.Abstractions;
+
+namespace OmniSharp.MSBuild.Tests
+{
+    public abstract class AbstractMSBuildTestFixture : AbstractTestFixture, IDisposable
+    {
+        private readonly IAssemblyLoader _assemblyLoader;
+        private readonly IMSBuildLocator _msbuildLocator;
+
+        public AbstractMSBuildTestFixture(ITestOutputHelper output)
+            : base(output)
+        {
+            _assemblyLoader = new AssemblyLoader(this.LoggerFactory);
+            _msbuildLocator = MSBuildLocator.CreateStandAlone(this.LoggerFactory, _assemblyLoader, allowMonoPaths: false);
+
+            // Some tests require MSBuild to be discovered early
+            // to ensure that the Microsoft.Build.* assemblies can be located
+            _msbuildLocator.RegisterDefaultInstance(this.LoggerFactory.CreateLogger("MSBuildTests"));
+        }
+
+        public void Dispose()
+        {
+            (_msbuildLocator as IDisposable)?.Dispose();
+        }
+
+        protected OmniSharpTestHost CreateMSBuildTestHost(string path, IEnumerable<ExportDescriptorProvider> additionalExports = null)
+        {
+            var environment = new OmniSharpEnvironment(path, logLevel: LogLevel.Trace);
+            var serviceProvider = TestServiceProvider.Create(this.TestOutput, environment, this.LoggerFactory, _assemblyLoader, _msbuildLocator);
+
+            return OmniSharpTestHost.Create(serviceProvider, additionalExports);
+        }
+    }
+}

--- a/tests/OmniSharp.MSBuild.Tests/NotificationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/NotificationTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Composition.Hosting.Core;
+using System.Threading.Tasks;
+using OmniSharp.Mef;
+using OmniSharp.MSBuild.Notification;
+using TestUtility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OmniSharp.MSBuild.Tests
+{
+    public class NotificationTests : AbstractMSBuildTestFixture
+    {
+        public NotificationTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        private class FakeMSBuildEventSink : IMSBuildEventSink
+        {
+            private readonly Action<ProjectLoadedEventArgs> _onLoaded;
+
+            public FakeMSBuildEventSink(Action<ProjectLoadedEventArgs> onLoaded)
+            {
+                _onLoaded = onLoaded;
+            }
+
+            public void ProjectLoaded(ProjectLoadedEventArgs e)
+            {
+                _onLoaded(e);
+            }
+        }
+
+        [Fact]
+        public async Task ProjectLoadedFires()
+        {
+            var allEventArgs = new List<ProjectLoadedEventArgs>();
+
+            var eventSink = new FakeMSBuildEventSink(e =>
+            {
+                allEventArgs.Add(e);
+            });
+
+            var exports = new ExportDescriptorProvider[]
+            {
+                MefValueProvider.From<IMSBuildEventSink>(eventSink)
+            };
+
+            using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectAndSolution"))
+            using (var host = CreateMSBuildTestHost(testProject.Directory, exports))
+            {
+                var eventArgs = Assert.Single(allEventArgs);
+                Assert.Equal(
+                    $"{testProject.Directory}/{testProject.Name}.csproj".EnsureForwardSlashes(),
+                    eventArgs.ProjectInstance.FullPath.EnsureForwardSlashes());
+            }
+        }
+    }
+}

--- a/tests/OmniSharp.MSBuild.Tests/OmniSharp.MSBuild.Tests.csproj
+++ b/tests/OmniSharp.MSBuild.Tests/OmniSharp.MSBuild.Tests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit" />
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -32,7 +32,7 @@ namespace OmniSharp.MSBuild.Tests
                 loggerFactory: LoggerFactory,
                 sdksPathResolver: sdksPathResolver);
 
-            var (projectFileInfo, _) = ProjectFileInfo.Load(projectFilePath, loader);
+            var (projectFileInfo, _, _) = ProjectFileInfo.Load(projectFilePath, loader);
 
             return projectFileInfo;
         }

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -49,11 +49,14 @@ namespace OmniSharp.MSBuild.Tests
 
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
-                Assert.Single(projectFileInfo.TargetFrameworks);
-                Assert.Equal("netcoreapp1.0", projectFileInfo.TargetFrameworks[0]);
-                Assert.Equal("bin/Debug/netcoreapp1.0/", projectFileInfo.OutputPath.Replace('\\', '/'));
+                var targetFramework = Assert.Single(projectFileInfo.TargetFrameworks);
+                Assert.Equal("netcoreapp1.0", targetFramework);
+                Assert.Equal("bin/Debug/netcoreapp1.0/", projectFileInfo.OutputPath.EnsureForwardSlashes());
+                Assert.Equal("obj/Debug/netcoreapp1.0/", projectFileInfo.IntermediateOutputPath.EnsureForwardSlashes());
                 Assert.Equal(3, projectFileInfo.SourceFiles.Length); // Program.cs, AssemblyInfo.cs, AssemblyAttributes.cs
                 Assert.Equal(LanguageVersion.CSharp7_1, projectFileInfo.LanguageVersion);
+                Assert.Equal("Debug", projectFileInfo.Configuration);
+                Assert.Equal("AnyCPU", projectFileInfo.Platform);
             }
         }
 
@@ -69,10 +72,13 @@ namespace OmniSharp.MSBuild.Tests
 
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
-                Assert.Single(projectFileInfo.TargetFrameworks);
-                Assert.Equal("netcoreapp1.0", projectFileInfo.TargetFrameworks[0]);
-                Assert.Equal("bin/Debug/netcoreapp1.0/", projectFileInfo.OutputPath.Replace('\\', '/'));
+                var targetFramework = Assert.Single(projectFileInfo.TargetFrameworks);
+                Assert.Equal("netcoreapp1.0", targetFramework);
+                Assert.Equal("bin/Debug/netcoreapp1.0/", projectFileInfo.OutputPath.EnsureForwardSlashes());
+                Assert.Equal("obj/Debug/netcoreapp1.0/", projectFileInfo.IntermediateOutputPath.EnsureForwardSlashes());
                 Assert.Equal(3, projectFileInfo.SourceFiles.Length); // Program.cs, AssemblyInfo.cs, AssemblyAttributes.cs
+                Assert.Equal("Debug", projectFileInfo.Configuration);
+                Assert.Equal("AnyCPU", projectFileInfo.Platform);
             }
         }
 
@@ -91,8 +97,11 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.Equal(2, projectFileInfo.TargetFrameworks.Length);
                 Assert.Equal("netcoreapp1.0", projectFileInfo.TargetFrameworks[0]);
                 Assert.Equal("netstandard1.5", projectFileInfo.TargetFrameworks[1]);
-                Assert.Equal(@"bin/Debug/netcoreapp1.0/", projectFileInfo.OutputPath.Replace('\\', '/'));
+                Assert.Equal("bin/Debug/netcoreapp1.0/", projectFileInfo.OutputPath.EnsureForwardSlashes());
+                Assert.Equal("obj/Debug/netcoreapp1.0/", projectFileInfo.IntermediateOutputPath.EnsureForwardSlashes());
                 Assert.Equal(3, projectFileInfo.SourceFiles.Length); // Program.cs, AssemblyInfo.cs, AssemblyAttributes.cs
+                Assert.Equal("Debug", projectFileInfo.Configuration);
+                Assert.Equal("AnyCPU", projectFileInfo.Platform);
             }
         }
     }

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -1,46 +1,20 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Composition.Hosting.Core;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using OmniSharp.MSBuild.Discovery;
-using OmniSharp.Services;
 using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace OmniSharp.MSBuild.Tests
 {
-    public class WorkspaceInformationTests : AbstractTestFixture, IDisposable
+    public class WorkspaceInformationTests : AbstractMSBuildTestFixture
     {
-        private readonly IAssemblyLoader _assemblyLoader;
-        private readonly IMSBuildLocator _msbuildLocator;
-
         public WorkspaceInformationTests(ITestOutputHelper output)
             : base(output)
         {
-            _assemblyLoader = new AssemblyLoader(this.LoggerFactory);
-            _msbuildLocator = MSBuildLocator.CreateStandAlone(this.LoggerFactory, _assemblyLoader, allowMonoPaths: false);
-
-            // Some tests require MSBuild to be discovered early
-            // to ensure that the Microsoft.Build.* assemblies can be located
-            _msbuildLocator.RegisterDefaultInstance(this.LoggerFactory.CreateLogger<WorkspaceInformationTests>());
-        }
-
-        public void Dispose()
-        {
-            (_msbuildLocator as IDisposable)?.Dispose();
-        }
-
-        private OmniSharpTestHost CreateMSBuildTestHost(string path, IEnumerable<ExportDescriptorProvider> additionalExports = null)
-        {
-            var environment = new OmniSharpEnvironment(path, logLevel: LogLevel.Trace);
-            var serviceProvider = TestServiceProvider.Create(this.TestOutput, environment, this.LoggerFactory, _assemblyLoader, _msbuildLocator);
-
-            return OmniSharpTestHost.Create(serviceProvider, additionalExports);
         }
 
         [Fact]

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using OmniSharp.Models;
-using OmniSharp.Models.CodeCheck;
 using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
@@ -25,7 +23,7 @@ namespace OmniSharp.MSBuild.Tests
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectAndSolution"))
             using (var host = CreateOmniSharpHost(testProject.Directory))
             {
-                var workspaceInfo = await host.GetMSBuildWorkspaceInfoAsync();
+                var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
 
                 Assert.Equal("ProjectAndSolution.sln", Path.GetFileName(workspaceInfo.SolutionPath));
                 Assert.NotNull(workspaceInfo.Projects);
@@ -53,7 +51,7 @@ namespace OmniSharp.MSBuild.Tests
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectAndSolutionWithProjectSection"))
             using (var host = CreateOmniSharpHost(testProject.Directory))
             {
-                var workspaceInfo = await host.GetMSBuildWorkspaceInfoAsync();
+                var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
 
                 Assert.Equal("ProjectAndSolutionWithProjectSection.sln", Path.GetFileName(workspaceInfo.SolutionPath));
                 Assert.NotNull(workspaceInfo.Projects);
@@ -69,7 +67,7 @@ namespace OmniSharp.MSBuild.Tests
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("TwoProjectsWithSolution"))
             using (var host = CreateOmniSharpHost(testProject.Directory))
             {
-                var workspaceInfo = await host.GetMSBuildWorkspaceInfoAsync();
+                var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
 
                 Assert.Equal("TwoProjectsWithSolution.sln", Path.GetFileName(workspaceInfo.SolutionPath));
                 Assert.NotNull(workspaceInfo.Projects);
@@ -93,7 +91,7 @@ namespace OmniSharp.MSBuild.Tests
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectWithGeneratedFile"))
             using (var host = CreateOmniSharpHost(testProject.Directory))
             {
-                var workspaceInfo = await host.GetMSBuildWorkspaceInfoAsync();
+                var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
 
                 Assert.NotNull(workspaceInfo.Projects);
                 var project = Assert.Single(workspaceInfo.Projects);
@@ -109,7 +107,7 @@ namespace OmniSharp.MSBuild.Tests
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectWithSdkProperty"))
             using (var host = CreateOmniSharpHost(testProject.Directory))
             {
-                var workspaceInfo = await host.GetMSBuildWorkspaceInfoAsync();
+                var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
 
                 Assert.NotNull(workspaceInfo.Projects);
                 var project = Assert.Single(workspaceInfo.Projects);
@@ -125,7 +123,7 @@ namespace OmniSharp.MSBuild.Tests
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("CSharpAndFSharp"))
             using (var host = CreateOmniSharpHost(testProject.Directory))
             {
-                var workspaceInfo = await host.GetMSBuildWorkspaceInfoAsync();
+                var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
 
                 Assert.NotNull(workspaceInfo.Projects);
                 var project = Assert.Single(workspaceInfo.Projects);
@@ -141,7 +139,7 @@ namespace OmniSharp.MSBuild.Tests
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("TwoProjectsWithSolution"))
             using (var host = CreateOmniSharpHost(Path.Combine(testProject.Directory, "App")))
             {
-                var workspaceInfo = await host.GetMSBuildWorkspaceInfoAsync();
+                var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
 
                 Assert.NotNull(workspaceInfo.Projects);
                 Assert.Equal(2, workspaceInfo.Projects.Count);
@@ -160,7 +158,7 @@ namespace OmniSharp.MSBuild.Tests
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("SolutionWithSignedProject"))
             using (var host = CreateOmniSharpHost(Path.Combine(testProject.Directory)))
             {
-                var workspaceInfo = await host.GetMSBuildWorkspaceInfoAsync();
+                var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
                 Assert.NotNull(workspaceInfo.Projects);
                 Assert.Equal(2, workspaceInfo.Projects.Count);
 
@@ -180,7 +178,7 @@ namespace OmniSharp.MSBuild.Tests
                 var token = BitConverter.ToString(AssemblyName.GetAssemblyName(signedProject.TargetPath).GetPublicKeyToken());
                 Assert.Equal("A5-D8-5A-5B-AA-39-A6-A6", token, ignoreCase: true);
 
-                var response = await host.CodeCheckRequestAsync(Path.Combine(testProject.Directory, "CallerLib", "Caller.cs"));
+                var response = await host.RequestCodeCheckAsync(Path.Combine(testProject.Directory, "CallerLib", "Caller.cs"));
                 // Log result to easier debugging of the test should it fail during automated valdiation
                 foreach (var fix in response.QuickFixes)
                 {
@@ -197,7 +195,7 @@ namespace OmniSharp.MSBuild.Tests
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectWithMultiTFMLib"))
             using (var host = CreateOmniSharpHost(Path.Combine(testProject.Directory, "App")))
             {
-                var workspaceInfo = await host.GetMSBuildWorkspaceInfoAsync();
+                var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
 
                 Assert.NotNull(workspaceInfo.Projects);
                 Assert.Equal(2, workspaceInfo.Projects.Count);
@@ -218,7 +216,7 @@ namespace OmniSharp.MSBuild.Tests
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("AntlrGeneratedFiles"))
             using (var host = CreateOmniSharpHost(testProject.Directory))
             {
-                var workspaceInfo = await host.GetMSBuildWorkspaceInfoAsync();
+                var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
 
                 Assert.NotNull(workspaceInfo.Projects);
                 var project = Assert.Single(workspaceInfo.Projects);

--- a/tests/OmniSharp.Stdio.Tests/StdioServerFacts.cs
+++ b/tests/OmniSharp.Stdio.Tests/StdioServerFacts.cs
@@ -22,7 +22,6 @@ namespace OmniSharp.Stdio.Tests
             var cancelationTokenSource = new CancellationTokenSource();
             var host = new Host(reader, writer,
                 environment,
-                configuration,
                 serviceProvider,
                 new CompositionHostBuilder(serviceProvider),
                 serviceProvider.GetRequiredService<ILoggerFactory>(),

--- a/tests/TestUtility/DotNetCliVersion.cs
+++ b/tests/TestUtility/DotNetCliVersion.cs
@@ -1,9 +1,25 @@
-﻿namespace TestUtility
+﻿using System;
+
+namespace TestUtility
 {
     public enum DotNetCliVersion
     {
         Current,
         Legacy,
         Future
+    }
+
+    public static class DotNetCliVersionExtensions
+    {
+        public static string GetFolderName(this DotNetCliVersion dotNetCliVersion)
+        {
+            switch (dotNetCliVersion)
+            {
+                case DotNetCliVersion.Current: return ".dotnet";
+                case DotNetCliVersion.Legacy: return ".dotnet-legacy";
+                case DotNetCliVersion.Future: throw new InvalidOperationException("Test infrastructure does not support a future .NET Core SDK yet.");
+                default: throw new ArgumentException($"Unknown {nameof(dotNetCliVersion)}: {dotNetCliVersion}", nameof(dotNetCliVersion));
+            }
+        }
     }
 }

--- a/tests/TestUtility/StringExtensions.cs
+++ b/tests/TestUtility/StringExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.IO;
+
+namespace TestUtility
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Given a file or directory path, return a path where all directory separators
+        /// are replaced with a forward slash (/) character.
+        /// </summary>
+        public static string EnsureForwardSlashes(this string path)
+            => path.Replace(Path.DirectorySeparatorChar, '/');
+    }
+}

--- a/tests/TestUtility/StringExtensions.cs
+++ b/tests/TestUtility/StringExtensions.cs
@@ -9,6 +9,6 @@ namespace TestUtility
         /// are replaced with a forward slash (/) character.
         /// </summary>
         public static string EnsureForwardSlashes(this string path)
-            => path.Replace(Path.DirectorySeparatorChar, '/');
+            => path.Replace('\\', '/');
     }
 }

--- a/tests/TestUtility/TestHostExtensions.cs
+++ b/tests/TestUtility/TestHostExtensions.cs
@@ -1,14 +1,22 @@
-﻿using OmniSharp.Models;
+﻿using OmniSharp;
+using OmniSharp.Models;
 using OmniSharp.Models.CodeCheck;
 using OmniSharp.Models.WorkspaceInformation;
 using OmniSharp.MSBuild.Models;
+using OmniSharp.Roslyn.CSharp.Services.Diagnostics;
 using System.Threading.Tasks;
 
 namespace TestUtility
 {
     public static class TestHostExtensions
     {
-        public static async Task<MSBuildWorkspaceInfo> GetMSBuildWorkspaceInfoAsync(this OmniSharpTestHost host)
+        public static CodeCheckService GetCodeCheckService(this OmniSharpTestHost host)
+            => host.GetRequestHandler<CodeCheckService>(OmniSharpEndpoints.CodeCheck);
+
+        public static WorkspaceInformationService GetWorkspaceInformationService(this OmniSharpTestHost host)
+            => host.GetRequestHandler<WorkspaceInformationService>(OmniSharpEndpoints.WorkspaceInformation, "Projects");
+
+        public static async Task<MSBuildWorkspaceInfo> RequestMSBuildWorkspaceInfoAsync(this OmniSharpTestHost host)
         {
             var service = host.GetWorkspaceInformationService();
 
@@ -22,9 +30,9 @@ namespace TestUtility
             return (MSBuildWorkspaceInfo)response["MsBuild"];
         }
 
-        public static async Task<QuickFixResponse> CodeCheckRequestAsync(this OmniSharpTestHost host, string filePath)
+        public static async Task<QuickFixResponse> RequestCodeCheckAsync(this OmniSharpTestHost host, string filePath)
         {
-            var service = host.GetCodeCheckServiceService();
+            var service = host.GetCodeCheckService();
 
             var request = new CodeCheckRequest { FileName = filePath };
 

--- a/tests/TestUtility/TestHostExtensions.cs
+++ b/tests/TestUtility/TestHostExtensions.cs
@@ -1,0 +1,34 @@
+﻿using OmniSharp.Models;
+using OmniSharp.Models.CodeCheck;
+using OmniSharp.Models.WorkspaceInformation;
+using OmniSharp.MSBuild.Models;
+using System.Threading.Tasks;
+
+namespace TestUtility
+{
+    public static class TestHostExtensions
+    {
+        public static async Task<MSBuildWorkspaceInfo> GetMSBuildWorkspaceInfoAsync(this OmniSharpTestHost host)
+        {
+            var service = host.GetWorkspaceInformationService();
+
+            var request = new WorkspaceInformationRequest
+            {
+                ExcludeSourceFiles = false
+            };
+
+            var response = await service.Handle(request);
+
+            return (MSBuildWorkspaceInfo)response["MsBuild"];
+        }
+
+        public static async Task<QuickFixResponse> CodeCheckRequestAsync(this OmniSharpTestHost host, string filePath)
+        {
+            var service = host.GetCodeCheckServiceService();
+
+            var request = new CodeCheckRequest { FileName = filePath };
+
+            return await service.Handle(request);
+        }
+    }
+}

--- a/tests/TestUtility/TestServiceProvider.cs
+++ b/tests/TestUtility/TestServiceProvider.cs
@@ -74,6 +74,29 @@ namespace TestUtility
                 msbuildLocator, eventEmitter, dotNetCliService, configuration, optionsMonitor);
         }
 
+        public static IServiceProvider Create(
+            ITestOutputHelper testOutput,
+            IOmniSharpEnvironment environment,
+            ILoggerFactory loggerFactory,
+            IAssemblyLoader assemblyLoader,
+            IMSBuildLocator msbuildLocator,
+            IEnumerable<KeyValuePair<string, string>> configurationData = null,
+            DotNetCliVersion dotNetCliVersion = DotNetCliVersion.Current,
+            IEventEmitter eventEmitter = null)
+        {
+            eventEmitter = eventEmitter ?? NullEventEmitter.Instance;
+
+            var dotNetCliService = CreateDotNetCliService(dotNetCliVersion, loggerFactory, eventEmitter);
+            var configuration = CreateConfiguration(configurationData, dotNetCliService);
+            var memoryCache = CreateMemoryCache();
+            var optionsMonitor = CreateOptionsMonitor(configuration);
+            var sharedTextWriter = CreateSharedTextWriter(testOutput);
+
+            return new TestServiceProvider(
+                environment, loggerFactory, assemblyLoader, memoryCache, sharedTextWriter,
+                msbuildLocator, eventEmitter, dotNetCliService, configuration, optionsMonitor);
+        }
+
         private static IAssemblyLoader CreateAssemblyLoader(ILoggerFactory loggerFactory)
             => new AssemblyLoader(loggerFactory);
 

--- a/tests/TestUtility/TestServiceProvider.cs
+++ b/tests/TestUtility/TestServiceProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
@@ -12,6 +13,8 @@ using OmniSharp.Options;
 using OmniSharp.Services;
 using OmniSharp.Stdio.Services;
 using OmniSharp.Utilities;
+using TestUtility.Logging;
+using Xunit.Abstractions;
 
 namespace TestUtility
 {
@@ -20,45 +23,142 @@ namespace TestUtility
         private readonly ILogger<TestServiceProvider> _logger;
         private readonly Dictionary<Type, object> _services = new Dictionary<Type, object>();
 
-        public TestServiceProvider(
+        private TestServiceProvider(
             IOmniSharpEnvironment environment,
             ILoggerFactory loggerFactory,
+            IAssemblyLoader assemblyLoader,
+            IMemoryCache memoryCache,
             ISharedTextWriter sharedTextWriter,
-            IConfiguration configuration,
+            IMSBuildLocator msbuildLocator,
             IEventEmitter eventEmitter,
-            IDotNetCliService dotNetCliService = null)
+            IDotNetCliService dotNetCliService,
+            IConfigurationRoot configuration,
+            IOptionsMonitor<OmniSharpOptions> optionsMonitor)
         {
             _logger = loggerFactory.CreateLogger<TestServiceProvider>();
 
-            _services[typeof(IOptionsMonitor<OmniSharpOptions>)] = new OptionsMonitor<OmniSharpOptions>(
-                new OptionsFactory<OmniSharpOptions>(
-                    new IConfigureOptions<OmniSharpOptions>[] {
-                        new ConfigureOptions<OmniSharpOptions>(c => ConfigurationBinder.Bind(configuration, c))
-                    },
-                    Enumerable.Empty<IPostConfigureOptions<OmniSharpOptions>>()
-                ),
-                Enumerable.Empty<IOptionsChangeTokenSource<OmniSharpOptions>>(),
-                new OptionsCache<OmniSharpOptions>()
+            AddService(environment);
+            AddService(loggerFactory);
+            AddService(assemblyLoader);
+            AddService(memoryCache);
+            AddService(sharedTextWriter);
+            AddService(msbuildLocator);
+            AddService(eventEmitter);
+            AddService(dotNetCliService);
+            AddService(configuration);
+            AddService(optionsMonitor);
+        }
+
+        public static IServiceProvider Create(
+            ITestOutputHelper testOutput,
+            IOmniSharpEnvironment environment,
+            IEnumerable<KeyValuePair<string, string>> configurationData = null,
+            DotNetCliVersion dotNetCliVersion = DotNetCliVersion.Current,
+            IEventEmitter eventEmitter = null)
+        {
+            var loggerFactory = new LoggerFactory()
+                .AddXunit(testOutput);
+
+            eventEmitter = eventEmitter ?? NullEventEmitter.Instance;
+
+            var assemblyLoader = CreateAssemblyLoader(loggerFactory);
+            var dotNetCliService = CreateDotNetCliService(dotNetCliVersion, loggerFactory, eventEmitter);
+            var configuration = CreateConfiguration(configurationData, dotNetCliService);
+            var memoryCache = CreateMemoryCache();
+            var msbuildLocator = CreateMSBuildLocator(loggerFactory, assemblyLoader);
+            var optionsMonitor = CreateOptionsMonitor(configuration);
+            var sharedTextWriter = CreateSharedTextWriter(testOutput);
+
+            return new TestServiceProvider(
+                environment, loggerFactory, assemblyLoader, memoryCache, sharedTextWriter,
+                msbuildLocator, eventEmitter, dotNetCliService, configuration, optionsMonitor);
+        }
+
+        private static IAssemblyLoader CreateAssemblyLoader(ILoggerFactory loggerFactory)
+            => new AssemblyLoader(loggerFactory);
+
+        private static IConfigurationRoot CreateConfiguration(IEnumerable<KeyValuePair<string, string>> configurationData, IDotNetCliService dotNetCliService)
+        {
+            var info = dotNetCliService.GetInfo();
+            var msbuildSdksPath = Path.Combine(info.BasePath, "Sdks");
+
+            var builder = new Microsoft.Extensions.Configuration.ConfigurationBuilder();
+
+            builder.AddInMemoryCollection(configurationData);
+
+            // We need to set the "UseLegacySdkResolver" for tests because
+            // MSBuild's SDK resolver will not be able to locate the .NET Core SDKs
+            // that we install locally in the ".dotnet" and ".dotnet-legacy" directories.
+            // This property will cause the MSBuild project loader to set the
+            // MSBuildSDKsPath environment variable to the correct path "Sdks" folder
+            // within the appropriate .NET Core SDK.
+            var msbuildProperties = new Dictionary<string, string>()
+            {
+                [$"MSBuild:{nameof(MSBuildOptions.UseLegacySdkResolver)}"] = "true",
+                [$"MSBuild:{nameof(MSBuildOptions.MSBuildSDKsPath)}"] = msbuildSdksPath
+            };
+
+            builder.AddInMemoryCollection(msbuildProperties);
+
+            return builder.Build();
+        }
+
+        private static IDotNetCliService CreateDotNetCliService(DotNetCliVersion dotNetCliVersion, ILoggerFactory loggerFactory, IEventEmitter eventEmitter)
+        {
+            var dotnetPath = Path.Combine(
+                TestAssets.Instance.RootFolder,
+                dotNetCliVersion.GetFolderName(),
+                "dotnet");
+
+            if (!File.Exists(dotnetPath))
+            {
+                dotnetPath = Path.ChangeExtension(dotnetPath, ".exe");
+            }
+
+            if (!File.Exists(dotnetPath))
+            {
+                throw new InvalidOperationException($"Local .NET CLI path does not exist. Did you run build.(ps1|sh) from the command line?");
+            }
+
+            return new DotNetCliService(loggerFactory, NullEventEmitter.Instance, dotnetPath);
+        }
+
+        private static IMemoryCache CreateMemoryCache()
+            => new MemoryCache(new MemoryCacheOptions());
+
+        private static IMSBuildLocator CreateMSBuildLocator(ILoggerFactory loggerFactory, IAssemblyLoader assemblyLoader)
+            => MSBuildLocator.CreateStandAlone(loggerFactory, assemblyLoader, allowMonoPaths: false);
+
+        private static IOptionsMonitor<OmniSharpOptions> CreateOptionsMonitor(IConfigurationRoot configurationRoot)
+        {
+            var setups = new IConfigureOptions<OmniSharpOptions>[]
+            {
+                new ConfigureOptions<OmniSharpOptions>(c => ConfigurationBinder.Bind(configurationRoot, c))
+            };
+
+            var factory = new OptionsFactory<OmniSharpOptions>(
+                setups,
+                postConfigures: Enumerable.Empty<IPostConfigureOptions<OmniSharpOptions>>()
             );
 
-            var assemblyLoader = new AssemblyLoader(loggerFactory);
-            var msbuildLocator = MSBuildLocator.CreateStandAlone(loggerFactory, assemblyLoader, allowMonoPaths: false);
-            var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            dotNetCliService = dotNetCliService ?? new DotNetCliService(loggerFactory, eventEmitter);
-
-            _services[typeof(ILoggerFactory)] = loggerFactory;
-            _services[typeof(IOmniSharpEnvironment)] = environment;
-            _services[typeof(IAssemblyLoader)] = assemblyLoader;
-            _services[typeof(IMemoryCache)] = memoryCache;
-            _services[typeof(ISharedTextWriter)] = sharedTextWriter;
-            _services[typeof(IMSBuildLocator)] = msbuildLocator;
-            _services[typeof(IEventEmitter)] = eventEmitter;
-            _services[typeof(IDotNetCliService)] = dotNetCliService;
+            return new OptionsMonitor<OmniSharpOptions>(
+                factory,
+                sources: Enumerable.Empty<IOptionsChangeTokenSource<OmniSharpOptions>>(),
+                cache: new OptionsCache<OmniSharpOptions>()
+            );
         }
+
+        private static ISharedTextWriter CreateSharedTextWriter(ITestOutputHelper testOutput)
+            => new TestSharedTextWriter(testOutput);
 
         ~TestServiceProvider()
         {
             throw new InvalidOperationException($"{nameof(TestServiceProvider)}.{nameof(Dispose)}() not called.");
+        }
+
+        private void AddService<TServiceType>(TServiceType instance)
+        {
+            _services[typeof(TServiceType)] = instance;
         }
 
         protected override void DisposeCore(bool disposing)
@@ -81,11 +181,11 @@ namespace TestUtility
 
             if (result == null)
             {
-                _logger.LogWarning($"GetSerivce {serviceType.Name} => {result?.GetType()?.Name ?? "null"}");
+                _logger.LogWarning($"{nameof(GetService)}: {serviceType.Name} => null");
             }
             else
             {
-                _logger.LogInformation($"GetSerivce {serviceType.Name} => {result?.GetType()?.Name ?? "null"}");
+                _logger.LogInformation($"{nameof(GetService)}: {serviceType.Name} => {result.GetType().Name}");
             }
 
             return result;


### PR DESCRIPTION
This is a fairly substantial change for a relatively small API. If you're reviewing, I recommend looking at one commit at a time. I ended up refactoring a lot of test code to ensure that the test for this new API works.

The API is an optional interface that an OmniSharp plug-in can MEF export in order to be notified when the MSBuild project system loads or reloads a project. The event includes the `Microsoft.Build.Evaluation.ProjectInstance` that was built so that consumers (such as Razor) can build additional targets.

Any plug-in that uses this interface will need to add a package reference to `Microsoft.Build` like so: `<PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" PrivateAssets="all" />`. In addition, the for tests, the MSBuild discovery needs to happen sooner a bit sooner. The reason for this is because any test methods that happen to refer to the the new API will cause the CLR to try and load `Microsoft.Build` at JIT time. However, because OmniSharp needs to discover MSBuild before installing an `AppDomain.AssemblyResolve` event that allows `Microsoft.Build` to be located, that discovery must happen _before_ the JIT. Much of the test infrastructure refactoring was in support of being able to do this (though a lot of it was just to be more cleanly).

Finally, at the request of the Razor folks, I've added a few more properties to the MSBuildProjectInfo models -- namely, "IntermediateOutputPath", "Configuration", and "Platform"

cc @NTaylorMullen and @TheRealPiotrP 