### PR TITLE
ensure SQLite dependencies are included in the mono archive

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -724,8 +724,6 @@ string PublishMonoBuild(string project, BuildEnvironment env, BuildPlan plan, st
 
     CopyExtraDependencies(env, outputFolder);
 
-    Package(project, "mono", outputFolder, env.Folders.ArtifactsPackage, env.Folders.DeploymentPackage);
-
      // Copy dependencies of Mono build
      FileHelper.Copy(
          source: CombinePaths(env.Folders.Tools, "SQLitePCLRaw.core", "lib", "net45", "SQLitePCLRaw.core.dll"),
@@ -743,6 +741,8 @@ string PublishMonoBuild(string project, BuildEnvironment env, BuildPlan plan, st
          source: CombinePaths(env.Folders.Tools, "SQLitePCLRaw.bundle_green", "lib", "net45", "SQLitePCLRaw.batteries_green.dll"),
          destination: CombinePaths(outputFolder, "SQLitePCLRaw.batteries_green.dll"),
          overwrite: true);
+
+    Package(project, "mono", outputFolder, env.Folders.ArtifactsPackage, env.Folders.DeploymentPackage);
 
     return outputFolder;
 }


### PR DESCRIPTION
At the moment the `omnisharp-mono` archives we publish as part of the releases do not work (only `omnisharp-linux` and `omnisharp-osx` work), due to missing SQLite dependencies. The problem was the archive was created before the extra dependencies were copied.

Fixes #1536 ravi