### PR TITLE
Use FindSourceDeclarationsWithPatternAsync to have nice fuzzy search

### DIFF
--- a/src/OmniSharp.Cake/Services/RequestHandlers/Navigation/FindSymbolsHandler.cs
+++ b/src/OmniSharp.Cake/Services/RequestHandlers/Navigation/FindSymbolsHandler.cs
@@ -26,13 +26,8 @@ namespace OmniSharp.Cake.Services.RequestHandlers.Navigation
                 return Task.FromResult(new QuickFixResponse { QuickFixes = Array.Empty<QuickFix>() });
             }
 
-            Func<string, bool> isMatch =
-                candidate => request != null
-                ? candidate.IsValidCompletionFor(request.Filter)
-                : true;
-
             int maxItemsToReturn = (request?.MaxItemsToReturn).GetValueOrDefault();
-            return Workspace.CurrentSolution.FindSymbols(isMatch, LanguageNames.Cake, maxItemsToReturn);
+            return Workspace.CurrentSolution.FindSymbols(request?.Filter, LanguageNames.Cake, maxItemsToReturn);
         }
 
         protected override Task<QuickFixResponse> TranslateResponse(QuickFixResponse response, FindSymbolsRequest request)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindSymbolsService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindSymbolsService.cs
@@ -28,14 +28,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                 return new QuickFixResponse { QuickFixes = Array.Empty<QuickFix>() };
             }
 
-            Func<string, bool> isMatch =
-                candidate => request != null
-                ? candidate.IsValidCompletionFor(request.Filter)
-                : true;
-
             int maxItemsToReturn = (request?.MaxItemsToReturn).GetValueOrDefault();
-            var csprojSymbols = await _workspace.CurrentSolution.FindSymbols(isMatch, ".csproj", maxItemsToReturn);
-            var projectJsonSymbols = await _workspace.CurrentSolution.FindSymbols(isMatch, ".json", maxItemsToReturn);
+            var csprojSymbols = await _workspace.CurrentSolution.FindSymbols(request?.Filter, ".csproj", maxItemsToReturn);
+            var projectJsonSymbols = await _workspace.CurrentSolution.FindSymbols(request?.Filter, ".json", maxItemsToReturn);
             return new QuickFixResponse()
             {
                 QuickFixes = csprojSymbols.QuickFixes.Concat(projectJsonSymbols.QuickFixes)

--- a/src/OmniSharp.Roslyn/Extensions/SolutionExtensions.cs
+++ b/src/OmniSharp.Roslyn/Extensions/SolutionExtensions.cs
@@ -11,7 +11,7 @@ namespace OmniSharp.Extensions
     public static class SolutionExtensions
     {
         public static async Task<QuickFixResponse> FindSymbols(this Solution solution,
-            Func<string, bool> predicate,
+            string pattern,
             string projectFileExtension,
             int maxItemsToReturn)
         {
@@ -23,7 +23,9 @@ namespace OmniSharp.Extensions
 
             foreach (var project in projects)
             {
-                var symbols = await SymbolFinder.FindSourceDeclarationsAsync(project, predicate, SymbolFilter.TypeAndMember);
+                var symbols = !string.IsNullOrEmpty(pattern) ?
+                    await SymbolFinder.FindSourceDeclarationsWithPatternAsync(project, pattern, SymbolFilter.TypeAndMember) :
+                    await SymbolFinder.FindSourceDeclarationsAsync(project, candidate => true, SymbolFilter.TypeAndMember);
 
                 foreach (var symbol in symbols)
                 {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindSymbolsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindSymbolsFacts.cs
@@ -285,6 +285,24 @@ public partial class MyClass
             Assert.Equal(2, symbols.Count());
         }
 
+        [Fact]
+        public async Task fuzzy_search()
+        {
+            const string code = @"
+                namespace Some.Namespace
+                {
+                    public class ProjectManager {}
+                    public class CoolProjectManager {}
+                    public class ProbabilityManager {}
+                }";
+
+            var usages = await FindSymbolsWithFilterAsync(code, "ProjMana", minFilterLength: 0, maxItemsToReturn: 0);
+            var symbols = usages.QuickFixes.Select(q => q.Text);
+            Assert.Contains("ProjectManager", symbols);
+            Assert.Contains("CoolProjectManager", symbols);
+            Assert.DoesNotContain("ProbabilityManager", symbols);
+        }
+
         private async Task<QuickFixResponse> FindSymbolsAsync(string code)
         {
             var testFile = new TestFile("dummy.cs", code);


### PR DESCRIPTION
I've noticed symbol search seems much less powerful than VS's one, which always seems to return nice fuzzy searches. 

o# uses "SymbolFinder.FindSourceDeclarationsAsync" with a custom matching algorithm passed in, while there is "SymbolFinder.FindSourceDeclarationsWithPatternAsync", which seems to the right thing when the search filter is passed in. 

After this change "#ProjMana" is able to find **Proj**ect**Mana**ger

So far it works as I expected, but somebody who know this API better should check if this makes sense. 

btw, when request.filter is not specified, full symbol list should be returned, which used to be done with (x => true). It seems funny, but I couldn't find a better way.