### PR TITLE
Fix missing signatures for some cases

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -69,7 +69,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
                     var throughExpression = ((MemberAccessExpressionSyntax)invocation.Receiver).Expression;
                     throughSymbol = invocation.SemanticModel.GetSpeculativeSymbolInfo(invocation.Position, throughExpression, SpeculativeBindingOption.BindAsExpression).Symbol;
                     throughType = invocation.SemanticModel.GetSpeculativeTypeInfo(invocation.Position, throughExpression, SpeculativeBindingOption.BindAsTypeOrNamespace).Type;
-                    var includeInstance = throughSymbol != null && !(throughSymbol is ITypeSymbol);
+                    var includeInstance = (throughSymbol != null && !(throughSymbol is ITypeSymbol)) ||
+                        throughExpression is LiteralExpressionSyntax ||
+                        throughExpression is TypeOfExpressionSyntax;
                     var includeStatic = (throughSymbol is INamedTypeSymbol) || throughType != null;
                     methodGroup = methodGroup.Where(m => (m.IsStatic && includeStatic) || (!m.IsStatic && includeInstance));
                 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -747,7 +747,7 @@ class B : A
     }
 }";
             var actual = await GetSignatureHelp(filename, source);
-            Assert.NotEmpty(actual.Signatures);
+            Assert.Contains(actual.Signatures, signature => signature.Name == "ToString" && signature.Parameters.Count() == 0);
         }
 
         [Theory]
@@ -764,7 +764,7 @@ class B : A
     }
 }";
             var actual = await GetSignatureHelp(filename, source);
-            Assert.NotEmpty(actual.Signatures);
+            Assert.Contains(actual.Signatures, signature => signature.Name == "GetMembers" && signature.Parameters.Count() == 0);
         }
 
         [Fact]
@@ -793,7 +793,7 @@ class Program
             Assert.Single(actual.Signatures);
 
             var signature = actual.Signatures.ElementAt(0);
-            Assert.Equal("void string.MyMethod(int number)",signature.Label);
+            Assert.Equal("void string.MyMethod(int number)", signature.Label);
             Assert.Single(signature.Parameters);
             Assert.Equal("number", signature.Parameters.ElementAt(0).Name);
         }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -733,6 +733,40 @@ class B : A
             Assert.Equal(4, actual.Signatures.Count());
         }
 
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task LiteralContextMethod(string filename)
+        {
+            const string source =
+@"class A
+{
+    static void M()
+    {
+        string three = 3.ToString($$);
+    }
+}";
+            var actual = await GetSignatureHelp(filename, source);
+            Assert.NotEmpty(actual.Signatures);
+        }
+
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task TypeOfContextMethod(string filename)
+        {
+            const string source =
+@"class A
+{
+    static void M()
+    {
+        string a = typeof(A).GetMembers($$);
+    }
+}";
+            var actual = await GetSignatureHelp(filename, source);
+            Assert.NotEmpty(actual.Signatures);
+        }
+
         [Fact]
         public async Task OverloadedExtensionMethods1()
         {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -177,21 +177,21 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             const string source =
 @"using System;
 [MyTest($$)]
-public class TestClass 
+public class TestClass
 {
     public static void Main()
     {
     }
 }
-public class MyTestAttribute : Attribute 
+public class MyTestAttribute : Attribute
 {
     public MyTestAttribute(int value)
     {
     }
 }";
-            var actual = await GetSignatureHelp(filename, source);    
+            var actual = await GetSignatureHelp(filename, source);
             Assert.Equal(0, actual.ActiveParameter);
-       
+
             var signature = actual.Signatures.ElementAt(0);
             Assert.Single(signature.Parameters);
             Assert.Equal("value", signature.Parameters.ElementAt(0).Name);
@@ -206,13 +206,13 @@ public class MyTestAttribute : Attribute
             const string source =
 @"using System;
 [MyTest($$)]
-public class TestClass 
+public class TestClass
 {
     public static void Main()
     {
     }
 }
-public class MyTestAttribute : Attribute 
+public class MyTestAttribute : Attribute
 {
     public MyTestAttribute(int value1,double value2)
     {
@@ -238,13 +238,13 @@ public class MyTestAttribute : Attribute
             const string source =
 @"using System;
 [MyTest(2,$$)]
-public class TestClass 
+public class TestClass
 {
     public static void Main()
     {
     }
 }
-public class MyTestAttribute : Attribute 
+public class MyTestAttribute : Attribute
 {
     public MyTestAttribute(int value1,double value2)
     {
@@ -263,13 +263,13 @@ public class MyTestAttribute : Attribute
             const string source =
 @"using System;
 [MyTest($$)]
-public class TestClass 
+public class TestClass
 {
     public static void Main()
     {
     }
 }
-public class MyTestAttribute : Attribute 
+public class MyTestAttribute : Attribute
 {
     public MyTestAttribute()
     {
@@ -760,7 +760,7 @@ class B : A
 {
     static void M()
     {
-        string a = typeof(A).GetMembers($$);
+        var members = typeof(A).GetMembers($$);
     }
 }";
             var actual = await GetSignatureHelp(filename, source);
@@ -916,7 +916,7 @@ class Program
         var flag = Compare($$);
     }
     ///<summary>Checks if object is tagged with the tag.</summary>
-    /// <param name=""gameObject"">The game object.</param> 
+    /// <param name=""gameObject"">The game object.</param>
     /// <param name=""tagName"">Name of the tag.</param>
     /// <returns>Returns <c> true</c> if object is tagged with tag.</returns>
     public static bool Compare(GameObject gameObject, string tagName)
@@ -948,7 +948,7 @@ class Program
         var flag = Compare($$);
     }
     ///<summary>Checks if object is tagged with the tag.</summary>
-    /// <param name=""gameObject"">The game object.</param> 
+    /// <param name=""gameObject"">The game object.</param>
     /// <param name=""tagName"">Name of the tag.It has the default value as <c>null</c></param>
     /// <returns>Returns <c> true</c> if object is tagged with tag.</returns>
     public static bool Compare(GameObject gameObject, string tagName = null)
@@ -977,7 +977,7 @@ class Program
         var flag = Compare($$);
     }
     ///<summary>Checks if object is tagged with the tag.</summary>
-    /// <param name=""gameObject"">The game object.</param> 
+    /// <param name=""gameObject"">The game object.</param>
     /// <param name=""tagName"">Name of the tag.</param>
     /// <returns>Returns <c>true</c> if object is tagged with tag.</returns>
     public static bool Compare(GameObject gameObject, string tagName)


### PR DESCRIPTION
A fix for https://github.com/OmniSharp/omnisharp-vscode/issues/2495. Provides missing signature help for compiler literals and typeof(T)... expressions. Added two tests for those cases.

bonus question: will roslyn cover the whole signature service soon? it sounds like something that should be handled out-of-the-box