### PR TITLE
Improve MSBuild discovery for future scenarios

### DIFF
--- a/src/OmniSharp.Host/MSBuild/Discovery/MSBuildInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/MSBuildInstanceProvider.cs
@@ -17,6 +17,35 @@ namespace OmniSharp.MSBuild.Discovery
 
         public abstract ImmutableArray<MSBuildInstance> GetInstances();
 
+        /// <summary>
+        /// Handles locating the MSBuild tools path given a base path (typically a Visual Studio install path).
+        /// </summary>
+        protected string FindMSBuildToolsPath(string basePath)
+        {
+            if (TryGetToolsPath("Current", "Bin", out var result) ||
+                TryGetToolsPath("Current", "bin", out result) ||
+                TryGetToolsPath("15.0", "Bin", out result) ||
+                TryGetToolsPath("15.0", "bin", out result))
+            {
+                return result;
+            }
+
+            Logger.LogDebug($"Could not locate MSBuild tools path within {basePath}");
+            return null;
+
+            bool TryGetToolsPath(string versionPath, string binPath, out string toolsPath)
+            {
+                toolsPath = Path.Combine(basePath, "MSBuild", versionPath, binPath);
+                if (Directory.Exists(toolsPath))
+                {
+                    return true;
+                }
+
+                toolsPath = null;
+                return false;
+            }
+        }
+
         protected static string FindLocalMSBuildDirectory()
         {
             // If OmniSharp is running normally, MSBuild is located in an 'msbuild' folder beneath OmniSharp.exe.

--- a/src/OmniSharp.Host/MSBuild/Discovery/MSBuildInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/MSBuildInstanceProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.IO;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 
 namespace OmniSharp.MSBuild.Discovery
@@ -35,14 +36,28 @@ namespace OmniSharp.MSBuild.Discovery
 
             bool TryGetToolsPath(string versionPath, string binPath, out string toolsPath)
             {
-                toolsPath = Path.Combine(basePath, "MSBuild", versionPath, binPath);
-                if (Directory.Exists(toolsPath))
+                toolsPath = null;
+
+                var baseDir = new DirectoryInfo(basePath);
+                if (!baseDir.Exists)
                 {
-                    return true;
+                    return false;
                 }
 
-                toolsPath = null;
-                return false;
+                var versionDir = baseDir.EnumerateDirectories().FirstOrDefault(di => di.Name == versionPath);
+                if (versionDir == null)
+                {
+                    return false;
+                }
+
+                var binDir = versionDir.EnumerateDirectories().FirstOrDefault(di => di.Name == binPath);
+                if (binDir == null)
+                {
+                    return false;
+                }
+
+                toolsPath = binDir.FullName;
+                return true;
             }
         }
 

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/DevConsoleInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/DevConsoleInstanceProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Immutable;
-using System.IO;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Utilities;
 
@@ -27,8 +26,8 @@ namespace OmniSharp.MSBuild.Discovery.Providers
                 return NoInstances;
             }
 
-            var toolsPath = Path.Combine(path, "MSBuild", "15.0", "Bin");
-            if (!Directory.Exists(toolsPath))
+            var toolsPath = FindMSBuildToolsPath(path);
+            if (toolsPath == null)
             {
                 return NoInstances;
             }

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/MonoInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/MonoInstanceProvider.cs
@@ -75,10 +75,10 @@ namespace OmniSharp.MSBuild.Discovery.Providers
                 return NoInstances;
             }
 
-            var toolsPath = Path.Combine(path, "15.0", "bin");
-            if (!Directory.Exists(toolsPath))
+            var toolsPath = FindMSBuildToolsPath(path);
+            if (toolsPath != null)
             {
-                Logger.LogDebug($"Mono MSBuild could not be used because '{toolsPath}' does not exist.");
+                Logger.LogDebug($"Mono MSBuild could not be used because an MSBuild tools path could not be found.");
                 return NoInstances;
             }
 

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/MonoInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/MonoInstanceProvider.cs
@@ -76,7 +76,7 @@ namespace OmniSharp.MSBuild.Discovery.Providers
             }
 
             var toolsPath = FindMSBuildToolsPath(path);
-            if (toolsPath != null)
+            if (toolsPath == null)
             {
                 Logger.LogDebug($"Mono MSBuild could not be used because an MSBuild tools path could not be found.");
                 return NoInstances;

--- a/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
+++ b/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
@@ -22,6 +22,12 @@ namespace OmniSharp.Options
         public string CscToolPath { get; set; }
         public string CscToolExe { get; set; }
 
+        /// <summary>
+        /// When set to true, the MSBuild project system will generate binary logs for each project that
+        /// it loads.
+        /// </summary>
+        public bool GenerateBinaryLogs { get; set; }
+
         // TODO: Allow loose properties
         // public IConfiguration Properties { get; set; }
     }

--- a/src/OmniSharp.MSBuild/ProjectLoader.cs
+++ b/src/OmniSharp.MSBuild/ProjectLoader.cs
@@ -77,9 +77,27 @@ namespace OmniSharp.MSBuild
 
                 var projectInstance = evaluatedProject.CreateProjectInstance();
                 var msbuildLogger = new MSBuildLogger(_logger);
+
+                var loggers = new List<MSB.Framework.ILogger>()
+                {
+                    msbuildLogger
+                };
+
+                if (_options.GenerateBinaryLogs)
+                {
+                    var binlogPath = Path.ChangeExtension(projectInstance.FullPath, ".binlog");
+                    var binaryLogger = new MSB.Logging.BinaryLogger()
+                    {
+                        CollectProjectImports = MSB.Logging.BinaryLogger.ProjectImportsCollectionMode.Embed,
+                        Parameters = binlogPath
+                    };
+
+                    loggers.Add(binaryLogger);
+                }
+
                 var buildResult = projectInstance.Build(
                     targets: new string[] { TargetNames.Compile, TargetNames.CoreCompile },
-                    loggers: new[] { msbuildLogger });
+                    loggers);
 
                 var diagnostics = msbuildLogger.GetDiagnostics();
 


### PR DESCRIPTION
This change fixes MSBuild discovery to handle scenarios where the MSBuild tools path is not included in a "15.0" folder. In future releases of Visual Studio, MSBuild will move to a folder named "Current" and OmniSharp should support that. In addition, I've added some extra logging during discovery to help indicate why a particular MSBuild instance isn't chosen. Finally, this change introduces a new option that causes OmniSharp to produce MSBuild binary logs when loading projects. This should be a big help for MSBuild debugging. It can be enabled in an omnisharp.json file like so:

```JSON
{
    "MSBuild": {
        "GenerateBinaryLogs": true
    }
}
```