### PR TITLE
removed unused stdio flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to the project will be documented in this file.
 ## [1.32.9] - not yet released
 * Updated to Roslyn 2.10.0 (PR: [#1344](https://github.com/OmniSharp/omnisharp-roslyn/pull/1344))
 * Incorporate *IndentSwitchCaseSectionWhenBlock* into OmniSharp's formatting options. This fixes the default formatting behavior, as the setting is set to *true* by default, and still allows users to disable it if needed. ([#1351](https://github.com/OmniSharp/omnisharp-roslyn/issues/1351), PR: [#1353](https://github.com/OmniSharp/omnisharp-roslyn/pull/1353))
+* Removed unused `-stdio` flag from the `StdioCommandLineApplication` (PR: [#1362](https://github.com/OmniSharp/omnisharp-roslyn/pull/1362))
 
 ## [1.32.8] - 2018-11-14
 * Fixed MSBuild discovery path (1.32.7 regression) (PR: [#1337](https://github.com/OmniSharp/omnisharp-roslyn/pull/1337))

--- a/src/OmniSharp.Stdio/StdioCommandLineApplication.cs
+++ b/src/OmniSharp.Stdio/StdioCommandLineApplication.cs
@@ -5,18 +5,14 @@ namespace OmniSharp.Stdio
 {
     internal class StdioCommandLineApplication : CommandLineApplication
     {
-        private readonly CommandOption _stdio;
         private readonly CommandOption _lsp;
         private readonly CommandOption _encoding;
 
         public StdioCommandLineApplication() : base()
         {
-            _stdio = Application.Option("-stdio | --stdio", "Use STDIO over HTTP as OmniSharp communication protocol.", CommandOptionType.NoValue);
             _lsp = Application.Option("-lsp | --languageserver", "Use Language Server Protocol.", CommandOptionType.NoValue);
             _encoding = Application.Option("-e | --encoding", "Input / output encoding for STDIO protocol.", CommandOptionType.SingleValue);
         }
-
-        public bool Stdio => true;
 
         public bool Lsp => _lsp.HasValue();
 


### PR DESCRIPTION
The STDIO application has an unnecessary flag "stdio" exposed, which is not used for anything. This is a leftover from the days where both HTTP and STDIO could be launched from the same entry point.