### PR TITLE
Make adding transient documents more reliable.

### DIFF
--- a/src/OmniSharp.Roslyn/BufferManager.cs
+++ b/src/OmniSharp.Roslyn/BufferManager.cs
@@ -159,7 +159,7 @@ namespace OmniSharp.Roslyn
                 lock (_lock)
                 {
                     var documentIds = documentInfos.Select(document => document.Id);
-                    _transientDocuments.Add(fileName, documentIds);
+                    _transientDocuments[fileName] = documentIds;
                     _transientDocumentIds.UnionWith(documentIds);
                 }
 


### PR DESCRIPTION
- Prior to this change there were times when a transient document had not been fully removed from the buffer manager's list tracking before trying to add it again.

- I initially based this branch off of the `v1.32.6` tag but looks like I can't represent that in the PR.


@rchande @akshita31 For a mid-november patch release would we grab everything from master in omnisharp-roslyn or would we build a separate branch? Either way, this can go into either one, just want to follow the same guidelines that you have always used.

Also, I and @ajaybhargavb tried this out locally and couldn't reproduce the exceptions.

aspnet/Razor.VSCode#214