### PR TITLE
Rename msbuild directory to .msbuild

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -683,7 +683,7 @@ void CopyMonoBuild(BuildEnvironment env, string sourceFolder, string outputFolde
 {
     DirectoryHelper.Copy(sourceFolder, outputFolder, copySubDirectories: false);
 
-    var msbuildFolder = CombinePaths(outputFolder, "msbuild");
+    var msbuildFolder = CombinePaths(outputFolder, ".msbuild");
 
     // Copy MSBuild runtime and libraries
     DirectoryHelper.Copy($"{env.Folders.MSBuild}", msbuildFolder);
@@ -830,7 +830,7 @@ string PublishWindowsBuild(string project, BuildEnvironment env, BuildPlan plan,
     }
 
     // Copy MSBuild to output
-    DirectoryHelper.Copy($"{env.Folders.MSBuild}", CombinePaths(outputFolder, "msbuild"));
+    DirectoryHelper.Copy($"{env.Folders.MSBuild}", CombinePaths(outputFolder, ".msbuild"));
 
     CopyExtraDependencies(env, outputFolder);
 

--- a/src/OmniSharp.Host/MSBuild/Discovery/MSBuildInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/MSBuildInstanceProvider.cs
@@ -63,8 +63,8 @@ namespace OmniSharp.MSBuild.Discovery
 
         protected static string FindLocalMSBuildDirectory()
         {
-            // If OmniSharp is running normally, MSBuild is located in an 'msbuild' folder beneath OmniSharp.exe.
-            var msbuildDirectory = Path.Combine(AppContext.BaseDirectory, "msbuild");
+            // If OmniSharp is running normally, MSBuild is located in an '.msbuild' folder beneath OmniSharp.exe.
+            var msbuildDirectory = Path.Combine(AppContext.BaseDirectory, ".msbuild");
 
             if (!Directory.Exists(msbuildDirectory))
             {


### PR DESCRIPTION
In MSBuild 16, the current omnisharp standalone msbuild path gets detected as belonging to Visual Studio, resulting in incorrect build behavior.