### PR TITLE
Small 📚updates to bring them up to date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.32.xx] - not yet released
+* Fixed logging for OmniSharp HTTP server (PR: [#1456](https://github.com/OmniSharp/omnisharp-roslyn/pull/1456))
+
+## [1.32.18] - 2019-04-12
+* Renamed `ProjectGuid` to `ProjectId` and no longer hash target framework names on `ProjectConfigurationMessage` (PR: [#1454](https://github.com/OmniSharp/omnisharp-roslyn/pull/1454))
+
+## [1.32.17] - 2019-04-12
+* Fixed a bug in embedded MSBuild 16 path detection (PR: [#1457](https://github.com/OmniSharp/omnisharp-roslyn/pull/1457))
+
 ## [1.32.16] - 2019-04-10
 * .NET Core 3.0 support (PR: [#1450](https://github.com/OmniSharp/omnisharp-roslyn/pull/1450))
 * Upgraded to Roslyn `3.1.0-beta2-19205-01` (PR: [#1448](https://github.com/OmniSharp/omnisharp-roslyn/pull/1448))

--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 omnisharp-roslyn
 ================
 
-[![Mono Build Status](https://travis-ci.org/OmniSharp/omnisharp-roslyn.svg?branch=master)](https://travis-ci.org/OmniSharp/omnisharp-roslyn)
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/dj36uvllv0qmkljr/branch/master?svg=true)](https://ci.appveyor.com/project/david-driscoll/omnisharp-roslyn/branch/master)
+[![Build Status](https://dev.azure.com/omnisharp/Builds/_apis/build/status/OmniSharp.omnisharp-roslyn?branchName=master)](https://dev.azure.com/omnisharp/Builds/_build/latest?definitionId=2&branchName=master)
 
 ## Introduction
 
-OmniSharp-Roslyn is a .NET development platform based on [Roslyn](https://github.com/dotnet/roslyn) workspaces. It provides project dependencies and language syntax to various IDE and plugins.
+OmniSharp is a .NET development platform based on [Roslyn](https://github.com/dotnet/roslyn) workspaces. It provides project dependencies and C# language services to various IDEs and plugins.
 
-OmniSharp-Roslyn is built with the [.NET Core SDK](https://dot.net/) on Windows and [Mono](http://www.mono-project.com/) on OSX/Linux. It targets the __net461__ target framework. OmniSharp requires __mono__ (>=5.2.0) if it is run on a platform other than Windows.
+OmniSharp is built with the [.NET Core SDK](https://dot.net/) on Windows and [Mono](http://www.mono-project.com/) on OSX/Linux. It targets the *net472* target framework. For platforms other than Windows, OmniSharp ships with an *embedded Mono* which is based on version *5.18.0* and provisioned during the build script. If *Mono* is globally installed on the system, OmniSharp will prefer it over the embedded version, however version *>=5.18.0* is required.
 
-For Arch Linux users, need package [msbuild-stable](https://aur.archlinux.org/packages/msbuild-stable/) (>= 15.0).
+For Arch Linux users, you need package [msbuild-stable](https://aur.archlinux.org/packages/msbuild-stable/) (>= 16.0).
 
-In addition, if you need the HTTP interface and you want to run on Linux, you'll also need to make sure that you have [libuv](http://libuv.org) installed.
-
-See also https://github.com/OmniSharp/omnisharp-roslyn/issues/1202#issuecomment-421543905 .
+In addition, if you need the HTTP interface and you want to run on Linux, you'll also need to make sure that you have [libuv](http://libuv.org) installed. See also https://github.com/OmniSharp/omnisharp-roslyn/issues/1202#issuecomment-421543905 .
 
 ## What's new
 
 See our [change log](https://github.com/OmniSharp/omnisharp-roslyn/blob/master/CHANGELOG.md) for all of the updates.
 
-## Using the latest OmniSharp-Roslyn with VS Code
+## Using OmniSharp
+
+OmniSharp ships in two flavors:
+
+* Stdio server
+* HTTP server 
 
 ### Prerelease Versions
 Pre-release versions are available in azure storage, they can be viewed [here](https://roslynomnisharp.blob.core.windows.net/releases?restype=container&comp=list).
@@ -37,7 +39,7 @@ All changes to `master` will be pushed to this feed and will be made available w
   * `linux-x86`
   * `osx`
   * `mono`  (Requires global mono installed)
-* Extenisons are archive specific, windows will be `zip` and all others will be `tar.gz`.
+* Extensions are archive specific, windows will be `zip` and all others will be `tar.gz`.
 
 ### Building
 
@@ -68,6 +70,7 @@ Add the following setting to your [User Settings or Workspace Settings](https://
   "omnisharp.path": "<Path to the omnisharp executable>"
 }
 ```
+
 The above option can also be set to:
 * "latest" - To consume the latest build from the master branch
 * A specific version number like `1.29.2-beta.60`
@@ -81,6 +84,10 @@ In order to be able to attach a debugger, add the following setting:
 ```
 
 This will print the OmniSharp process ID in the VS Code OmniSharp output panel and pause the start of the server until a debugger is attached to this process. This is equivalent to launching OmniSharp from a command line with the `--debug` flag.
+
+### Configuration
+
+OmniSharp provides a rich set of hierarchical configuration options, controlled via startup arguments, environment variables and `omnisharp.json` file. For more details please visit the [Configuration Options](https://github.com/OmniSharp/omnisharp-roslyn/wiki/Configuration-Options) section of the wiki.
 
 ## Help wanted!
 

--- a/build.json
+++ b/build.json
@@ -6,7 +6,7 @@
     "1.1.2"
   ],
   "LegacyDotNetVersion": "1.0.0-preview2-1-003177",
-  "RequiredMonoVersion": "5.8.0.0",
+  "RequiredMonoVersion": "5.18.0.0",
   "DownloadURL": "https://roslynomnisharp.blob.core.windows.net/ext",
   "MonoRuntimeMacOS": "mono.macOS-5.18.1.0.zip",
   "MonoRuntimeLinux32": "mono.linux-x86-5.18.1.0.zip",


### PR DESCRIPTION
Changelog and readme tweaks. Also removed the travis/appveyor badges and replaced with Azure DevOps.