### PR TITLE
Escape markdown to fix plaintext returns.

### DIFF
--- a/src/OmniSharp.LanguageServerProtocol/Handlers/HoverHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/HoverHandler.cs
@@ -54,7 +54,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
             {
                 // TODO: Range?  We don't currently have that!
                 // Range =
-                Contents = new MarkedStringsOrMarkupContent(new MarkedStringContainer(omnisharpResponse.Type, omnisharpResponse.Documentation))
+                Contents = new MarkedStringsOrMarkupContent(new MarkedStringContainer(Helpers.EscapeMarkdown(omnisharpResponse.Type), Helpers.EscapeMarkdown(omnisharpResponse.Documentation)))
             };
         }
 

--- a/src/OmniSharp.LanguageServerProtocol/Helpers.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Helpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Models;
 using OmniSharp.Models.Diagnostics;
@@ -117,6 +118,13 @@ namespace OmniSharp.LanguageServerProtocol
                 Start = ToPosition(range.Start),
                 End = ToPosition(range.End)
             };
+        }
+
+        public static string EscapeMarkdown(string markdown)
+        {
+            if (markdown == null)
+                return null;
+            return Regex.Replace(markdown, @"([\\`\*_\{\}\[\]\(\)#+\-\.!])", @"\$1");
         }
     }
 }


### PR DESCRIPTION
Fixes #1556.  Omnisharp is returning plaintext and assigning to MarkedString, which, according to the LSP spec, is a markdown formatted string.  Add a function to escape the text to prevent parsing errors.