### PR TITLE
pin CI builds to use Mono 5.18.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
       - script: |
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           sudo apt install apt-transport-https ca-certificates
-          echo "deb https://download.mono-project.com/repo/ubuntu stable-xenial/snapshots/5.18.1 main" | sudo tee /etc/apt/sources.list.d/mono-official-vs.list
+          echo "deb https://download.mono-project.com/repo/ubuntu stable-xenial/snapshots/5.18.1 main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
           sudo apt update
           sudo apt install mono-devel
         displayName: Use Mono $(MONO_VERSION)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
       - script: |
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           sudo apt install apt-transport-https ca-certificates
-          echo "deb https://download.mono-project.com/repo/ubuntu stable-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          echo "deb https://download.mono-project.com/repo/ubuntu vs-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-vs.list
           sudo apt update
           sudo apt install mono-devel
         displayName: Use Mono $(MONO_VERSION)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
       vmImage: "Ubuntu-16.04"
     dependsOn: GitVersion
     variables:
-      MONO_VERSION: 5.16.0
+      MONO_VERSION: 5.18.1
     steps:
       - template: ./.pipelines/init.yml
         parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
       - script: |
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           sudo apt install apt-transport-https ca-certificates
-          echo "deb https://download.mono-project.com/repo/ubuntu vs-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-vs.list
+          echo "deb https://download.mono-project.com/repo/ubuntu stable-xenial/snapshots/5.18.1 main" | sudo tee /etc/apt/sources.list.d/mono-official-vs.list
           sudo apt update
           sudo apt install mono-devel
         displayName: Use Mono $(MONO_VERSION)


### PR DESCRIPTION
At the moment the CI builds use Mono 5.18.1 (macOS) and stable-xenial (Linux). 
The problem with this is that `stable-xenial` is a moving target as it points to latest stable Mono - it was 5.16 recently, and now it's actually 5.20.1 already. 
There is also `stable-vs` which is pinned to correspond to the VS for Mac version and currently resolves to 5.18.1 but it is also changing as new releases are done.

It makes sense for us to pin a Mono version instead - this way we can always make sure we work on our *minimal* required Mono version - https://github.com/OmniSharp/omnisharp-roslyn/blob/master/build.json#L9 instead of building in CI against what is the latest.

With this PR we will now run on Mono 5.18.1 on both macOS and Linux.