### PR TITLE
updated Roslyn to 3.2.0-beta4-19319-04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All changes to the project will be documented in this file.
     }
     ```
 * Fixed a regression on declaration name completion (PR: [#1520](https://github.com/OmniSharp/omnisharp-roslyn/pull/1520))
+* Update to Roslyn `3.2.0-beta4-19319-04` (PR: [#1527](https://github.com/OmniSharp/omnisharp-roslyn/pull/1527))
 
 ## [1.32.20] - 2019-06-03
 * Added support for `TreatWarningsAsErrors` in csproj files (PR: [#1459](https://github.com/OmniSharp/omnisharp-roslyn/pull/1459))

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -7,6 +7,5 @@
         <add key="dotnet-core-redux" value="https://dotnet.myget.org/F/dotnet-cli/api/v3/index.json" />
         <add key="OmniSharp" value="https://www.myget.org/F/omnisharp/api/v3/index.json" />
         <add key="roslyn-myget" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
-        <add key="roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
     </packageSources>
 </configuration>

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>16.0.461</MSBuildPackageVersion>
     <NuGetPackageVersion>5.0.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.2.0-beta3-19281-01</RoslynPackageVersion>
+    <RoslynPackageVersion>3.2.0-beta4-19319-04</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 
@@ -32,7 +32,6 @@
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynPackageVersion)" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynPackageVersion)" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.FlowAnalysis.Utilities" Version="2.9.3-beta1.19271.2+23ca1e2d" />
     <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
 
     <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />

--- a/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
+++ b/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="System.Reactive" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FlowAnalysis.Utilities" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 


### PR DESCRIPTION
This allows us to get rid of the workaround added in https://github.com/OmniSharp/omnisharp-roslyn/commit/8bccccfa2dd2dade7db3d595515c471dbf5de492 - thanks to the upstream fix in Roslyn [here](https://github.com/dotnet/roslyn/commit/06927469eaa4b31921aa6da99a52917b7e2e8b28)