### PR TITLE
Replace ToLanguageVersion switch with TryParse

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
@@ -28,29 +28,10 @@ namespace OmniSharp.MSBuild.ProjectFile
 
         public static LanguageVersion ToLanguageVersion(string propertyValue)
         {
-            if (string.IsNullOrWhiteSpace(propertyValue) ||
-                propertyValue.Equals("Default", StringComparison.OrdinalIgnoreCase))
-            {
-                return LanguageVersion.Default;
-            }
+            if (LanguageVersionFacts.TryParse(propertyValue, out var result))
+                return result;
 
-            // ISO-1, ISO-2, 3, 4, 5, 6, 7 or Default
-            switch (propertyValue.ToLower())
-            {
-                case "latest": return LanguageVersion.Latest;
-                case "iso-1": return LanguageVersion.CSharp1;
-                case "iso-2": return LanguageVersion.CSharp2;
-                case "3": return LanguageVersion.CSharp3;
-                case "4": return LanguageVersion.CSharp4;
-                case "5": return LanguageVersion.CSharp5;
-                case "6": return LanguageVersion.CSharp6;
-                case "7": return LanguageVersion.CSharp7;
-                case "7.1": return LanguageVersion.CSharp7_1;
-                case "7.2": return LanguageVersion.CSharp7_2;
-                case "7.3": return LanguageVersion.CSharp7_3;
-                case "8.0": return LanguageVersion.CSharp8;
-                default: return LanguageVersion.Default;
-            }
+            return LanguageVersion.Default;
         }
 
         public static ImmutableArray<string> SplitList(string propertyValue, char separator)


### PR DESCRIPTION
This should fix #1487.

I wasn't able to run the build.sh script to run the unit tests for some reason, as I was getting this response:
```
$ ./build.sh
Index was outside the bounds of the array.
Could not restore NuGet packages.
```

I'm not entirely sure why I was getting this, but I'm pretty certain I installed Mono correctly, as the snippets they gave to test the installation ran correctly.