### PR TITLE
updated to Roslyn 2.11.0-beta1-final

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>15.8.166</MSBuildPackageVersion>
     <NuGetPackageVersion>4.8.0</NuGetPackageVersion>
-    <RoslynPackageVersion>2.10.0</RoslynPackageVersion>
+    <RoslynPackageVersion>2.11.0-beta1-final</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 
@@ -61,6 +61,7 @@
     <PackageReference Update="Nuget.Versioning" Version="$(NuGetPackageVersion)" />
 
     <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
     <PackageReference Update="System.Composition" Version="1.0.31" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.4.2" />
     <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.5.24" />

--- a/src/OmniSharp.Abstractions/Configuration.cs
+++ b/src/OmniSharp.Abstractions/Configuration.cs
@@ -4,7 +4,7 @@ namespace OmniSharp
     {
         public static bool ZeroBasedIndices = false;
 
-        public const string RoslynVersion = "2.10.0.0";
+        public const string RoslynVersion = "2.11.0.0";
         public const string RoslynPublicKeyToken = "31bf3856ad364e35";
 
         public readonly static string RoslynFeatures = GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.Features");

--- a/src/OmniSharp.Http.Driver/app.config
+++ b/src/OmniSharp.Http.Driver/app.config
@@ -7,15 +7,15 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.11.0.0" newVersion="2.11.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.11.0.0" newVersion="2.11.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.11.0.0" newVersion="2.11.0.0"/>
             </dependentAssembly>
 
             <dependentAssembly>

--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
@@ -48,6 +48,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 case "7.1": return LanguageVersion.CSharp7_1;
                 case "7.2": return LanguageVersion.CSharp7_2;
                 case "7.3": return LanguageVersion.CSharp7_3;
+                case "8.0": return LanguageVersion.CSharp8;
                 default: return LanguageVersion.Default;
             }
         }

--- a/src/OmniSharp.Roslyn/OmniSharp.Roslyn.csproj
+++ b/src/OmniSharp.Roslyn/OmniSharp.Roslyn.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+    <PackageReference Include="System.ComponentModel.Composition" />
   </ItemGroup>
 
 </Project>

--- a/src/OmniSharp.Stdio.Driver/app.config
+++ b/src/OmniSharp.Stdio.Driver/app.config
@@ -7,15 +7,15 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.11.0.0" newVersion="2.11.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.11.0.0" newVersion="2.11.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.11.0.0" newVersion="2.11.0.0"/>
             </dependentAssembly>
 
             <dependentAssembly>

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -464,6 +464,27 @@ class C
             ContainsCompletions(completions.Select(c => c.CompletionText), new[] { "myValue" });
         }
 
+        [Fact]
+        public async Task Scripting_by_default_returns_completions_for_CSharp8_0()
+        {
+            const string source =
+                @"
+                  class Point {
+                    public Point(int x, int y) {
+                      PositionX = x;
+                      PositionY = y;
+                    }
+                    public int PositionX { get; }
+                    public int PositionY { get; }
+                  }
+                  Point[] points = { new (1, 2), new (3, 4) };
+                  points[0].Po$$
+                ";
+
+            var completions = await FindCompletionsAsync("dummy.csx", source);
+            ContainsCompletions(completions.Select(c => c.CompletionText), new[] { "PositionX", "PositionY" });
+        }
+
         private void ContainsCompletions(IEnumerable<string> completions, params string[] expected)
         {
             if (!completions.SequenceEqual(expected))

--- a/tests/app.config
+++ b/tests/app.config
@@ -7,15 +7,15 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.11.0.0" newVersion="2.11.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.11.0.0" newVersion="2.11.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-2.11.0.0" newVersion="2.11.0.0"/>
             </dependentAssembly>
 
             <dependentAssembly>


### PR DESCRIPTION
Fixes #1364 
Additionally, added C# 8.0 to the language version converter and added a test to verify that scripting defaults to C# 8.0 (it should always use latest version).

I think this should only be merged after we release a new version from master, as master has Roslyn 2.10.0 and we have not yet released a 2.10.0-based OmniSharp.