### PR TITLE
Fix FindImplementationService not finding all implementations of the partial class

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Helpers/QuickFixExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/QuickFixExtensions.cs
@@ -10,10 +10,15 @@ namespace OmniSharp.Helpers
         {
             foreach (var symbol in symbols)
             {
-                foreach (var location in symbol.Locations)
-                {
-                    quickFixes.Add(location, workspace);
-                }
+                quickFixes.Add(symbol, workspace);
+            }
+        }
+
+        internal static void Add(this ICollection<QuickFix> quickFixes, ISymbol symbol, OmniSharpWorkspace workspace)
+        {
+            foreach (var location in symbol.Locations)
+            {
+                quickFixes.Add(location, workspace);
             }
         }
 

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindImplementationsService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindImplementationsService.cs
@@ -53,13 +53,15 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                 if (!symbol.IsAbstract)
                 {
                     // for partial methods, pick the one with body
-                    if (symbol is IMethodSymbol method)
+                    if (symbol is IMethodSymbol method && method.PartialImplementationPart != null)
                     {
-                        symbol = method.PartialImplementationPart ?? symbol;
+                        var implementationPart = method.Locations.First();
+                        quickFixes.Add(implementationPart, _workspace);
                     }
-
-                    var location = symbol.Locations.First();
-                    quickFixes.Add(location, _workspace);
+                    else
+                    {
+                        quickFixes.Add(symbol, _workspace);
+                    }
                 }
 
                 response = new QuickFixResponse(quickFixes.OrderBy(q => q.FileName)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindImplementationsService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindImplementationsService.cs
@@ -71,8 +71,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                     // for partial methods, pick the one with body
                     if (symbol is IMethodSymbol method && method.PartialImplementationPart != null)
                     {
-                        var implementationPart = method.Locations.First();
-                        quickFixes.Add(implementationPart, _workspace);
+                        quickFixes.Add(method.PartialImplementationPart, _workspace);
                     }
                     else
                     {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
@@ -152,7 +152,6 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             Assert.Equal(SymbolKind.Method, implementation.Kind);
         }
 
-
         [Theory]
         [InlineData("dummy.cs")]
         [InlineData("dummy.csx")]

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
@@ -95,13 +95,13 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         public async Task CanFindTypeDeclaration(string filename)
         {
             const string code = @"
-                public class MyClass 
-                { 
+                public class MyClass
+                {
                     public MyClass() { var other = new Other$$Class(); }
                 }
 
-                public class OtherClass 
-                { 
+                public class OtherClass
+                {
                 }";
 
             var implementations = await FindImplementationsAsync(code, filename);
@@ -116,8 +116,8 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         public async Task CanFindMethodDeclaration(string filename)
         {
             const string code = @"
-                public class MyClass 
-                { 
+                public class MyClass
+                {
                     public MyClass() { Fo$$o(); }
 
                     public void Foo() {}
@@ -129,6 +129,39 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             Assert.Equal("Foo", implementation.Name);
             Assert.Equal("MyClass", implementation.ContainingType.Name);
             Assert.Equal(SymbolKind.Method, implementation.Kind);
+        }
+
+
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task CanFindPartialClass(string filename)
+        {
+            const string code = @"
+                public partial class Some$$Class { void SomeMethod() {} }
+                public partial class SomeClass { void AnotherMethod() {} }";
+
+            var implementations = await FindImplementationsAsync(code, filename);
+
+            Assert.Equal(2, implementations.Count());
+            Assert.True(implementations.All(x => x.Name == "SomeClass"));
+        }
+
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task CanFindPartialMethod(string filename)
+        {
+            const string code = @"
+                public partial class SomeClass { partial void Some$$Method(); }
+                public partial class SomeClass { partial void SomeMethod() { /* this is implementation of the partial method */ }";
+
+            var implementations = await FindImplementationsAsync(code, filename);
+
+            Assert.Single(implementations);
+
+            var implementation = implementations.First();
+            Assert.Equal("SomeMethod", implementation.Name);
         }
 
         private async Task<IEnumerable<ISymbol>> FindImplementationsAsync(string code, string filename)

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindImplementationFacts.cs
@@ -174,7 +174,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         {
             const string code = @"
                 public partial class SomeClass { partial void Some$$Method(); }
-                public partial class SomeClass { partial void SomeMethod() { /* this is implementation of the partial method */ }";
+                public partial class SomeClass { partial void SomeMethod() { /* this is implementation of the partial method */ } }";
 
             var implementations = await FindImplementationsAsync(code, filename);
 
@@ -182,6 +182,9 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
             var implementation = implementations.First();
             Assert.Equal("SomeMethod", implementation.Name);
+
+            // Assert that the actual implementation part is returned.
+            Assert.True(implementation is IMethodSymbol method && method.PartialDefinitionPart != null && method.PartialImplementationPart == null);
         }
 
         private async Task<IEnumerable<ISymbol>> FindImplementationsAsync(string code, string filename)


### PR DESCRIPTION
Currently, when you use "Find Implementations" on a partial class, it appears to randomly select one of the definitions instead of returning all of them (like VS does). Looks like this was unintentionally broken in order to handle partialMethod case (guess there is makes sense to take symbol.Locations.First() instead of symbol.Locations).

Should be easy to merge with @filipw fix for separate bug fix in the same service. 



