### PR TITLE
Fixed issue with "go to implementation" and symbol overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to the project will be documented in this file.
 
 ## [1.33.0] - Not yet released
 * Fixed issue where `/codestructure` endpoint did not return enum members. (PR: [#1285](https://github.com/OmniSharp/omnisharp-roslyn/pull/1285))
+* Fixed issue where `/findimplemenations` endpoint did not return overridden members in derived types (PR: [#1302](https://github.com/OmniSharp/omnisharp-roslyn/pull/1302))
 
 ## [1.32.3] - 2018-08-28
 * Added support for files without a project. (PR: [#1252](https://github.com/OmniSharp/omnisharp-roslyn/pull/1252))

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/QuickFixExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/QuickFixExtensions.cs
@@ -6,14 +6,11 @@ namespace OmniSharp.Helpers
 {
     internal static class QuickFixExtensions
     {
-        internal static void AddRange(this ICollection<QuickFix> quickFixes, IEnumerable<ISymbol> symbols, OmniSharpWorkspace workspace)
+        internal static void Add(this ICollection<QuickFix> quickFixes, ISymbol symbol, OmniSharpWorkspace workspace)
         {
-            foreach (var symbol in symbols)
+            foreach (var location in symbol.Locations)
             {
-                foreach (var location in symbol.Locations)
-                {
-                    quickFixes.Add(location, workspace);
-                }
+                quickFixes.Add(location, workspace);
             }
         }
 
@@ -23,6 +20,17 @@ namespace OmniSharp.Helpers
             {
                 var quickFix = location.GetQuickFix(workspace);
                 quickFixes.Add(quickFix);
+            }
+        }
+
+        internal static void AddRange(this ICollection<QuickFix> quickFixes, IEnumerable<ISymbol> symbols, OmniSharpWorkspace workspace)
+        {
+            foreach (var symbol in symbols)
+            {
+                foreach (var location in symbol.Locations)
+                {
+                    quickFixes.Add(location, workspace);
+                }
             }
         }
     }

--- a/src/OmniSharp.Roslyn/Extensions/SymbolExtensions.cs
+++ b/src/OmniSharp.Roslyn/Extensions/SymbolExtensions.cs
@@ -175,6 +175,8 @@ namespace OmniSharp.Extensions
                 : SymbolKinds.Property;
         }
 
+        public static bool IsOverridable(this ISymbol symbol) => symbol?.ContainingType?.TypeKind == TypeKind.Class && !symbol.IsSealed && (symbol.IsVirtual || symbol.IsAbstract || symbol.IsOverride);
+
         /// <summary>
         /// Do not use this API in new OmniSharp endpoints. Use <see cref="GetKindString(ISymbol)"/> instead.
         /// </summary>

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
@@ -58,6 +58,27 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         [Theory]
         [InlineData("dummy.cs")]
         [InlineData("dummy.csx")]
+        public async Task CanFindInterfaceMethodOverride(string filename)
+        {
+            const string code = @"
+                public interface SomeInterface { void Some$$Method(); }
+                public class SomeClass : SomeInterface {
+                    public virtual void SomeMethod() {}
+                }
+                public class SomeChildClass : SomeClass {
+                    public override void SomeMethod() {}
+                }";
+
+            var implementations = await FindImplementationsAsync(code, filename);
+
+            Assert.Equal(2, implementations.Count());
+            Assert.True(implementations.Any(x => x.ContainingType.Name == "SomeClass" && x.Name == "SomeMethod"), "Couldn't find SomeClass.SomeMethod in the discovered implementations");
+            Assert.True(implementations.Any(x => x.ContainingType.Name == "SomeChildClass" && x.Name == "SomeMethod"), "Couldn't find SomeChildClass.SomeMethod in the discovered implementations");
+        }
+
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
         public async Task CanFindOverride(string filename)
         {
             const string code = @"


### PR DESCRIPTION
This PR fixes the issue where "find implementation" OmniSharp would not find symbol overrides in child types. We were missing the look up of overrides on the symbols returned from `SymbolFinder.FindImplementationsAsync`.

Consider the following:

```csharp
    interface IFoo
    {
        string Hi();
    }

    public class Bar : IFoo
    {
        public virtual string Hi() => "hi";
    }

    public class Baz : Bar
    {
        public override string Hi() => "hello";
    }
```

In Visual Studio, trying to go to implementation of `Hi()`, from the interface declaration, would find both `Bar.Hi()` and `Baz.Hi()`. However, OmniSharp would find only `Bar.Hi()`.

This is with the fix applied:

<img width="1322" alt="screenshot 2018-09-25 19 38 17" src="https://user-images.githubusercontent.com/1710369/46032272-6fcf9700-c0fb-11e8-8098-050f02208212.png">
