### PR TITLE
 Run editor config options provider last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All changes to the project will be documented in this file.
         }
     ```
 * Added support for *AdditionalFiles* in csproj files ([#1510](https://github.com/OmniSharp/omnisharp-roslyn/issues/1510), PR: [#1547](https://github.com/OmniSharp/omnisharp-roslyn/pull/1547))
+* Fixed a bug in *.editorconfig* where formatting settings were not correctly passed into external code fixes ([#1558](https://github.com/OmniSharp/omnisharp-roslyn/issues/1558), PR: [#1526](https://github.com/OmniSharp/omnisharp-roslyn/pull/1559))
 
 ## [1.33.0] - 2019-07-01
 * Added support for `.editorconfig` files to control formatting settings, analyzers, coding styles and naming conventions. The feature is currently opt-into and needs to be enabled using OmniSharp configuration ([#31](https://github.com/OmniSharp/omnisharp-roslyn/issues/31), PR: [#1526](https://github.com/OmniSharp/omnisharp-roslyn/pull/1526))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All changes to the project will be documented in this file.
         }
     ```
 * Added support for *AdditionalFiles* in csproj files ([#1510](https://github.com/OmniSharp/omnisharp-roslyn/issues/1510), PR: [#1547](https://github.com/OmniSharp/omnisharp-roslyn/pull/1547))
-* Fixed a bug in *.editorconfig* where formatting settings were not correctly passed into external code fixes ([#1558](https://github.com/OmniSharp/omnisharp-roslyn/issues/1558), PR: [#1526](https://github.com/OmniSharp/omnisharp-roslyn/pull/1559))
+* Fixed a bug in *.editorconfig* where formatting settings were not correctly passed into external code fixes ([#1558](https://github.com/OmniSharp/omnisharp-roslyn/issues/1558), PR: [#1559](https://github.com/OmniSharp/omnisharp-roslyn/pull/1559))
 
 ## [1.33.0] - 2019-07-01
 * Added support for `.editorconfig` files to control formatting settings, analyzers, coding styles and naming conventions. The feature is currently opt-into and needs to be enabled using OmniSharp configuration ([#31](https://github.com/OmniSharp/omnisharp-roslyn/issues/31), PR: [#1526](https://github.com/OmniSharp/omnisharp-roslyn/pull/1526))

--- a/src/OmniSharp.Roslyn.CSharp/Services/EditorConfigWorkspaceOptionsProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/EditorConfigWorkspaceOptionsProvider.cs
@@ -1,10 +1,7 @@
 ﻿using System.Composition;
 using System.IO;
-using System.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.CodingConventions;
 using OmniSharp.Options;
 using OmniSharp.Roslyn.CSharp.Services.Formatting.EditorConfig;
 using OmniSharp.Roslyn.Options;
@@ -16,7 +13,7 @@ namespace OmniSharp.Roslyn.CSharp.Services
     {
         private readonly ILoggerFactory _loggerFactory;
 
-        public int Order => -100;
+        public int Order => 200;
 
         [ImportingConstructor]
         public EditorConfigWorkspaceOptionsProvider(ILoggerFactory loggerFactory)

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/EditorConfigFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/EditorConfigFacts.cs
@@ -357,11 +357,6 @@ class Foo
             Assert.Equal(TrimLines(expected), TrimLines(actual), false, true, true);
         }
 
-        //private static void AssertIgnoringLineEnding(string expected, string actual)
-        //{
-        //    Assert.Equal(expected.Replace("\r\n", "\n"), actual.Replace("\r\n", "\n"),);
-        //}
-
         private static string TrimLines(string source)
         {
             return string.Join("\n", source.Split('\n').Select(s => s.Trim()));

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/EditorConfigFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/EditorConfigFacts.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -118,6 +119,48 @@ class Bar:Foo { }
                 var response = await requestHandler.Handle(request);
 
                 Assert.Equal(expected, response.Buffer);
+            }
+        }
+
+
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task RespectsCSharpFormatSettings_InExecutedCodeActions(string filename)
+        {
+            // omnisharp.json sets spacing to true (1 space)
+            // but .editorconfig sets it to false (0 spaces)
+            var testFile = new TestFile(Path.Combine(TestAssets.Instance.TestFilesFolder, filename), @"
+class Foo { }
+class Bar $$   :    Foo { }
+");
+            var expected = @"
+class Foo { }
+class Bar:Foo { }
+";
+            using (var host = CreateOmniSharpHost(new[] { testFile }, new Dictionary<string, string>
+            {
+                ["FormattingOptions:EnableEditorConfigSupport"] = "true",
+                ["FormattingOptions:SpaceAfterColonInBaseTypeDeclaration"] = "true", // this should be ignored because .editorconfig gets higher priority
+                ["FormattingOptions:SpaceBeforeColonInBaseTypeDeclaration"] = "true", // this should be ignored because .editorconfig gets higher priority
+                ["RoslynExtensionsOptions:EnableAnalyzersSupport"] = "true"
+            }, TestAssets.Instance.TestFilesFolder))
+            {
+                var point = testFile.Content.GetPointFromPosition();
+                var runRequestHandler = host.GetRequestHandler<RunCodeActionService>(OmniSharpEndpoints.V2.RunCodeAction);
+                var runRequest = new RunCodeActionRequest
+                {
+                    Line = point.Line,
+                    Column = point.Offset,
+                    FileName = testFile.FileName,
+                    Identifier = "Fix formatting",
+                    WantsTextChanges = false,
+                    WantsAllCodeActionOperations = true,
+                    Buffer = testFile.Content.Code
+                };
+                var runResponse = await runRequestHandler.Handle(runRequest);
+
+                Assert.Equal(expected, ((ModifiedFileResponse)runResponse.Changes.First()).Buffer, ignoreLineEndingDifferences: true);
             }
         }
 
@@ -313,6 +356,11 @@ class Foo
         {
             Assert.Equal(TrimLines(expected), TrimLines(actual), false, true, true);
         }
+
+        //private static void AssertIgnoringLineEnding(string expected, string actual)
+        //{
+        //    Assert.Equal(expected.Replace("\r\n", "\n"), actual.Replace("\r\n", "\n"),);
+        //}
 
         private static string TrimLines(string source)
         {


### PR DESCRIPTION
fixes #1558 

At the moment we run `.editorconfig` options provider before the formatting options provider (formatting options from `omnisharp.json` + config params).

It doesn't work, because the result is we load formatting settings from `.editorconfig` and then *override them all* (not just the "changed" ones) with defaults from [here](https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Shared/Options/FormattingOptions.cs). This only applies to formatting rules, not other settings like naming conventions and code style.

Now, on our formatting endpoints it doesn't matter, since we reapply `.editorconfig` options on the fly again then - that's why the bug doesn't manifest itself on "normal" formatting, but for external code fixes, the formatting options do not correctly reflect `.editorconfig`. 

The practical consequence is also that if you have an `.editorconfig` file, it will take precedence over anything else but I think this is fine.