### PR TITLE
Fixed declaration name completion regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.32.21] - not yet released
+* Fixed a regression on declaration name completion (PR: [#1520](https://github.com/OmniSharp/omnisharp-roslyn/pull/1520))
+
 ## [1.32.20] - 2019-06-03
 * Added support for `TreatWarningsAsErrors` in csproj files (PR: [#1459](https://github.com/OmniSharp/omnisharp-roslyn/pull/1459))
 * Updated to Roslyn `3.2.0-beta3-19281-01` to match VS dev16.2p2 (PR: [#1511](https://github.com/OmniSharp/omnisharp-roslyn/pull/1511))

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -14,6 +14,7 @@
     <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.6.1" />
     <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.6.2" />
 
+    <PackageReference Update="Humanizer" Version="2.2.0" />
     <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
 
     <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />

--- a/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
+++ b/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Humanizer" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />
     <PackageReference Include="System.Reactive" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/BufferManagerFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/BufferManagerFacts.cs
@@ -25,19 +25,16 @@ namespace OmniSharp.Tests
         {
             using (var host = CreateOmniSharpHost(new TestFile("test.cs", "class C {}")))
             {
-                Assert.Equal(2, host.Workspace.CurrentSolution.Projects.Count());
+                Assert.Single(host.Workspace.CurrentSolution.Projects);
                 Assert.Single(host.Workspace.CurrentSolution.Projects.ElementAt(0).Documents);
-                Assert.Single(host.Workspace.CurrentSolution.Projects.ElementAt(1).Documents);
 
                 await host.Workspace.BufferManager.UpdateBufferAsync(new Request() { });
-                Assert.Equal(2, host.Workspace.CurrentSolution.Projects.Count());
+                Assert.Single(host.Workspace.CurrentSolution.Projects);
                 Assert.Single(host.Workspace.CurrentSolution.Projects.ElementAt(0).Documents);
-                Assert.Single(host.Workspace.CurrentSolution.Projects.ElementAt(1).Documents);
 
                 await host.Workspace.BufferManager.UpdateBufferAsync(new Request() { FileName = "", Buffer = "enum E {}" });
-                Assert.Equal(2, host.Workspace.CurrentSolution.Projects.Count());
+                Assert.Single(host.Workspace.CurrentSolution.Projects);
                 Assert.Single(host.Workspace.CurrentSolution.Projects.ElementAt(0).Documents);
-                Assert.Single(host.Workspace.CurrentSolution.Projects.ElementAt(1).Documents);
             }
         }
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -142,7 +142,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                             System.Guid.gu$$
                         }
                     }";
-            
+
             var completions = await FindCompletionsAsync(filename, input);
             ContainsCompletions(completions.Select(c => c.CompletionText).Take(1), "NewGuid");
         }
@@ -284,6 +284,24 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             var completions = await FindCompletionsAsync(filename, source);
             ContainsCompletions(completions.Select(c => c.CompletionText).Take(1), "text");
         }
+
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Returns_declaration_names(string filename)
+        {
+            const string source =
+                @"
+public class MyClass
+{
+    MyClass m$$
+}
+                ";
+
+            var completions = await FindCompletionsAsync(filename, source);
+            ContainsCompletions(completions.Select(c => c.CompletionText), "my", "myClass", "My", "MyClass");
+        }
+
 
         [Theory]
         [InlineData("dummy.cs")]

--- a/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
+++ b/tests/OmniSharp.Tests/UpdateBufferFilterFacts.cs
@@ -59,7 +59,7 @@ namespace OmniSharp.Tests
             {
                 await host.Workspace.BufferManager.UpdateBufferAsync(new Request() { FileName = "test2.cs", Buffer = "interface I {}" });
 
-                Assert.Equal(2, host.Workspace.CurrentSolution.GetDocumentIdsWithFilePath("test2.cs").Length);
+                Assert.Single(host.Workspace.CurrentSolution.GetDocumentIdsWithFilePath("test2.cs"));
                 var docId = host.Workspace.CurrentSolution.GetDocumentIdsWithFilePath("test2.cs").FirstOrDefault();
                 Assert.NotNull(docId);
                 var sourceText = await host.Workspace.CurrentSolution.GetDocument(docId).GetTextAsync();
@@ -82,7 +82,7 @@ namespace OmniSharp.Tests
                 await host.Workspace.BufferManager.UpdateBufferAsync(new Request() { FileName = "transient.cs", Buffer = "interface I {}" });
 
                 var docIds = host.Workspace.CurrentSolution.GetDocumentIdsWithFilePath("transient.cs");
-                Assert.Equal(2, docIds.Length);
+                Assert.Single(docIds);
 
                 // simulate a project system adding the file for real
                 var project1 = host.Workspace.CurrentSolution.Projects.First();

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -131,8 +131,8 @@ namespace TestUtility
         {
             TestHelpers.AddProjectToWorkspace(
                 this.Workspace,
-                "project.json",
-                new[] { "dnx451", "dnxcore50" },
+                "project.csproj",
+                new[] { "net472" },
                 testFiles.Where(f => f.FileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)).ToArray());
 
             foreach (var csxFile in testFiles.Where(f => f.FileName.EndsWith(".csx", StringComparison.OrdinalIgnoreCase)))


### PR DESCRIPTION
With one of the recent Roslyn betas, we have (or rather Roslyn has) regressed on declaration name completion - it doesn't work for us anymore at all. 
There was no test for that, so it went unnoticed - the test is added in this PR now.

The root cause is here http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp.Features/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs,70 Roslyn actually swallows all exceptions for `DeclarationNameCompletionProvider`. With the current beta, Roslyn actually throws as it can't find a reference to `Humanizer`. It is a bug in Roslyn since this package is required at runtime but not listed as dependency of the Roslyn Nuget. 

Adding the package directly restores our old behavior and the declaration name completion works again (I tested in the editor too). I will open this as bug in Roslyn but until it's resolved, we should take in this fix.