### PR TITLE
allow setting a custom OmniSharp home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.32.7] - not yet released
+* It's now possible to override the default location of OmniSharp's global folder (%USERPROFILE%\.omnisharp or ~/.omnisharp.) with an OMNISHARPHOME environment variable (PR: [#1317](https://github.com/OmniSharp/omnisharp-roslyn/pull/1317)) 
+
 ## [1.32.6] - 2018-10-02
 * Fixed a bug where virtual C# documents would not get promoted to be a part of a project. (PR: [#1306](https://github.com/OmniSharp/omnisharp-roslyn/pull/1306)).
 * Added MinFilterLength to configure the number of characters a user must type in for FindSymbolRequest command to return any results (default is 0 to preserve existing behavior). Additionally added MaxItemsToReturn for configuring maximum number of items returned by the FindSymbolsRequestAPI.(PR: [#1284](https://github.com/OmniSharp/omnisharp-roslyn/pull/1284)).

--- a/src/OmniSharp.Host/Services/OmniSharpEnvironment.cs
+++ b/src/OmniSharp.Host/Services/OmniSharpEnvironment.cs
@@ -8,12 +8,9 @@ namespace OmniSharp.Services
     {
         public string TargetDirectory { get; }
         public string SharedDirectory { get; }
-
         public string SolutionFilePath { get; }
-
         public int HostProcessId { get; }
         public LogLevel LogLevel { get; }
-
         public string[] AdditionalArguments { get; }
 
         public OmniSharpEnvironment(
@@ -45,9 +42,11 @@ namespace OmniSharp.Services
             LogLevel = logLevel;
             AdditionalArguments = additionalArguments;
 
+            // First look at OMNISHARPHOME to allow users to set custom location, then
             // On Windows: %USERPROFILE%\.omnisharp\omnisharp.json
             // On Mac/Linux: ~/.omnisharp/omnisharp.json
             var root =
+                Environment.GetEnvironmentVariable("OMNISHARPHOME") ??
                 Environment.GetEnvironmentVariable("USERPROFILE") ??
                 Environment.GetEnvironmentVariable("HOME");
 


### PR DESCRIPTION
At the moment, OmniSharp home directory is in user profile - `%USERPROFILE%\.omnisharp` or ` ~/.omnisharp`.
This PR introduces an `OMNISHARPHOME` environment variable which can be used to set a custom "home" path.

I mentioned this a while ago https://github.com/OmniSharp/omnisharp-roslyn/issues/953#issuecomment-325577768 and this should be enough to close that issue from OmniSharp server perspective (the remaining aspects are related to VS Code extension).