### PR TITLE
fixed logical typo in CompletionItemExtensions

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
@@ -61,7 +61,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
             var properties = completionItem.Properties;
 
             // if the completion provider encoded symbols into Properties, we can return them
-            if (properties.ContainsKey(SymbolName) && properties.ContainsKey(SymbolName))
+            if (properties.ContainsKey(SymbolName) && properties.ContainsKey(SymbolKind))
             {
                 return recommendedSymbols.Where(x => x.Name == properties[SymbolName] && (int)x.Kind == int.Parse(properties[SymbolKind])).Distinct();
             }


### PR DESCRIPTION
This was missed when we merged https://github.com/OmniSharp/omnisharp-roslyn/pull/1479