### PR TITLE
Rollback NuGet.Build.Tasks

### DIFF
--- a/tools/packages.config
+++ b/tools/packages.config
@@ -8,14 +8,14 @@
     <package id="Microsoft.Build.Utilities.Core" version="15.8.166" />
     <package id="Microsoft.Net.Compilers" version="2.9.0" />
     <package id="Microsoft.DotNet.MSBuildSdkResolver" version="2.1.401" />
-    <package id="NuGet.Build.Tasks" version="4.8.0" />
-    <package id="NuGet.Commands" version="4.8.0" />
-    <package id="NuGet.Common" version="4.8.0" />
-    <package id="NuGet.Configuration" version="4.8.0" />
-    <package id="NuGet.Frameworks" version="4.8.0" />
-    <package id="NuGet.ProjectModel" version="4.8.0" />
-    <package id="NuGet.Protocol" version="4.8.0" />
-    <package id="NuGet.Versioning" version="4.8.0" />
+    <package id="NuGet.Build.Tasks" version="4.6.1" />
+    <package id="NuGet.Commands" version="4.6.1" />
+    <package id="NuGet.Common" version="4.6.1" />
+    <package id="NuGet.Configuration" version="4.6.1" />
+    <package id="NuGet.Frameworks" version="4.6.1" />
+    <package id="NuGet.ProjectModel" version="4.6.1" />
+    <package id="NuGet.Protocol" version="4.6.1" />
+    <package id="NuGet.Versioning" version="4.6.1" />
     <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="2.1.3" />
     <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="2.1.3" />
     <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="2.1.3" />

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Cake" version="0.23" />
-    <package id="Microsoft.Build" version="15.8.166" />
-    <package id="Microsoft.Build.Framework" version="15.8.166" />
-    <package id="Microsoft.Build.Runtime" version="15.8.166" />
-    <package id="Microsoft.Build.Tasks.Core" version="15.8.166" />
-    <package id="Microsoft.Build.Utilities.Core" version="15.8.166" />
+    <package id="Microsoft.Build" version="15.6.82" />
+    <package id="Microsoft.Build.Framework" version="15.6.82" />
+    <package id="Microsoft.Build.Runtime" version="15.6.82" />
+    <package id="Microsoft.Build.Tasks.Core" version="15.6.82" />
+    <package id="Microsoft.Build.Utilities.Core" version="15.6.82" />
     <package id="Microsoft.Net.Compilers" version="2.9.0" />
     <package id="Microsoft.DotNet.MSBuildSdkResolver" version="2.1.401" />
     <package id="NuGet.Build.Tasks" version="4.6.1" />


### PR DESCRIPTION
This created a whole mess of problems due to NuGet.Build.Tasks requiring difference dependencies in 4.8.0. Rolling them back until we can take a look at what new dependencies are needed.

cc @rchande 