### PR TITLE
Fix OmniSharp log filtering

### DIFF
--- a/src/OmniSharp.Abstractions/Logging/BaseLogger.cs
+++ b/src/OmniSharp.Abstractions/Logging/BaseLogger.cs
@@ -89,11 +89,6 @@ namespace OmniSharp.Logging
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            if (!IsEnabled(logLevel))
-            {
-                return;
-            }
-
             var messageText = formatter(state, exception);
             if (!string.IsNullOrEmpty(messageText) || exception != null)
             {
@@ -102,10 +97,7 @@ namespace OmniSharp.Logging
             }
         }
 
-        public bool IsEnabled(LogLevel logLevel) =>
-            _filter != null
-                ? _filter(this.CategoryName, logLevel)
-                : true;
+        public bool IsEnabled(LogLevel logLevel) => true;
 
         public IDisposable BeginScope<TState>(TState state) => new NoopDisposable();
 

--- a/src/OmniSharp.Host/CompositionHostBuilder.cs
+++ b/src/OmniSharp.Host/CompositionHostBuilder.cs
@@ -147,7 +147,7 @@ namespace OmniSharp
                         !category.Equals(workspaceInformationServiceName, StringComparison.OrdinalIgnoreCase) &&
                         !category.Equals(projectEventForwarder, StringComparison.OrdinalIgnoreCase));
 
-                configureLogging(builder);
+                configureLogging?.Invoke(builder);
             });
 
             return services.BuildServiceProvider();

--- a/src/OmniSharp.Host/CompositionHostBuilder.cs
+++ b/src/OmniSharp.Host/CompositionHostBuilder.cs
@@ -106,7 +106,12 @@ namespace OmniSharp
             }
         }
 
-        public static IServiceProvider CreateDefaultServiceProvider(IOmniSharpEnvironment environment, IConfigurationRoot configuration, IEventEmitter eventEmitter, IServiceCollection services = null)
+        public static IServiceProvider CreateDefaultServiceProvider(
+            IOmniSharpEnvironment environment,
+            IConfigurationRoot configuration,
+            IEventEmitter eventEmitter,
+            IServiceCollection services = null,
+            Action<ILoggingBuilder> configureLogging = null)
         {
             services = services ?? new ServiceCollection();
 
@@ -130,7 +135,20 @@ namespace OmniSharp
             services.Configure<OmniSharpOptions>(configuration);
             services.AddSingleton(configuration);
 
-            services.AddLogging();
+            services.AddLogging(builder =>
+            {
+                var workspaceInformationServiceName = typeof(WorkspaceInformationService).FullName;
+                var projectEventForwarder = typeof(ProjectEventForwarder).FullName;
+
+                builder.AddFilter(
+                    (category, logLevel) =>
+                        environment.LogLevel <= logLevel &&
+                        category.StartsWith("OmniSharp", StringComparison.OrdinalIgnoreCase) &&
+                        !category.Equals(workspaceInformationServiceName, StringComparison.OrdinalIgnoreCase) &&
+                        !category.Equals(projectEventForwarder, StringComparison.OrdinalIgnoreCase));
+
+                configureLogging(builder);
+            });
 
             return services.BuildServiceProvider();
         }

--- a/src/OmniSharp.Host/HostHelpers.cs
+++ b/src/OmniSharp.Host/HostHelpers.cs
@@ -7,31 +7,6 @@ namespace OmniSharp
 {
     public class HostHelpers
     {
-        public static bool LogFilter(string category, LogLevel level, IOmniSharpEnvironment environment)
-        {
-            if (environment.LogLevel > level)
-            {
-                return false;
-            }
-
-            if (!category.StartsWith("OmniSharp", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            if (string.Equals(category, typeof(WorkspaceInformationService).FullName, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            if (string.Equals(category, typeof(ProjectEventForwarder).FullName, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            return true;
-        }
-
         public static int Start(Func<int> action)
         {
             try

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerLoggerFactory.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerLoggerFactory.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using OmniSharp.Extensions.LanguageServer;
 using OmniSharp.LanguageServerProtocol.Logging;
+using OmniSharp.Roslyn;
 using OmniSharp.Services;
 
 namespace OmniSharp.LanguageServerProtocol
@@ -21,7 +22,7 @@ namespace OmniSharp.LanguageServerProtocol
             if (environment.LogLevel <= LogLevel.Debug)
                 _provider.SetProvider(server, (category, level) => true);
             else
-                _provider.SetProvider(server, (category, level) => HostHelpers.LogFilter(category, level, environment));
+                _provider.SetProvider(server, (category, level) => LogFilter(category, level, environment));
         }
 
         public ILogger CreateLogger(string categoryName)
@@ -32,6 +33,31 @@ namespace OmniSharp.LanguageServerProtocol
         public void Dispose()
         {
             throw new NotImplementedException();
+        }
+
+        private static bool LogFilter(string category, LogLevel level, IOmniSharpEnvironment environment)
+        {
+            if (environment.LogLevel > level)
+            {
+                return false;
+            }
+
+            if (!category.StartsWith("OmniSharp", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (string.Equals(category, typeof(WorkspaceInformationService).FullName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (string.Equals(category, typeof(ProjectEventForwarder).FullName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/src/OmniSharp.Stdio.Driver/Program.cs
+++ b/src/OmniSharp.Stdio.Driver/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using OmniSharp.LanguageServerProtocol;
 using OmniSharp.Services;
 using OmniSharp.Stdio.Eventing;
+using OmniSharp.Stdio.Logging;
 
 namespace OmniSharp.Stdio.Driver
 {
@@ -50,11 +51,14 @@ namespace OmniSharp.Stdio.Driver
                     Configuration.ZeroBasedIndices = application.ZeroBasedIndices;
                     var configuration = new ConfigurationBuilder(environment).Build();
                     var writer = new SharedTextWriter(output);
-                    var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(environment, configuration, new StdioEventEmitter(writer));
+                    var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(environment, configuration, new StdioEventEmitter(writer),
+                        configureLogging: builder => builder.AddStdio(writer));
+
                     var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+                    var assemblyLoader = serviceProvider.GetRequiredService<IAssemblyLoader>();
+
                     var plugins = application.CreatePluginAssemblies();
 
-                    var assemblyLoader = serviceProvider.GetRequiredService<IAssemblyLoader>();
                     var compositionHostBuilder = new CompositionHostBuilder(serviceProvider)
                         .WithOmniSharpAssemblies()
                         .WithAssemblies(assemblyLoader.LoadByAssemblyNameOrPath(plugins.AssemblyNames).ToArray());

--- a/src/OmniSharp.Stdio/Host.cs
+++ b/src/OmniSharp.Stdio/Host.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -15,7 +14,6 @@ using OmniSharp.Mef;
 using OmniSharp.Models.UpdateBuffer;
 using OmniSharp.Plugins;
 using OmniSharp.Services;
-using OmniSharp.Stdio.Logging;
 using OmniSharp.Stdio.Protocol;
 using OmniSharp.Stdio.Services;
 using OmniSharp.Utilities;
@@ -29,7 +27,6 @@ namespace OmniSharp.Stdio
         private readonly IServiceProvider _serviceProvider;
         private readonly IDictionary<string, Lazy<EndpointHandler>> _endpointHandlers;
         private readonly CompositionHost _compositionHost;
-        private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger _logger;
         private readonly IOmniSharpEnvironment _environment;
         private readonly CancellationTokenSource _cancellationTokenSource;
@@ -44,7 +41,6 @@ namespace OmniSharp.Stdio
             _writer = writer;
             _environment = environment;
             _serviceProvider = serviceProvider;
-            _loggerFactory = loggerFactory.AddStdio(_writer, (category, level) => HostHelpers.LogFilter(category, level, _environment));
             _logger = loggerFactory.CreateLogger<Host>();
 
             _logger.LogInformation($"Starting OmniSharp on {Platform.Current}");
@@ -128,7 +124,6 @@ namespace OmniSharp.Stdio
         public void Dispose()
         {
             _compositionHost?.Dispose();
-            _loggerFactory?.Dispose();
             _cancellationTokenSource?.Dispose();
         }
 

--- a/src/OmniSharp.Stdio/Logging/StdioLogger.cs
+++ b/src/OmniSharp.Stdio/Logging/StdioLogger.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Logging;
 using OmniSharp.Stdio.Protocol;
@@ -10,8 +9,8 @@ namespace OmniSharp.Stdio.Logging
     {
         private readonly ISharedTextWriter _writer;
 
-        public StdioLogger(ISharedTextWriter writer, string categoryName, Func<string, LogLevel, bool> filter)
-            : base(categoryName, filter, addHeader: false)
+        public StdioLogger(ISharedTextWriter writer, string categoryName)
+            : base(categoryName, addHeader: false)
         {
             _writer = writer;
         }

--- a/src/OmniSharp.Stdio/Logging/StdioLoggerExtensions.cs
+++ b/src/OmniSharp.Stdio/Logging/StdioLoggerExtensions.cs
@@ -1,15 +1,14 @@
-﻿using System;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using OmniSharp.Stdio.Services;
 
 namespace OmniSharp.Stdio.Logging
 {
     static class StdioLoggerExtensions
     {
-        public static ILoggerFactory AddStdio(this ILoggerFactory factory, ISharedTextWriter writer, Func<string, LogLevel, bool> filter)
+        public static ILoggingBuilder AddStdio(this ILoggingBuilder builder, ISharedTextWriter writer)
         {
-            factory.AddProvider(new StdioLoggerProvider(writer, filter));
-            return factory;
+            builder.AddProvider(new StdioLoggerProvider(writer));
+            return builder;
         }
     }
 }

--- a/src/OmniSharp.Stdio/Logging/StdioLoggerProvider.cs
+++ b/src/OmniSharp.Stdio/Logging/StdioLoggerProvider.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Stdio.Services;
 
@@ -6,18 +5,16 @@ namespace OmniSharp.Stdio.Logging
 {
     class StdioLoggerProvider : ILoggerProvider
     {
-        private readonly Func<string, LogLevel, bool> _filter;
         private readonly ISharedTextWriter _writer;
 
-        public StdioLoggerProvider(ISharedTextWriter writer, Func<string, LogLevel, bool> filter)
+        public StdioLoggerProvider(ISharedTextWriter writer)
         {
             _writer = writer;
-            _filter = filter;
         }
 
         public ILogger CreateLogger(string name)
         {
-            return new StdioLogger(_writer, name, _filter);
+            return new StdioLogger(_writer, name);
         }
 
         public void Dispose() { }

--- a/tests/OmniSharp.Tests/LoggingTests.cs
+++ b/tests/OmniSharp.Tests/LoggingTests.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Eventing;
+using OmniSharp.Services;
+using Xunit;
+
+namespace OmniSharp.Tests
+{
+    using ConfigurationBuilder = Microsoft.Extensions.Configuration.ConfigurationBuilder;
+
+    public class LoggingTests
+    {
+        private class FakeLoggerProvider : ILoggerProvider
+        {
+            private readonly IDictionary<LogLevel, List<string>> _logMessages;
+
+            public FakeLoggerProvider(IDictionary<LogLevel, List<string>> logMessages) => _logMessages = logMessages;
+
+            public ILogger CreateLogger(string categoryName) => new FakeLogger(_logMessages);
+            public void Dispose() { }
+        }
+
+        private class FakeLogger : ILogger
+        {
+            private readonly IDictionary<LogLevel, List<string>> _logMessages;
+
+            public FakeLogger(IDictionary<LogLevel, List<string>> logMessages) => _logMessages = logMessages;
+
+            public IDisposable BeginScope<TState>(TState state) => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                if (!_logMessages.TryGetValue(logLevel, out var messages))
+                {
+                    messages = new List<string>();
+                    _logMessages.Add(logLevel, messages);
+                }
+
+                messages.Add(formatter(state, exception));
+            }
+        }
+
+        private static (ILogger, IDictionary<LogLevel, List<string>>) CreateLogger(LogLevel logLevel)
+        {
+            var environment = new OmniSharpEnvironment(logLevel: logLevel);
+            var configuration = new ConfigurationBuilder().Build();
+            var logMessages = new Dictionary<LogLevel, List<string>>();
+
+            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(environment, configuration, NullEventEmitter.Instance,
+                configureLogging: builder =>
+                {
+                    builder.AddProvider(new FakeLoggerProvider(logMessages));
+                });
+
+            var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger<LoggingTests>();
+
+            return (logger, logMessages);
+        }
+
+        [Fact]
+        public void TestDebugLogLevel()
+        {
+            var (logger, logMessages) = CreateLogger(LogLevel.Debug);
+
+            logger.LogDebug("TestDebug");
+            logger.LogTrace("TestTrace");
+
+            Assert.Single(logMessages);
+            Assert.True(logMessages.ContainsKey(LogLevel.Debug));
+            Assert.False(logMessages.ContainsKey(LogLevel.Trace));
+        }
+
+        [Fact]
+        public void TestInfoLogLevel()
+        {
+            var (logger, logMessages) = CreateLogger(LogLevel.Information);
+
+            logger.LogInformation("TestInformation");
+            logger.LogDebug("TestDebug");
+            logger.LogTrace("TestTrace");
+
+            Assert.Single(logMessages);
+            Assert.True(logMessages.ContainsKey(LogLevel.Information));
+            Assert.False(logMessages.ContainsKey(LogLevel.Debug));
+            Assert.False(logMessages.ContainsKey(LogLevel.Trace));
+        }
+
+        [Fact]
+        public void TestTraceLogLevel()
+        {
+            var (logger, logMessages) = CreateLogger(LogLevel.Trace);
+
+            logger.LogInformation("TestInformation");
+            logger.LogDebug("TestDebug");
+            logger.LogTrace("TestTrace");
+
+            Assert.Equal(3, logMessages.Count);
+            Assert.True(logMessages.ContainsKey(LogLevel.Information));
+            Assert.True(logMessages.ContainsKey(LogLevel.Debug));
+            Assert.True(logMessages.ContainsKey(LogLevel.Trace));
+        }
+    }
+}


### PR DESCRIPTION
When the logging packages were updated from 1.1 to 2.1, we took a breaking change (https://github.com/aspnet/Announcements/issues/238) that caused the `--loglevel` switch to no longer work properly. So, passing `--loglevel debug` doesn't do anything.

This change uses the new APIs for configuring logging and centralizes the filter. Note that I didn't change the LSP implementation because it looks to me like LSP is using loggers differently.