### PR TITLE
updated the omnisharp.json file to not report CSI-specifc errors

### DIFF
--- a/omnisharp.json
+++ b/omnisharp.json
@@ -1,5 +1,9 @@
 {
     "dotnet": {
         "enabled": false
-    }
+    },
+    "script": {
+        "enableScriptNuGetReferences": true,
+        "defaultTargetFramework": "netcoreapp2.1"
+      }
 }


### PR DESCRIPTION
When working on OmniSharp code using OmniSharp (i.e. in VS Code) we have 2 errors reported from CSX filesystem about missing assembly references. This is caused by the fact that we run in "CSI" scripting mode by default, but we have CSX files that use the "dotnet-script"/.NET Core scripting mode in the source of OmniSharp (in tests). Since the "CSI" mode can't parse NuGet references used there, we report 2 diagnostics.

![](https://user-images.githubusercontent.com/2008729/46496256-74b3db00-c7cc-11e8-8bdb-b63a5b441945.png)

This has caused some confusion i.e here from @NTaylorMullen https://github.com/OmniSharp/omnisharp-roslyn/issues/1310#issuecomment-427174083
I have updated the `omnisharp.json` in OmniSharp to use "dotnet-script"/.NET Core scripting mode as the default behavior when working with OmniSharp source code.