### PR TITLE
Promote misc documents to projects after project load.

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -353,6 +353,7 @@ namespace OmniSharp.MSBuild
                 return;
             }
 
+            _workspace.TryPromoteMiscellaneousDocumentsToProject(project);
             UpdateSourceFiles(project, projectFileInfo.SourceFiles);
             UpdateParseOptions(project, projectFileInfo.LanguageVersion, projectFileInfo.PreprocessorSymbolNames, !string.IsNullOrWhiteSpace(projectFileInfo.DocumentationFile));
             UpdateProjectReferences(project, projectFileInfo.ProjectReferences);

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
@@ -113,6 +114,39 @@ namespace OmniSharp
             return true;
         }
 
+        public void TryPromoteMiscellaneousDocumentsToProject(Project project)
+        {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            var miscProjectInfos = miscDocumentsProjectInfos.Values.ToArray();
+            for (var i = 0; i < miscProjectInfos.Length; i++)
+            {
+                var miscProject = CurrentSolution.GetProject(miscProjectInfos[i].Id);
+                var documents = miscProject.Documents.ToArray();
+
+                for (var j = 0; j < documents.Length; j++)
+                {
+                    var document = documents[j];
+                    if (FileBelongsToProject(document.FilePath, project))
+                    {
+                        var textLoader = new DelegatingTextLoader(document);
+                        var documentId = DocumentId.CreateNewId(project.Id);
+                        var documentInfo = DocumentInfo.Create(
+                            documentId,
+                            document.FilePath,
+                            filePath: document.FilePath,
+                            loader: textLoader);
+
+                        // This transitively will remove the document from the misc project.
+                        AddDocument(documentInfo);
+                    }
+                }
+            }
+        }
+
         private ProjectInfo CreateMiscFilesProject(string language)
         {
             string assemblyName = Guid.NewGuid().ToString("N");
@@ -202,6 +236,31 @@ namespace OmniSharp
             return true;
         }
 
+        internal bool FileBelongsToProject(string fileName, Project project)
+        {
+            if (string.IsNullOrWhiteSpace(project.FilePath) ||
+                string.IsNullOrWhiteSpace(fileName))
+            {
+                return false;
+            }
+
+            var fileDirectory = new FileInfo(fileName).Directory;
+            var projectPath = project.FilePath;
+            var projectDirectory = new FileInfo(projectPath).Directory.FullName;
+
+            while (fileDirectory != null)
+            {
+                if (string.Equals(fileDirectory.FullName, projectDirectory, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                fileDirectory = fileDirectory.Parent;
+            }
+
+            return false;
+        }
+
         protected override void ApplyDocumentRemoved(DocumentId documentId)
         {
             var document = this.CurrentSolution.GetDocument(documentId);
@@ -279,6 +338,28 @@ namespace OmniSharp
         private bool IsMiscellaneousDocument(DocumentId documentId)
         {
             return miscDocumentsProjectInfos.Where(p => p.Value.Id == documentId.ProjectId).Any();
+        }
+
+        private class DelegatingTextLoader : TextLoader
+        {
+            private readonly Document _fromDocument;
+
+            public DelegatingTextLoader(Document fromDocument)
+            {
+                _fromDocument = fromDocument ?? throw new ArgumentNullException(nameof(fromDocument));
+            }
+
+            public override async Task<TextAndVersion> LoadTextAndVersionAsync(
+                Workspace workspace,
+                DocumentId documentId,
+                CancellationToken cancellationToken)
+            {
+                var sourceText = await _fromDocument.GetTextAsync();
+                var version = await _fromDocument.GetTextVersionAsync();
+                var textAndVersion = TextAndVersion.Create(sourceText, version);
+
+                return textAndVersion;
+            }
         }
     }
 }

--- a/src/OmniSharp.Roslyn/Properties/AssemblyInfo.cs
+++ b/src/OmniSharp.Roslyn/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OmniSharp.Roslyn.CSharp.Tests")]
+

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/OmniSharpWorkspaceFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/OmniSharpWorkspaceFacts.cs
@@ -1,0 +1,145 @@
+﻿using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using OmniSharp.FileWatching;
+using OmniSharp.Services;
+using Xunit;
+
+namespace OmniSharp.Roslyn.CSharp.Tests
+{
+    public class OmniSharpWorkspaceFacts
+    {
+        public OmniSharpWorkspaceFacts()
+        {
+            Workspace = new OmniSharpWorkspace(
+                new HostServicesAggregator(
+                    Enumerable.Empty<IHostServicesProvider>(),
+                    new LoggerFactory()),
+                new LoggerFactory(), new ManualFileSystemWatcher());
+        }
+
+        public OmniSharpWorkspace Workspace { get; }
+
+        [Fact]
+        public void TryPromoteMiscellaneousDocumentsToProject_RelatedProject_PromotesAllDocuments()
+        {
+            // Arrange
+            var project = AddProjectToWorkspace("/path/to/project.csproj");
+            Workspace.TryAddMiscellaneousDocument("/path/to/file1.cs", LanguageNames.CSharp);
+            Workspace.TryAddMiscellaneousDocument("/path/to/file2.cs", LanguageNames.CSharp);
+
+            // Act
+            Workspace.TryPromoteMiscellaneousDocumentsToProject(project);
+
+            // Assert
+            project = Workspace.CurrentSolution.GetProject(project.Id);
+            Assert.Collection(
+                project.Documents,
+                document => Assert.Equal("/path/to/file1.cs", document.FilePath),
+                document => Assert.Equal("/path/to/file2.cs", document.FilePath));
+
+            var miscProject = Assert.Single(Workspace.CurrentSolution.Projects.Except(new[] { project }));
+            Assert.Empty(miscProject.DocumentIds);
+        }
+
+        [Fact]
+        public void TryPromoteMiscellaneousDocumentsToProject_UnrelatedProject_Noops()
+        {
+            // Arrange
+            var project = AddProjectToWorkspace("/path/to/project.csproj");
+            var expectedDocumentId = Workspace.TryAddMiscellaneousDocument("/misc/file.cs", LanguageNames.CSharp);
+
+            // Act
+            Workspace.TryPromoteMiscellaneousDocumentsToProject(project);
+
+            // Assert
+            project = Workspace.CurrentSolution.GetProject(project.Id);
+            Assert.Empty(project.DocumentIds);
+            var miscProject = Assert.Single(Workspace.CurrentSolution.Projects.Except(new[] { project }));
+            var document = Assert.Single(miscProject.DocumentIds);
+            Assert.Equal(expectedDocumentId.Id, document.Id);
+        }
+
+        [Fact]
+        public void FileBelongsToProject_EmptyProjectFilePath_ReturnsFalse()
+        {
+            // Arrange
+            var project = AddProjectToWorkspace(filePath: string.Empty);
+
+            // Act
+            var result = Workspace.FileBelongsToProject("/path/to/file.cs", project);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void FileBelongsToProject_EmptyFilePath_ReturnsFalse()
+        {
+            // Arrange
+            var project = AddProjectToWorkspace(filePath: "/path/to/project.csproj");
+
+            // Act
+            var result = Workspace.FileBelongsToProject(string.Empty, project);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void FileBelongsToProject_UnrelatedFile_ReturnsFalse()
+        {
+            // Arrange
+            var project = AddProjectToWorkspace(filePath: "/path/to/project.csproj");
+            var filePath = "/different/path/file.cs";
+
+            // Act
+            var result = Workspace.FileBelongsToProject(filePath, project);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void FileBelongsToProject_Sibling_ReturnsTrue()
+        {
+            // Arrange
+            var project = AddProjectToWorkspace(filePath: "/path/to/project.csproj");
+            var filePath = "/path/to/file.cs";
+
+            // Act
+            var result = Workspace.FileBelongsToProject(filePath, project);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void FileBelongsToProject_Descendant_ReturnsTrue()
+        {
+            // Arrange
+            var project = AddProjectToWorkspace(filePath: "/path/to/project.csproj");
+            var filePath = "/path/to/folder/file.cs";
+
+            // Act
+            var result = Workspace.FileBelongsToProject(filePath, project);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        private Project AddProjectToWorkspace(string filePath)
+        {
+            var projectInfo = ProjectInfo.Create(
+                ProjectId.CreateNewId(),
+                VersionStamp.Create(),
+                "ProjectNameVal",
+                "AssemblyNameVal",
+                LanguageNames.CSharp,
+                filePath);
+            Workspace.AddProject(projectInfo);
+            var project = Workspace.CurrentSolution.GetProject(projectInfo.Id);
+            return project;
+        }
+    }
+}


### PR DESCRIPTION
- Once a project has loaded we now evaluate all miscellaneous documents and try to lift them into the loaded project. This ensures that any document in the system gets properly promoted into a project once a project has been loaded. Before this virtual C# documents would not get promoted into a proper project because they didn't exist as part of the projects MSBuild compile items (which usually forces the promotion).
- Added tests to verify the two methods I added to OmnisharpWorkspaceFacts

aspnet/Razor.VSCode#148

@DustinCampbell @rchande 