### PR TITLE
Fix "Ambiguity" errors appearing when files are modified during project load

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -353,11 +353,11 @@ namespace OmniSharp.MSBuild
                 return;
             }
 
-            _workspace.TryPromoteMiscellaneousDocumentsToProject(project);
             UpdateSourceFiles(project, projectFileInfo.SourceFiles);
             UpdateParseOptions(project, projectFileInfo.LanguageVersion, projectFileInfo.PreprocessorSymbolNames, !string.IsNullOrWhiteSpace(projectFileInfo.DocumentationFile));
             UpdateProjectReferences(project, projectFileInfo.ProjectReferences);
             UpdateReferences(project, projectFileInfo.ProjectReferences, projectFileInfo.References);
+            _workspace.TryPromoteMiscellaneousDocumentsToProject(project);
         }
 
         private void UpdateSourceFiles(Project project, IList<string> sourceFiles)


### PR DESCRIPTION
fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1356

Context of what happens:

1) When you edit file before projects get loaded, o# puts them in "Misc" project, because that's the best it can do at the moment.
2) On project load, MSBuildProjectManager creates a real Document on the same path, which kills the "Misc" document
3) **Problem is**: there is a bit of code that tries to "promote" misc documents into the newly loaded project, and this happens before step 2.

This unfortunate timing means that both "TryPromote" and "ProjectLoad" create each their own version of non-misc document (and ambiguity errors follow).

Moving "TryPromote" after actual project load, lets MSBuild properly delete misc files, so unnecessary document creating in "TryPromote" is avoided

cc @akshita31 @rchande @DustinCampbell

On a sIde note: 
Its weird that MiscProject has its own version of "Try-to-put-file-into-exisitng-projects" - IMHO TryPromote should use some part of bufferManager's "TryAddTransientDocument".