### PR TITLE
Fix HTTP logging

### DIFF
--- a/src/OmniSharp.Http/Startup.cs
+++ b/src/OmniSharp.Http/Startup.cs
@@ -2,11 +2,11 @@ using System;
 using System.Composition.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Eventing;
 using OmniSharp.Http.Middleware;
+using OmniSharp.Roslyn;
 using OmniSharp.Services;
 using OmniSharp.Utilities;
 
@@ -32,9 +32,17 @@ namespace OmniSharp.Http
                 {
                     builder.AddConsole();
 
+                    var workspaceInformationServiceName = typeof(WorkspaceInformationService).FullName;
+                    var projectEventForwarder = typeof(ProjectEventForwarder).FullName;
                     var exceptionHandlerMiddlewareName = typeof(ExceptionHandlerMiddleware).FullName;
+
                     builder.AddFilter(
-                        (category, logLevel) => category.Equals(exceptionHandlerMiddlewareName, StringComparison.OrdinalIgnoreCase));
+                        (category, logLevel) =>
+                            category.Equals(exceptionHandlerMiddlewareName, StringComparison.OrdinalIgnoreCase) ||
+                            (_environment.LogLevel <= logLevel &&
+                                category.StartsWith("OmniSharp", StringComparison.OrdinalIgnoreCase) &&
+                                !category.Equals(workspaceInformationServiceName, StringComparison.OrdinalIgnoreCase) &&
+                                !category.Equals(projectEventForwarder, StringComparison.OrdinalIgnoreCase)));
                 });
 
             _compositionHost = new CompositionHostBuilder(serviceProvider)


### PR DESCRIPTION
As described in #1446, the HTTP version of OmniSharp-roslyn does not log any output.

I managed to find the commit where the logging stopped working, it was 4f9fb4d5 by @DustinCampbell. In that commit the `HostHelpers.LogFilter()` functionality was refactored into `CompositionHostBuilder.CreateDefaultServiceProvider()`, which has a `configureLogging` callback argument.

The problem here is that in the HTTP `configureLogging` callback, `ExceptionHandlerMiddleware` is included in a filter like this:

```cs
var exceptionHandlerMiddlewareName = typeof(ExceptionHandlerMiddleware).FullName;
builder.AddFilter(
    (category, logLevel) => category.Equals(exceptionHandlerMiddlewareName, StringComparison.OrdinalIgnoreCase));
```

This filter is applied _on top_ of the filter already added in `CompositionHostBuilder.CreateDefaultServiceProvider()`, which looks like this:

```cs

var workspaceInformationServiceName = typeof(WorkspaceInformationService).FullName;
var projectEventForwarder = typeof(ProjectEventForwarder).FullName;

builder.AddFilter(
    (category, logLevel) =>
        environment.LogLevel <= logLevel &&
        category.StartsWith("OmniSharp", StringComparison.OrdinalIgnoreCase) &&
        !category.Equals(workspaceInformationServiceName, StringComparison.OrdinalIgnoreCase) &&
        !category.Equals(projectEventForwarder, StringComparison.OrdinalIgnoreCase));
```

The simplest way I have found to ensure that the HTTP filter doesn't clobber the `CompositionHostBuilder` filter is to duplicate the entire `CompositionHostBuilder` filter in the HTTP code:

```cs
var workspaceInformationServiceName = typeof(WorkspaceInformationService).FullName;
var projectEventForwarder = typeof(ProjectEventForwarder).FullName;
var exceptionHandlerMiddlewareName = typeof(ExceptionHandlerMiddleware).FullName;

builder.AddFilter(
    (category, logLevel) =>
        category.Equals(exceptionHandlerMiddlewareName, StringComparison.OrdinalIgnoreCase) ||
        (_environment.LogLevel <= logLevel &&
            category.StartsWith("OmniSharp", StringComparison.OrdinalIgnoreCase) &&
            !category.Equals(workspaceInformationServiceName, StringComparison.OrdinalIgnoreCase) &&
            !category.Equals(projectEventForwarder, StringComparison.OrdinalIgnoreCase)));
```

This is not a very clean solution so please let me know if there's a tidier way to do this.

Fixes #1446
