### PR TITLE
Fix VS MSBuild discovery

### DIFF
--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/VisualStudioInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/VisualStudioInstanceProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
@@ -68,7 +69,9 @@ namespace OmniSharp.MSBuild.Discovery.Providers
                         continue;
                     }
 
-                    var toolsPath = FindMSBuildToolsPath(installPath);
+                    var msbuildPath = Path.Combine(installPath, "MSBuild");
+
+                    var toolsPath = FindMSBuildToolsPath(msbuildPath);
                     if (toolsPath != null)
                     {
                         builder.Add(


### PR DESCRIPTION
My recent change to support VS MSBuild discovery for future versions of VS accidentally broke VS discovery altogether be leaving "MSBuild" out of the path. Oops!