### PR TITLE
Bump roslyn packages to 3.0.0

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>15.8.166</MSBuildPackageVersion>
     <NuGetPackageVersion>4.8.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.0.0-beta4-19126-05</RoslynPackageVersion>
+    <RoslynPackageVersion>3.0.0</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR bumps the Roslyn package versions to 3.0.0 release packages. 