### PR TITLE
expose IndentSwitchCaseSectionWhenBlock in OmniSharp FormattingOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to the project will be documented in this file.
 
 ## [1.32.9] - not yet released
 * Updated to Roslyn 2.10.0 (PR: [#1344](https://github.com/OmniSharp/omnisharp-roslyn/pull/1344))
+* Incorporate *IndentSwitchCaseSectionWhenBlock* into OmniSharp's formatting options. This fixes the default formatting behavior, as the setting is set to *true* by default, and still allows users to disable it if needed. ([#1351](https://github.com/OmniSharp/omnisharp-roslyn/issues/1351), PR: [#1353](https://github.com/OmniSharp/omnisharp-roslyn/pull/1353))
 
 ## [1.32.8] - 2018-11-14
 * Fixed MSBuild discovery path (1.32.7 regression) (PR: [#1337](https://github.com/OmniSharp/omnisharp-roslyn/pull/1337))

--- a/src/OmniSharp.Abstractions/Options/FormattingOptions.cs
+++ b/src/OmniSharp.Abstractions/Options/FormattingOptions.cs
@@ -38,6 +38,7 @@ namespace OmniSharp.Options
             IndentBlock = true;
             IndentSwitchSection = true;
             IndentSwitchCaseSection = true;
+            IndentSwitchCaseSectionWhenBlock = true;
             LabelPositioning = "oneLess";
             WrappingPreserveSingleLine = true;
             WrappingKeepStatementsOnSingleLine = true;
@@ -121,6 +122,8 @@ namespace OmniSharp.Options
         public bool IndentSwitchSection { get; set; }
 
         public bool IndentSwitchCaseSection { get; set; }
+
+        public bool IndentSwitchCaseSectionWhenBlock { get; set; }
 
         public string LabelPositioning { get; set; }
 

--- a/src/OmniSharp.Roslyn.CSharp/Services/CSharpWorkspaceOptionsProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/CSharpWorkspaceOptionsProvider.cs
@@ -46,6 +46,7 @@ namespace OmniSharp.Roslyn.CSharp.Services
                 .WithChangedOption(CSharpFormattingOptions.IndentBlock, formattingOptions.IndentBlock)
                 .WithChangedOption(CSharpFormattingOptions.IndentSwitchSection, formattingOptions.IndentSwitchSection)
                 .WithChangedOption(CSharpFormattingOptions.IndentSwitchCaseSection, formattingOptions.IndentSwitchCaseSection)
+                .WithChangedOption(CSharpFormattingOptions.IndentSwitchCaseSectionWhenBlock, formattingOptions.IndentSwitchCaseSectionWhenBlock)
                 .WithChangedOption(CSharpFormattingOptions.LabelPositioning, LabelPositionOptionForStringValue(formattingOptions.LabelPositioning))
                 .WithChangedOption(CSharpFormattingOptions.WrappingPreserveSingleLine, formattingOptions.WrappingPreserveSingleLine)
                 .WithChangedOption(CSharpFormattingOptions.WrappingKeepStatementsOnSingleLine, formattingOptions.WrappingKeepStatementsOnSingleLine)


### PR DESCRIPTION
Fixes #1351 

As pointed out by @DustinCampbell, we missed this setting. I actually went through all of the `FormattingOptions` we expose and compared them to Roslyn's `CSharpFormattingOptions` and this was actually the only one we were missing 😀

This also fixes the default formatting behavior, since the default value is set to true.