### PR TITLE
fix collecting unexpected solution file like 'sln*'

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -19,6 +19,7 @@ using OmniSharp.MSBuild.ProjectFile;
 using OmniSharp.MSBuild.SolutionParsing;
 using OmniSharp.Options;
 using OmniSharp.Services;
+using System.Linq;
 
 namespace OmniSharp.MSBuild
 {
@@ -176,7 +177,10 @@ namespace OmniSharp.MSBuild
 
         private static string FindSolutionFilePath(string rootPath, ILogger logger)
         {
-            var solutionsFilePaths = Directory.GetFiles(rootPath, "*.sln");
+            // currently, Directory.GetFiles collects files that the file extension has 'sln' prefix.
+            // this causes collecting unexpected files like 'x.slnx', or 'x.slnproj'.
+            // see https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=netframework-4.7.2 ('Note' description)
+            var solutionsFilePaths = Directory.GetFiles(rootPath, "*.sln").Where(x => Path.GetExtension(x).Equals(".sln", StringComparison.OrdinalIgnoreCase)).ToArray();
             var result = SolutionSelector.Pick(solutionsFilePaths, rootPath);
 
             if (result.Message != null)


### PR DESCRIPTION
# Overview

This PR fixes omnisharp crash when the directory has '*.slnxxx' file.

# Problem Detail

## Environment

* windows8.1-x64
* omnisharp-vscode: 1.16.2
* vscode: 1.28.2

## Steps to reproduce

1. create new console project in empty directory
2. create 'x.slnproj' and edit `<Project Sdk="MSBuild.SolutionSdk/0.1.0"></Project>`
    * This is [MSBuild.SolutionSdk](https://github.com/JeffCyr/MSBuild.SolutionSdk) format
3. Restart Omnisharp

## Expected behavior

Omnisharp start to watch the project folder.

## Actual Behavior

Omnisharp throw the following exception and stop to watch the project.

```The project system 'OmniSharp.MSBuild.ProjectSystem' threw exception during initialization.
OmniSharp.MSBuild.SolutionParsing.InvalidSolutionFileException: Solution header should be on first or second line.
   場所 OmniSharp.MSBuild.SolutionParsing.SolutionFile.ParseHeaderAndVersion(Scanner scanner)
   場所 OmniSharp.MSBuild.SolutionParsing.SolutionFile.Parse(String text)
   場所 OmniSharp.MSBuild.ProjectSystem.GetProjectPathsFromSolution(String solutionFilePath)
   場所 OmniSharp.MSBuild.ProjectSystem.Initalize(IConfiguration configuration)
   場所 OmniSharp.WorkspaceInitializer.Initialize(IServiceProvider serviceProvider, CompositionHost compositionHost)
```

This behavior is caused by [Directory.GetFiles specification](https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=netframework-4.7.2) (in 'Note' section)