### PR TITLE
Respect the disabling of a project system in services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.33.1] - not released yet
+* Fixed a bug where some internal services didn't respect the disabling of a project system ([#1543](https://github.com/OmniSharp/omnisharp-roslyn/pull/1543))
+
 ## [1.33.0] - 2019-07-01
 * Added support for `.editorconfig` files to control formatting settings, analyzers, coding styles and naming conventions. The feature is currently opt-into and needs to be enabled using OmniSharp configuration ([#31](https://github.com/OmniSharp/omnisharp-roslyn/issues/31), PR: [#1526](https://github.com/OmniSharp/omnisharp-roslyn/pull/1526))
     ```JSON

--- a/src/OmniSharp.Abstractions/Plugins/Plugin.cs
+++ b/src/OmniSharp.Abstractions/Plugins/Plugin.cs
@@ -35,6 +35,7 @@ namespace OmniSharp.Plugins
         public string Language { get; }
         public IEnumerable<string> Extensions { get; }
         public bool EnabledByDefault { get; } = true;
+        public bool Initialized { get; private set; }
 
         public Task<TResponse> Handle<TRequest, TResponse>(string endpoint, TRequest request)
         {
@@ -101,6 +102,8 @@ namespace OmniSharp.Plugins
 
         public void Initalize(IConfiguration configuration)
         {
+            if (Initialized) return;
+            Initialized = true;
             Task.Run(() => Run());
         }
 

--- a/src/OmniSharp.Abstractions/Services/IProjectSystem.cs
+++ b/src/OmniSharp.Abstractions/Services/IProjectSystem.cs
@@ -13,6 +13,11 @@ namespace OmniSharp.Services
         bool EnabledByDefault { get; }
 
         /// <summary>
+        /// Flag indicating that the project system has been sucessfully initialized.
+        /// </summary>
+        bool Initialized { get; }
+
+        /// <summary>
         /// Initialize the project system.
         /// </summary>
         /// <param name="configuration">The configuration to use.</param>

--- a/src/OmniSharp.Cake/CakeProjectSystem.cs
+++ b/src/OmniSharp.Cake/CakeProjectSystem.cs
@@ -36,13 +36,12 @@ namespace OmniSharp.Cake
         private readonly ILogger<CakeProjectSystem> _logger;
         private readonly ConcurrentDictionary<string, ProjectInfo> _projects;
         private readonly Lazy<CSharpCompilationOptions> _compilationOptions;
-
         private CakeOptions _options;
-
         public string Key { get; } = "Cake";
         public string Language { get; } = Constants.LanguageNames.Cake;
         public IEnumerable<string> Extensions { get; } = new[] { ".cake" };
         public bool EnabledByDefault { get; } = true;
+        public bool Initialized { get; private set; }
 
         [ImportingConstructor]
         public CakeProjectSystem(
@@ -70,6 +69,8 @@ namespace OmniSharp.Cake
 
         public void Initalize(IConfiguration configuration)
         {
+            if (Initialized) return;
+
             _options = new CakeOptions();
             configuration.Bind(_options);
 
@@ -103,6 +104,8 @@ namespace OmniSharp.Cake
 
             // Watch .cake files
             _fileSystemWatcher.Watch(".cake", OnCakeFileChanged);
+
+            Initialized = true;
         }
 
         private void AddCakeFile(string cakeFilePath)

--- a/src/OmniSharp.DotNet/DotNetProjectSystem.cs
+++ b/src/OmniSharp.DotNet/DotNetProjectSystem.cs
@@ -28,7 +28,6 @@ namespace OmniSharp.DotNet
     public class DotNetProjectSystem : IProjectSystem
     {
         private const string CompilationConfiguration = "Debug";
-
         private readonly IOmniSharpEnvironment _environment;
         private readonly OmniSharpWorkspace _workspace;
         private readonly IDotNetCliService _dotNetCliService;
@@ -37,7 +36,6 @@ namespace OmniSharp.DotNet
         private readonly IFileSystemWatcher _fileSystemWatcher;
         private readonly ILogger _logger;
         private readonly ProjectStatesCache _projectStates;
-
         private DotNetWorkspace _workspaceContext;
         private bool _enableRestorePackages;
 
@@ -66,6 +64,7 @@ namespace OmniSharp.DotNet
         public string Language { get; } = LanguageNames.CSharp;
         public IEnumerable<string> Extensions { get; } = new string[] { ".cs" };
         public bool EnabledByDefault { get; } = false;
+        public bool Initialized { get; private set; }
 
         Task<object> IProjectSystem.GetWorkspaceModelAsync(WorkspaceInformationRequest request)
         {
@@ -103,6 +102,8 @@ namespace OmniSharp.DotNet
 
         public void Initalize(IConfiguration configuration)
         {
+            if (Initialized) return;
+
             _logger.LogInformation($"Initializing in {_environment.TargetDirectory}");
 
             if (!bool.TryParse(configuration["enablePackageRestore"], out _enableRestorePackages))
@@ -115,6 +116,8 @@ namespace OmniSharp.DotNet
             _workspaceContext = new DotNetWorkspace(_environment.TargetDirectory);
 
             Update(allowRestore: true);
+            
+            Initialized = true;
         }
 
         public void Update(bool allowRestore)

--- a/src/OmniSharp.Host/Endpoint/LanguagePredicateHandler.cs
+++ b/src/OmniSharp.Host/Endpoint/LanguagePredicateHandler.cs
@@ -16,7 +16,7 @@ namespace OmniSharp.Endpoint
 
         public string GetLanguageForFilePath(string filePath)
         {
-            foreach (var projectSystem in _projectSystems)
+            foreach (var projectSystem in _projectSystems.Where(project => project.Initialized))
             {
                 if (projectSystem.Extensions.Any(extension => filePath.EndsWith(extension, StringComparison.OrdinalIgnoreCase)))
                 {

--- a/src/OmniSharp.Roslyn/ProjectEventForwarder.cs
+++ b/src/OmniSharp.Roslyn/ProjectEventForwarder.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Composition;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using OmniSharp.Eventing;
@@ -85,7 +86,7 @@ namespace OmniSharp.Roslyn
         {
             var response = new ProjectInformationResponse();
 
-            foreach (var projectSystem in _projectSystems)
+            foreach (var projectSystem in _projectSystems.Where(project => project.Initialized))
             {
                 var project = await projectSystem.GetProjectModelAsync(fileName);
                 if (project != null)

--- a/src/OmniSharp.Roslyn/ProjectInformationService.cs
+++ b/src/OmniSharp.Roslyn/ProjectInformationService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Composition;
+using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Mef;
 using OmniSharp.Models.ProjectInformation;
@@ -23,7 +24,7 @@ namespace OmniSharp
         {
             var response = new ProjectInformationResponse();
 
-            foreach (var projectSystem in _projectSystems)
+            foreach (var projectSystem in _projectSystems.Where(project => project.Initialized))
             {
                 var project = await projectSystem.GetProjectModelAsync(request.FileName);
                 response.Add($"{projectSystem.Key}Project", project);

--- a/src/OmniSharp.Roslyn/WorkspaceInformationService.cs
+++ b/src/OmniSharp.Roslyn/WorkspaceInformationService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Composition;
+using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Mef;
 using OmniSharp.Models.WorkspaceInformation;
@@ -23,7 +24,7 @@ namespace OmniSharp
         {
             var response = new WorkspaceInformationResponse();
 
-            foreach (var projectSystem in _projectSystems)
+            foreach (var projectSystem in _projectSystems.Where(project => project.Initialized))
             {
                 var workspaceModel = await projectSystem.GetWorkspaceModelAsync(request);
                 response.Add(projectSystem.Key, workspaceModel);

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -22,16 +22,13 @@ namespace OmniSharp.Script
     public class ScriptProjectSystem : IProjectSystem
     {
         private const string CsxExtension = ".csx";
-
         private readonly ConcurrentDictionary<string, ProjectInfo> _projects = new ConcurrentDictionary<string, ProjectInfo>();
         private readonly ScriptContextProvider _scriptContextProvider;
         private readonly OmniSharpWorkspace _workspace;
         private readonly IOmniSharpEnvironment _env;
         private readonly ILogger _logger;
         private readonly IFileSystemWatcher _fileSystemWatcher;
-        private readonly ILoggerFactory _loggerFactory;
         private readonly FileSystemHelper _fileSystemHelper;
-
         private ScriptOptions _scriptOptions;
         private Lazy<ScriptContext> _scriptContext;
 
@@ -41,7 +38,6 @@ namespace OmniSharp.Script
         {
             _workspace = workspace;
             _env = env;
-            _loggerFactory = loggerFactory;
             _fileSystemWatcher = fileSystemWatcher;
             _fileSystemHelper = fileSystemHelper;
             _logger = loggerFactory.CreateLogger<ScriptProjectSystem>();
@@ -52,9 +48,12 @@ namespace OmniSharp.Script
         public string Language { get; } = LanguageNames.CSharp;
         public IEnumerable<string> Extensions { get; } = new[] { CsxExtension };
         public bool EnabledByDefault { get; } = true;
+        public bool Initialized { get; private set; }
 
         public void Initalize(IConfiguration configuration)
         {
+            if (Initialized) return;
+
             _scriptOptions = new ScriptOptions();
             ConfigurationBinder.Bind(configuration, _scriptOptions);
 
@@ -84,6 +83,8 @@ namespace OmniSharp.Script
 
             // Watch CSX files in order to add/remove them in workspace
             _fileSystemWatcher.Watch(CsxExtension, OnCsxFileChanged);
+
+            Initialized = true;
         }
 
         private void OnCsxFileChanged(string filePath, FileChangeType changeType)

--- a/tests/OmniSharp.Cake.Tests/CakeProjectSystemFacts.cs
+++ b/tests/OmniSharp.Cake.Tests/CakeProjectSystemFacts.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -71,6 +72,20 @@ namespace OmniSharp.Cake.Tests
             }
         }
 
+        [Fact]
+        public async Task DoesntParticipateInWorkspaceInfoResponseWhenDisabled()
+        {
+            using (var testProject = await TestAssets.Instance.GetTestProjectAsync("CakeProject", shadowCopy: false))
+            using (var host = CreateOmniSharpHost(testProject.Directory, configurationData: new Dictionary<string, string>
+            {
+                ["cake:enabled"] = "false"
+            }))
+            {
+                var workspaceInfo = await GetWorkspaceInfoAsync(host);
+                Assert.Null(workspaceInfo);
+            }
+        }
+
         private static async Task<CakeContextModelCollection> GetWorkspaceInfoAsync(OmniSharpTestHost host)
         {
             var service = host.GetWorkspaceInformationService();
@@ -81,6 +96,8 @@ namespace OmniSharp.Cake.Tests
             };
 
             var response = await service.Handle(request);
+
+            if (!response.ContainsKey("Cake")) return null;
 
             return (CakeContextModelCollection)response["Cake"];
         }

--- a/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
+++ b/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
@@ -78,6 +78,7 @@ namespace OmniSharp.Http.Tests
             public string Language { get; } = LanguageNames.CSharp;
             public IEnumerable<string> Extensions { get; } = new[] { ".cs" };
             public bool EnabledByDefault { get; } = true;
+            public bool Initialized => throw new NotImplementedException();
 
             public Task<object> GetWorkspaceModelAsync(WorkspaceInformationRequest request)
             {

--- a/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
+++ b/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
@@ -78,7 +78,7 @@ namespace OmniSharp.Http.Tests
             public string Language { get; } = LanguageNames.CSharp;
             public IEnumerable<string> Extensions { get; } = new[] { ".cs" };
             public bool EnabledByDefault { get; } = true;
-            public bool Initialized => throw new NotImplementedException();
+            public bool Initialized { get; } = true;
 
             public Task<object> GetWorkspaceModelAsync(WorkspaceInformationRequest request)
             {

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -239,6 +240,20 @@ namespace OmniSharp.MSBuild.Tests
 
                 Assert.Equal("ProjectWithWildcardPackageReference.csproj", Path.GetFileName(project.Path));
                 Assert.Equal(3, project.SourceFiles.Count);
+            }
+        }
+
+        [Fact]
+        public async Task DoesntParticipateInWorkspaceInfoResponseWhenDisabled()
+        {
+            using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectAndSolution"))
+            using (var host = CreateOmniSharpHost(testProject.Directory, configurationData: new Dictionary<string, string>
+            {
+                ["msbuild:enabled"] = "false"
+            }))
+            {
+                var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
+                Assert.Null(workspaceInfo);
             }
         }
     }

--- a/tests/OmniSharp.Script.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.Script.Tests/WorkspaceInformationTests.cs
@@ -186,6 +186,20 @@ namespace OmniSharp.Script.Tests
             }
         }
 
+        [Fact]
+        public async Task DoesntParticipateInWorkspaceInfoResponseWhenDisabled()
+        {
+            using (var testProject = TestAssets.Instance.GetTestScript("SingleCsiScript"))
+            using (var host = CreateOmniSharpHost(testProject.Directory, configurationData: new Dictionary<string, string>
+            {
+                ["script:enabled"] = "false"
+            }))
+            {
+                var workspaceInfo = await GetWorkspaceInfoAsync(host);
+                Assert.Null(workspaceInfo);
+            }
+        }
+
         private string GetMsCorlibPath() => Assembly.Load(new AssemblyName("mscorlib"))?.Location;
 
         private void VerifyCorLib(ScriptContextModel project, bool expected = true)
@@ -207,6 +221,8 @@ namespace OmniSharp.Script.Tests
             };
 
             var response = await service.Handle(request);
+
+            if (!response.ContainsKey("Script")) return null;
 
             return (ScriptContextModelCollection)response["Script"];
         }

--- a/tests/TestUtility/TestHostExtensions.cs
+++ b/tests/TestUtility/TestHostExtensions.cs
@@ -54,6 +54,8 @@ namespace TestUtility
 
             var response = await service.Handle(request);
 
+            if (!response.ContainsKey("MsBuild")) return null;
+
             return (MSBuildWorkspaceInfo)response["MsBuild"];
         }
 


### PR DESCRIPTION
At the moment we can disable any project system via the config, which causes it to be skipped upon initialization.
However, some services such as `WorkspaceInformationService` or `ProjectInformationService` didn't respect the flag and still reached into the project systems for some information when invoked.

This PR fixes that.