### PR TITLE
Added support for "sync namespace" refactoring

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>16.0.461</MSBuildPackageVersion>
     <NuGetPackageVersion>5.0.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.3.0-beta1-19365-07</RoslynPackageVersion>
+    <RoslynPackageVersion>3.3.0-beta2-19376-02</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>16.0.461</MSBuildPackageVersion>
     <NuGetPackageVersion>5.0.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.2.0-beta4-19326-12</RoslynPackageVersion>
+    <RoslynPackageVersion>3.3.0-beta1-19365-07</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 

--- a/src/OmniSharp.Abstractions/Configuration.cs
+++ b/src/OmniSharp.Abstractions/Configuration.cs
@@ -4,7 +4,7 @@ namespace OmniSharp
     {
         public static bool ZeroBasedIndices = false;
 
-        public const string RoslynVersion = "3.2.0.0";
+        public const string RoslynVersion = "3.3.0.0";
         public const string RoslynPublicKeyToken = "31bf3856ad364e35";
 
         public readonly static string RoslynFeatures = GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.Features");

--- a/src/OmniSharp.Http.Driver/app.config
+++ b/src/OmniSharp.Http.Driver/app.config
@@ -7,15 +7,15 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0"/>
             </dependentAssembly>
 
             <dependentAssembly>

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
@@ -51,6 +51,7 @@ namespace OmniSharp.MSBuild.ProjectFile
             public RuleSet RuleSet { get; }
             public ImmutableDictionary<string, string> ReferenceAliases { get; }
             public bool TreatWarningsAsErrors { get; }
+            public string DefaultNamespace { get; }
 
             private ProjectData()
             {
@@ -85,6 +86,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 bool signAssembly,
                 string assemblyOriginatorKeyFile,
                 bool treatWarningsAsErrors,
+                string defaultNamespace,
                 RuleSet ruleset)
                 : this()
             {
@@ -114,6 +116,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 AssemblyOriginatorKeyFile = assemblyOriginatorKeyFile;
                 TreatWarningsAsErrors = treatWarningsAsErrors;
                 RuleSet = ruleset;
+                DefaultNamespace = defaultNamespace;
             }
 
             private ProjectData(
@@ -139,11 +142,12 @@ namespace OmniSharp.MSBuild.ProjectFile
                 ImmutableArray<string> analyzers,
                 ImmutableArray<string> additionalFiles,
                 bool treatWarningsAsErrors,
+                string defaultNamespace,
                 RuleSet ruleset,
                 ImmutableDictionary<string, string> referenceAliases)
                 : this(guid, name, assemblyName, targetPath, outputPath, intermediateOutputPath, projectAssetsFile,
                       configuration, platform, targetFramework, targetFrameworks, outputKind, languageVersion, nullableContextOptions, allowUnsafeCode,
-                      documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, signAssembly, assemblyOriginatorKeyFile, treatWarningsAsErrors, ruleset)
+                      documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, signAssembly, assemblyOriginatorKeyFile, treatWarningsAsErrors, defaultNamespace, ruleset)
             {
                 SourceFiles = sourceFiles.EmptyIfDefault();
                 ProjectReferences = projectReferences.EmptyIfDefault();
@@ -165,6 +169,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 var projectAssetsFile = project.GetPropertyValue(PropertyNames.ProjectAssetsFile);
                 var configuration = project.GetPropertyValue(PropertyNames.Configuration);
                 var platform = project.GetPropertyValue(PropertyNames.Platform);
+                var defaultNamespace = project.GetPropertyValue(PropertyNames.RootNamespace);
 
                 var targetFramework = new FrameworkName(project.GetPropertyValue(PropertyNames.TargetFrameworkMoniker));
 
@@ -190,7 +195,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 return new ProjectData(
                     guid, name, assemblyName, targetPath, outputPath, intermediateOutputPath, projectAssetsFile,
                     configuration, platform, targetFramework, targetFrameworks, outputKind, languageVersion, nullableContextOptions, allowUnsafeCode,
-                    documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, signAssembly, assemblyOriginatorKeyFile, treatWarningsAsErrors, ruleset: null);
+                    documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, signAssembly, assemblyOriginatorKeyFile, treatWarningsAsErrors, defaultNamespace, ruleset: null);
             }
 
             public static ProjectData Create(MSB.Execution.ProjectInstance projectInstance)
@@ -204,6 +209,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 var projectAssetsFile = projectInstance.GetPropertyValue(PropertyNames.ProjectAssetsFile);
                 var configuration = projectInstance.GetPropertyValue(PropertyNames.Configuration);
                 var platform = projectInstance.GetPropertyValue(PropertyNames.Platform);
+                var defaultNamespace = projectInstance.GetPropertyValue(PropertyNames.RootNamespace);
 
                 var targetFramework = new FrameworkName(projectInstance.GetPropertyValue(PropertyNames.TargetFrameworkMoniker));
 
@@ -277,7 +283,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                     configuration, platform, targetFramework, targetFrameworks,
                     outputKind, languageVersion, nullableContextOptions, allowUnsafeCode, documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds,
                     signAssembly, assemblyOriginatorKeyFile,
-                    sourceFiles, projectReferences, references.ToImmutable(), packageReferences, analyzers, additionalFiles, treatWarningsAsErrors, ruleset, referenceAliases.ToImmutableDictionary());
+                    sourceFiles, projectReferences, references.ToImmutable(), packageReferences, analyzers, additionalFiles, treatWarningsAsErrors, defaultNamespace, ruleset, referenceAliases.ToImmutableDictionary());
             }
 
             private static RuleSet ResolveRulesetIfAny(MSB.Execution.ProjectInstance projectInstance)

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -53,6 +53,8 @@ namespace OmniSharp.MSBuild.ProjectFile
         public ImmutableArray<string> AdditionalFiles => _data.AdditionalFiles;
         public ImmutableDictionary<string, string> ReferenceAliases => _data.ReferenceAliases;
         public bool TreatWarningsAsErrors => _data.TreatWarningsAsErrors;
+        public string DefaultNamespace => _data.DefaultNamespace;
+
         public ProjectIdInfo ProjectIdInfo { get; }
 
         private ProjectFileInfo(

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
@@ -52,7 +52,6 @@ namespace OmniSharp.MSBuild.ProjectFile
         public static ImmutableDictionary<string, ReportDiagnostic> GetDiagnosticOptions(this ProjectFileInfo projectFileInfo)
         {
             var defaultSuppressions = CompilationOptionsHelper.GetDefaultSuppressedDiagnosticOptions(projectFileInfo.SuppressedDiagnosticIds);
-
             var specificRules = projectFileInfo.RuleSet?.SpecificDiagnosticOptions ?? ImmutableDictionary<string, ReportDiagnostic>.Empty;
 
             return specificRules.Concat(defaultSuppressions.Where(x => !specificRules.Keys.Contains(x.Key))).ToImmutableDictionary();
@@ -71,7 +70,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 filePath: projectFileInfo.FilePath,
                 outputFilePath: projectFileInfo.TargetPath,
                 compilationOptions: projectFileInfo.CreateCompilationOptions(),
-                analyzerReferences: analyzerReferences);
+                analyzerReferences: analyzerReferences).WithDefaultNamespace(projectFileInfo.DefaultNamespace);
         }
 
         private static IEnumerable<AnalyzerReference> ResolveAnalyzerReferencesForProject(ProjectFileInfo projectFileInfo, IAnalyzerAssemblyLoader analyzerAssemblyLoader)

--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
@@ -29,6 +29,7 @@
         public const string ProjectGuid = nameof(ProjectGuid);
         public const string ProjectName = nameof(ProjectName);
         public const string _ResolveReferenceDependencies = nameof(_ResolveReferenceDependencies);
+        public const string RootNamespace = nameof(RootNamespace);
         public const string RoslynTargetsPath = nameof(RoslynTargetsPath);
         public const string SignAssembly = nameof(SignAssembly);
         public const string SkipCompilerExecution = nameof(SkipCompilerExecution);

--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -490,7 +490,7 @@ namespace OmniSharp.MSBuild
                     continue;
                 }
 
-                _workspace.AddDocument(project.Id, sourceFile);
+                _workspace.AddDocument(project, sourceFile);
             }
 
             // Removing any remaining documents from the project.

--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -434,20 +434,37 @@ namespace OmniSharp.MSBuild
             UpdateParseOptions(project, projectFileInfo.LanguageVersion, projectFileInfo.PreprocessorSymbolNames, !string.IsNullOrWhiteSpace(projectFileInfo.DocumentationFile));
             UpdateProjectReferences(project, projectFileInfo.ProjectReferences);
             UpdateReferences(project, projectFileInfo.ProjectReferences, projectFileInfo.References);
-            UpdateAnalyzerReferences(projectFileInfo, project);
+            UpdateAnalyzerReferences(project, projectFileInfo);
             UpdateAdditionalFiles(project, projectFileInfo.AdditionalFiles);
+            UpdateProjectProperties(project, projectFileInfo);
 
             _workspace.TryPromoteMiscellaneousDocumentsToProject(project);
             _workspace.UpdateDiagnosticOptionsForProject(project.Id, projectFileInfo.GetDiagnosticOptions());
         }
 
-        private void UpdateAnalyzerReferences(ProjectFileInfo projectFileInfo, Project project)
+        private void UpdateAnalyzerReferences(Project project, ProjectFileInfo projectFileInfo)
         {
             var analyzerFileReferences = projectFileInfo.Analyzers
                 .Select(analyzerReferencePath => new AnalyzerFileReference(analyzerReferencePath, _analyzerAssemblyLoader))
                 .ToImmutableArray();
 
             _workspace.SetAnalyzerReferences(project.Id, analyzerFileReferences);
+        }
+
+        private void UpdateProjectProperties(Project project, ProjectFileInfo projectFileInfo)
+        {
+            if (projectFileInfo.DefaultNamespace != project.DefaultNamespace)
+            {
+                var newSolution = _workspace.CurrentSolution.WithProjectDefaultNamespace(project.Id, projectFileInfo.DefaultNamespace);
+                if (_workspace.TryApplyChanges(newSolution))
+                {
+                    _logger.LogDebug($"Updated default namespace from {project.DefaultNamespace} to {projectFileInfo.DefaultNamespace} on {project.FilePath} project.");
+                }
+                else
+                {
+                    _logger.LogWarning($"Couldn't update default namespace from {project.DefaultNamespace} to {projectFileInfo.DefaultNamespace} on {project.FilePath} project.");
+                }
+            }
         }
 
         private void UpdateAdditionalFiles(Project project, IList<string> additionalFiles)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/RunCodeActionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/RunCodeActionService.cs
@@ -148,7 +148,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
                             }
                         }
 
-                        this.Workspace.AddDocument(documentId, projectChange.ProjectId, newFilePath, newDocument.SourceCodeKind);
+                        this.Workspace.AddDocument(documentId, projectChange.NewProject, newFilePath, newDocument.SourceCodeKind);
                         solution = this.Workspace.CurrentSolution;
                     }
                     else

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -77,7 +77,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
                 }
                 else if (invocation.Receiver is SimpleNameSyntax && invocation.IsInStaticContext)
                 {
-                    methodGroup = methodGroup.Where(m => m.IsStatic);
+                    methodGroup = methodGroup.Where(m => m.IsStatic || m.MethodKind == MethodKind.LocalFunction);
                 }
 
                 foreach (var methodOverload in methodGroup)

--- a/src/OmniSharp.Roslyn/MetadataHelper.cs
+++ b/src/OmniSharp.Roslyn/MetadataHelper.cs
@@ -106,7 +106,7 @@ namespace OmniSharp.Roslyn
 
         public async Task<Location> GetSymbolLocationFromMetadata(ISymbol symbol, Document metadataDocument, CancellationToken cancellationToken = new CancellationToken())
         {
-            var symbolKeyCreateMethod = _symbolKey.GetMethod(Create, BindingFlags.Static | BindingFlags.Public);
+            var symbolKeyCreateMethod = _symbolKey.GetMethod(Create, BindingFlags.Static | BindingFlags.NonPublic);
             var symboldId = symbolKeyCreateMethod.InvokeStatic(new object[] { symbol, cancellationToken });
 
             return await _getLocationInGeneratedSourceAsync.InvokeStatic<Task<Location>>(new object[] { symboldId, metadataDocument, cancellationToken });

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -473,5 +473,23 @@ namespace OmniSharp
         {
             OnAdditionalDocumentRemoved(documentId);
         }
+
+        protected override void ApplyProjectChanges(ProjectChanges projectChanges)
+        {
+            // since Roslyn currently doesn't handle DefaultNamespace changes via ApplyProjectChanges
+            // and OnDefaultNamespaceChanged is internal, we use reflection for now
+            if (projectChanges.NewProject.DefaultNamespace != projectChanges.OldProject.DefaultNamespace)
+            {
+                var onDefaultNamespaceChanged = this.GetType().GetMethod("OnDefaultNamespaceChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+                if (onDefaultNamespaceChanged != null)
+                {
+                    onDefaultNamespaceChanged.Invoke(this, new object[] { projectChanges.ProjectId, projectChanges.NewProject.DefaultNamespace });
+                }
+            }
+            else
+            {
+                base.ApplyProjectChanges(projectChanges);
+            }
+        }
     }
 }

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -487,10 +487,8 @@ namespace OmniSharp
                     onDefaultNamespaceChanged.Invoke(this, new object[] { projectChanges.ProjectId, projectChanges.NewProject.DefaultNamespace });
                 }
             }
-            else
-            {
-                base.ApplyProjectChanges(projectChanges);
-            }
+
+            base.ApplyProjectChanges(projectChanges);
         }
     }
 }

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -94,16 +94,6 @@ namespace OmniSharp
             OnMetadataReferenceRemoved(projectId, metadataReference);
         }
 
-        public void AddDocument(DocumentInfo documentInfo)
-        {
-            // if the file has already been added as a misc file,
-            // because of a possible race condition between the updates of the project systems,
-            // remove the misc file and add the document as required
-            TryRemoveMiscellaneousDocument(documentInfo.FilePath);
-
-            OnDocumentAdded(documentInfo);
-        }
-
         public DocumentId TryAddMiscellaneousDocument(string filePath, string language)
         {
             if (GetDocument(filePath) != null)
@@ -179,6 +169,16 @@ namespace OmniSharp
 
             AddProject(projectInfo);
             return projectInfo;
+        }
+
+        public void AddDocument(DocumentInfo documentInfo)
+        {
+            // if the file has already been added as a misc file,
+            // because of a possible race condition between the updates of the project systems,
+            // remove the misc file and add the document as required
+            TryRemoveMiscellaneousDocument(documentInfo.FilePath);
+
+            OnDocumentAdded(documentInfo);
         }
 
         public DocumentId AddDocument(ProjectId projectId, string filePath, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -186,6 +186,13 @@ namespace OmniSharp
             return AddDocument(project, filePath, sourceCodeKind);
         }
 
+        public DocumentId AddDocument(ProjectId projectId, string filePath, TextLoader loader, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
+        {
+            var documentId = DocumentId.CreateNewId(projectId);
+            var project = this.CurrentSolution.GetProject(projectId);
+            return AddDocument(documentId, project, filePath, loader, sourceCodeKind);
+        }
+
         public DocumentId AddDocument(Project project, string filePath, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
         {
             var documentId = DocumentId.CreateNewId(project.Id);
@@ -194,15 +201,25 @@ namespace OmniSharp
 
         public DocumentId AddDocument(DocumentId documentId, Project project, string filePath, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
         {
+            return AddDocument(documentId, project, filePath, new OmniSharpTextLoader(filePath), sourceCodeKind);
+        }
+
+        internal DocumentId AddDocument(DocumentId documentId, ProjectId projectId, string filePath, TextLoader loader, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
+        {
+            var project = this.CurrentSolution.GetProject(projectId);
+            return AddDocument(documentId, project, filePath, loader, sourceCodeKind);
+        }
+
+        internal DocumentId AddDocument(DocumentId documentId, Project project, string filePath, TextLoader loader, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
+        {
             var projectFolder = Path.GetDirectoryName(project.FilePath);
-            string folder = null;
+            IEnumerable<string> folders = null;
             if (projectFolder != null && filePath.StartsWith(projectFolder))
             {
-                folder = Path.GetDirectoryName(filePath).Substring(projectFolder.Length).TrimStart(new[] { '\\', '/' });
+                folders = Path.GetDirectoryName(filePath).Substring(projectFolder.Length).TrimStart(new[] { '\\', '/' }).Split(new[] { '\\', '/' });
             }
 
-            var loader = new OmniSharpTextLoader(filePath);
-            var documentInfo = DocumentInfo.Create(documentId, Path.GetFileName(filePath), folders: string.IsNullOrWhiteSpace(folder) ? null : new string[] { folder }, filePath: filePath, loader: loader, sourceCodeKind: sourceCodeKind);
+            var documentInfo = DocumentInfo.Create(documentId, Path.GetFileName(filePath), folders: folders, filePath: filePath, loader: loader, sourceCodeKind: sourceCodeKind);
 
             AddDocument(documentInfo);
 

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -195,7 +195,11 @@ namespace OmniSharp
         public DocumentId AddDocument(DocumentId documentId, Project project, string filePath, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
         {
             var projectFolder = Path.GetDirectoryName(project.FilePath);
-            var folder = Path.GetDirectoryName(filePath).Substring(projectFolder.Length).TrimStart(new[] { '\\', '/' });
+            string folder = null;
+            if (projectFolder != null && filePath.StartsWith(projectFolder))
+            {
+                folder = Path.GetDirectoryName(filePath).Substring(projectFolder.Length).TrimStart(new[] { '\\', '/' });
+            }
 
             var loader = new OmniSharpTextLoader(filePath);
             var documentInfo = DocumentInfo.Create(documentId, Path.GetFileName(filePath), folders: string.IsNullOrWhiteSpace(folder) ? null : new string[] { folder }, filePath: filePath, loader: loader, sourceCodeKind: sourceCodeKind);

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -182,17 +182,25 @@ namespace OmniSharp
 
         public DocumentId AddDocument(ProjectId projectId, string filePath, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
         {
-            var documentId = DocumentId.CreateNewId(projectId);
-            this.AddDocument(documentId, projectId, filePath, sourceCodeKind);
-            return documentId;
+            var project = this.CurrentSolution.GetProject(projectId);
+            return AddDocument(project, filePath, sourceCodeKind);
         }
 
-        public DocumentId AddDocument(DocumentId documentId, ProjectId projectId, string filePath, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
+        public DocumentId AddDocument(Project project, string filePath, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
         {
-            var loader = new OmniSharpTextLoader(filePath);
-            var documentInfo = DocumentInfo.Create(documentId, Path.GetFileName(filePath), filePath: filePath, loader: loader, sourceCodeKind: sourceCodeKind);
+            var documentId = DocumentId.CreateNewId(project.Id);
+            return AddDocument(documentId, project, filePath, sourceCodeKind);
+        }
 
-            this.AddDocument(documentInfo);
+        public DocumentId AddDocument(DocumentId documentId, Project project, string filePath, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
+        {
+            var projectFolder = Path.GetDirectoryName(project.FilePath);
+            var folder = Path.GetDirectoryName(filePath).Substring(projectFolder.Length).TrimStart(new[] { '\\', '/' });
+
+            var loader = new OmniSharpTextLoader(filePath);
+            var documentInfo = DocumentInfo.Create(documentId, Path.GetFileName(filePath), folders: string.IsNullOrWhiteSpace(folder) ? null : new string[] { folder }, filePath: filePath, loader: loader, sourceCodeKind: sourceCodeKind);
+
+            AddDocument(documentInfo);
 
             return documentId;
         }

--- a/src/OmniSharp.Shared/FileSystem/FileSystemHelper.cs
+++ b/src/OmniSharp.Shared/FileSystem/FileSystemHelper.cs
@@ -44,7 +44,16 @@ namespace OmniSharp.FileSystem
 
         public static string GetRelativePath(string fullPath, string basePath)
         {
-            if (!basePath.EndsWith(s_directorySeparatorChar))
+            // if any of them is not set, abort
+            if (string.IsNullOrWhiteSpace(basePath) || string.IsNullOrWhiteSpace(fullPath)) return null;
+
+            // paths must be rooted
+            if (!Path.IsPathRooted(basePath) || !Path.IsPathRooted(fullPath)) return null;
+
+            // if they are the same, abort
+            if (fullPath == basePath) return null;
+
+            if (!Path.HasExtension(basePath) && !basePath.EndsWith(s_directorySeparatorChar))
             {
                 basePath += Path.DirectorySeparatorChar;
             }

--- a/src/OmniSharp.Shared/FileSystem/FileSystemHelper.cs
+++ b/src/OmniSharp.Shared/FileSystem/FileSystemHelper.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Composition;
+using System.IO;
 using System.Linq;
 using Microsoft.Extensions.FileSystemGlobbing;
 using OmniSharp.Options;
@@ -9,6 +11,7 @@ namespace OmniSharp.FileSystem
     [Export, Shared]
     public class FileSystemHelper
     {
+        private static string s_directorySeparatorChar = Path.DirectorySeparatorChar.ToString();
         private readonly OmniSharpOptions _omniSharpOptions;
         private readonly IOmniSharpEnvironment _omniSharpEnvironment;
 
@@ -37,6 +40,20 @@ namespace OmniSharp.FileSystem
             }
 
             return matcher.GetResultsInFullPath(targetDirectory);
+        }
+
+        public static string GetRelativePath(string fullPath, string basePath)
+        {
+            if (!basePath.EndsWith(s_directorySeparatorChar))
+            {
+                basePath += Path.DirectorySeparatorChar;
+            }
+
+            var baseUri = new Uri(basePath);
+            var fullUri = new Uri(fullPath);
+            var relativeUri = baseUri.MakeRelativeUri(fullUri);
+            var relativePath = Uri.UnescapeDataString(relativeUri.ToString()).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            return relativePath;
         }
     }
 }

--- a/src/OmniSharp.Shared/FileSystem/FileSystemHelper.cs
+++ b/src/OmniSharp.Shared/FileSystem/FileSystemHelper.cs
@@ -51,7 +51,7 @@ namespace OmniSharp.FileSystem
             if (!Path.IsPathRooted(basePath) || !Path.IsPathRooted(fullPath)) return null;
 
             // if they are the same, abort
-            if (fullPath == basePath) return null;
+            if (fullPath.Equals(basePath, StringComparison.Ordinal)) return null;
 
             if (!Path.HasExtension(basePath) && !basePath.EndsWith(s_directorySeparatorChar))
             {

--- a/src/OmniSharp.Stdio.Driver/app.config
+++ b/src/OmniSharp.Stdio.Driver/app.config
@@ -7,15 +7,15 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0"/>
             </dependentAssembly>
 
             <dependentAssembly>

--- a/tests/OmniSharp.Cake.Tests/CodeActionsV2Facts.cs
+++ b/tests/OmniSharp.Cake.Tests/CodeActionsV2Facts.cs
@@ -64,7 +64,8 @@ namespace OmniSharp.Cake.Tests
             {
                 "using System.Text.RegularExpressions;",
                 "System.Text.RegularExpressions.Regex",
-                "Extract Method"
+                "Extract Method",
+                "Introduce local for 'Regex.Match(\"foo\", \"bar\")'"
             };
             Assert.Equal(expected, refactorings);
         }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CodeActionsV2Facts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CodeActionsV2Facts.cs
@@ -137,7 +137,8 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 "Generate type 'Console' -> Generate class 'Console' in new file",
                 "Generate type 'Console' -> Generate class 'Console'",
                 "Generate type 'Console' -> Generate nested class 'Console'",
-                "Extract Method"
+                "Extract Method",
+                "Introduce local for 'Console.Write(\"should be using System;\")'"
             } : new List<string>
             {
                 "using System;",
@@ -150,7 +151,8 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 "Generate type 'Console' -> Generate class 'Console' in new file",
                 "Generate type 'Console' -> Generate class 'Console'",
                 "Generate type 'Console' -> Generate nested class 'Console'",
-                "Extract Method"
+                "Extract Method",
+                "Introduce local for 'Console.Write(\"should be using System;\")'"
             };
 
             Assert.Equal(expected, refactorings);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FilesChangedFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FilesChangedFacts.cs
@@ -32,7 +32,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 var handler = GetRequestHandler(host);
                 await handler.Handle(new[] { new FilesChangedRequest() { FileName = filePath, ChangeType = FileChangeType.Create } });
 
-                Assert.Contains(host.Workspace.CurrentSolution.Projects.First().Documents, d => d.Name == filePath);
+                Assert.Contains(host.Workspace.CurrentSolution.Projects.First().Documents, d => d.FilePath == filePath && d.Name == "FileName.cs");
             }
         }
 
@@ -51,7 +51,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 var handler = GetRequestHandler(host);
                 await handler.Handle(new[] { new FilesChangedRequest() { FileName = filePath, ChangeType = FileChangeType.Create } });
 
-                Assert.Contains(host.Workspace.CurrentSolution.Projects.First().Documents, d => d.Name == filePath);
+                Assert.Contains(host.Workspace.CurrentSolution.Projects.First().Documents, d => d.FilePath == filePath && d.Name == "FileName.cs");
 
                 var nestedDirectory = Path.Combine(projectDirectory, "Nested");
                 Directory.CreateDirectory(nestedDirectory);
@@ -62,8 +62,8 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 await handler.Handle(new[] { new FilesChangedRequest() { FileName = filePath, ChangeType = FileChangeType.Delete } });
                 await handler.Handle(new[] { new FilesChangedRequest() { FileName = destinationPath, ChangeType = FileChangeType.Create } });
 
-                Assert.Contains(host.Workspace.CurrentSolution.Projects.First().Documents, d => d.Name == destinationPath);
-                Assert.DoesNotContain(host.Workspace.CurrentSolution.Projects.First().Documents, d => d.Name == filePath);
+                Assert.Contains(host.Workspace.CurrentSolution.Projects.First().Documents, d => d.FilePath == destinationPath && d.Name == "FileName.cs");
+                Assert.DoesNotContain(host.Workspace.CurrentSolution.Projects.First().Documents, d => d.FilePath == filePath && d.Name == "FileName.cs");
             }
         }
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -880,12 +880,38 @@ class Program
         [Theory]
         [InlineData("dummy.cs")]
         [InlineData("dummy.csx")]
-        public async Task GivesHelpForLocalFunctions(string filename)
+        public async Task GivesHelpForLocalFunctionsInStaticContext(string filename)
         {
             const string source =
 @"class Program
 {
     public static void Main()
+    {
+        var flag = LocalFunction($$);
+        bool LocalFunction(int i)
+        {
+            return i > 0;
+        }
+    }
+}";
+            var actual = await GetSignatureHelp(filename, source);
+            Assert.Single(actual.Signatures);
+
+            var signature = actual.Signatures.ElementAt(0);
+            Assert.Single(signature.Parameters);
+            Assert.Equal("i", signature.Parameters.ElementAt(0).Name);
+            Assert.Equal("int i", signature.Parameters.ElementAt(0).Label);
+        }
+
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task GivesHelpForLocalFunctionsInNonStaticContext(string filename)
+        {
+            const string source =
+@"class Program
+{
+    public void Main()
     {
         var flag = LocalFunction($$);
         bool LocalFunction(int i)

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SyncNamespaceFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SyncNamespaceFacts.cs
@@ -1,0 +1,84 @@
+﻿using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using OmniSharp.Models;
+using OmniSharp.Models.V2.CodeActions;
+using OmniSharp.Roslyn.CSharp.Services.Refactoring.V2;
+using TestUtility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OmniSharp.Roslyn.CSharp.Tests
+{
+    public class SyncNamespaceFacts : AbstractTestFixture
+    {
+        public SyncNamespaceFacts(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Theory]
+        [InlineData("OmniSharpTest", "Bar.cs")]
+        [InlineData("OmniSharpTest.Foo", "Foo", "Bar.cs")]
+        [InlineData("OmniSharpTest.Foo.Bar", "Foo", "Bar", "Baz.cs")]
+        public async Task RespectFolderName_InOfferedRefactorings(string expectedNamespace, params string[] relativePath)
+        {
+            var testFile = new TestFile(Path.Combine(TestAssets.Instance.TestFilesFolder, Path.Combine(relativePath)), @"namespace Xx$$x { }");
+
+            using (var host = CreateOmniSharpHost(new[] { testFile }, null, path: TestAssets.Instance.TestFilesFolder))
+            {
+                var point = testFile.Content.GetPointFromPosition();
+                var getRequestHandler = host.GetRequestHandler<GetCodeActionsService>(OmniSharpEndpoints.V2.GetCodeActions);
+                var getRequest = new GetCodeActionsRequest
+                {
+                    Line = point.Line,
+                    Column = point.Offset,
+                    FileName = testFile.FileName
+                };
+
+                var getResponse = await getRequestHandler.Handle(getRequest);
+                Assert.NotNull(getResponse.CodeActions);
+                Assert.Contains(getResponse.CodeActions, f => f.Name == $"Change namespace to '{expectedNamespace}'");
+            }
+        }
+
+        [Theory]
+        [InlineData("OmniSharpTest", "Bar.cs")]
+        [InlineData("OmniSharpTest.Foo", "Foo", "Bar.cs")]
+        [InlineData("OmniSharpTest.Foo.Bar", "Foo", "Bar", "Baz.cs")]
+        public async Task RespectFolderName_InExecutedCodeActions(string expectedNamespace, params string[] relativePath)
+        {
+            var expected = "namespace " + expectedNamespace + " { }";
+            var testFile = new TestFile(Path.Combine(TestAssets.Instance.TestFilesFolder, Path.Combine(relativePath)), @"namespace Xx$$x { }");
+
+            using (var host = CreateOmniSharpHost(new[] { testFile }, null, TestAssets.Instance.TestFilesFolder))
+            {
+                var point = testFile.Content.GetPointFromPosition();
+                var runRequestHandler = host.GetRequestHandler<RunCodeActionService>(OmniSharpEndpoints.V2.RunCodeAction);
+                var runRequest = new RunCodeActionRequest
+                {
+                    Line = point.Line,
+                    Column = point.Offset,
+                    FileName = testFile.FileName,
+                    Identifier = $"Change namespace to '{expectedNamespace}'",
+                    WantsTextChanges = false,
+                    WantsAllCodeActionOperations = true,
+                    Buffer = testFile.Content.Code
+                };
+                var runResponse = await runRequestHandler.Handle(runRequest);
+
+                AssertIgnoringIndent(expected, ((ModifiedFileResponse)runResponse.Changes.First()).Buffer);
+            }
+        }
+
+        private static void AssertIgnoringIndent(string expected, string actual)
+        {
+            Assert.Equal(TrimLines(expected), TrimLines(actual), false, true, true);
+        }
+
+        private static string TrimLines(string source)
+        {
+            return string.Join("\n", source.Split('\n').Select(s => s.Trim()));
+        }
+    }
+}

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SyncNamespaceFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SyncNamespaceFacts.cs
@@ -1,6 +1,8 @@
 ﻿using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using OmniSharp.Models;
 using OmniSharp.Models.V2.CodeActions;
 using OmniSharp.Roslyn.CSharp.Services.Refactoring.V2;
@@ -69,6 +71,23 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
                 AssertIgnoringIndent(expected, ((ModifiedFileResponse)runResponse.Changes.First()).Buffer);
             }
+        }
+
+        [Fact]
+        public void CheckIfOnDefaultNamespaceChangedIsAvailableInRoslyn()
+        {
+            // This tracks the availability of OnDefaultNamespaceChanged on the Workspace
+            // at the moment it's not and we need to manually sync default namespace after it changes
+            // when OmniSharp is running by having reflection in
+            // protected override void ApplyProjectChanges(ProjectChanges projectChanges)
+            // once it's fixed in Roslyn we can get rid of this test
+            var onDefaultNamespaceChanged = typeof(OmniSharpWorkspace).GetMethod("OnDefaultNamespaceChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(onDefaultNamespaceChanged);
+
+            var parameters = onDefaultNamespaceChanged.GetParameters();
+            Assert.Equal(2, parameters.Count());
+            Assert.Equal(typeof(ProjectId), parameters[0].ParameterType);
+            Assert.Equal(typeof(string), parameters[1].ParameterType);
         }
 
         private static void AssertIgnoringIndent(string expected, string actual)

--- a/tests/TestUtility/AbstractCodeActionsTestFixture.cs
+++ b/tests/TestUtility/AbstractCodeActionsTestFixture.cs
@@ -19,7 +19,7 @@ namespace TestUtility
 
         protected ITestOutputHelper TestOutput { get; }
 
-        private string BufferPath => $"{Path.DirectorySeparatorChar}somepath{Path.DirectorySeparatorChar}buffer{_fileTypeExtension}";
+        private string BufferPath => $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}somepath{Path.DirectorySeparatorChar}buffer{_fileTypeExtension}";
 
         protected AbstractCodeActionsTestFixture(ITestOutputHelper output, string fileTypeExtension = ".cs")
         {

--- a/tests/TestUtility/AbstractTestFixture.cs
+++ b/tests/TestUtility/AbstractTestFixture.cs
@@ -65,7 +65,7 @@ namespace TestUtility
 
             if (testFiles.Length > 0)
             {
-                host.AddFilesToWorkspace(testFiles);
+                host.AddFilesToWorkspace(path, testFiles);
             }
 
             return host;

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -133,6 +133,7 @@ namespace TestUtility
 
         public IEnumerable<ProjectId> AddFilesToWorkspace(string folderPath, params TestFile[] testFiles)
         {
+            folderPath = folderPath ?? Directory.GetCurrentDirectory();
             var projects = TestHelpers.AddProjectToWorkspace(
                 Workspace,
                 Path.Combine(folderPath, "project.csproj"),

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Composition.Hosting;
 using System.Composition.Hosting.Core;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -128,10 +129,13 @@ namespace TestUtility
         }
 
         public IEnumerable<ProjectId> AddFilesToWorkspace(params TestFile[] testFiles)
+            => AddFilesToWorkspace(Directory.GetCurrentDirectory(), testFiles);
+
+        public IEnumerable<ProjectId> AddFilesToWorkspace(string folderPath, params TestFile[] testFiles)
         {
             var projects = TestHelpers.AddProjectToWorkspace(
-                this.Workspace,
-                "project.csproj",
+                Workspace,
+                Path.Combine(folderPath, "project.csproj"),
                 new[] { "net472" },
                 testFiles.Where(f => f.FileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)).ToArray());
 

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -59,20 +59,13 @@ namespace TestUtility
                     language: LanguageNames.CSharp,
                     filePath: filePath,
                     metadataReferences: references,
-                    analyzerReferences: analyzerRefs);
+                    analyzerReferences: analyzerRefs).WithDefaultNamespace("OmniSharpTest");
 
                 workspace.AddProject(projectInfo);
 
                 foreach (var testFile in testFiles)
                 {
-                    var documentInfo = DocumentInfo.Create(
-                        id: DocumentId.CreateNewId(projectInfo.Id),
-                        name: testFile.FileName,
-                        sourceCodeKind: SourceCodeKind.Regular,
-                        loader: TextLoader.From(TextAndVersion.Create(testFile.Content.Text, versionStamp)),
-                        filePath: testFile.FileName);
-
-                    workspace.AddDocument(documentInfo);
+                    workspace.AddDocument(projectInfo.Id, testFile.FileName, TextLoader.From(TextAndVersion.Create(testFile.Content.Text, versionStamp)), SourceCodeKind.Regular);
                 }
 
                 projectsIds.Add(projectInfo.Id);

--- a/tests/app.config
+++ b/tests/app.config
@@ -7,15 +7,15 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0"/>
             </dependentAssembly>
 
             <dependentAssembly>


### PR DESCRIPTION
Fixes #1475 

Demo (first from within a folder, and then from the root of the project):

![tjh31xd8tC](https://user-images.githubusercontent.com/1710369/61534923-2d33ce00-aa31-11e9-81cd-ec9db9456751.gif)

We have actually PR-ed into Roslyn a change that opened up the necessary APIs to public https://github.com/dotnet/roslyn/pull/35486 to make it work.
This PR introduces a bump to Roslyn `3.3.0-beta1-19365-07` to have access to them - this is a build for the `dev16.3` release train. 

We also now track "folders" of the documents added to the workspace (the refactoring works off that) - which is basically a relative path.
Default namespace is, by default, the assembly name, unless overwritten by `<RootNamespace>` MsBuild property. A change in MsBuild project file is respected by us in real time (no need to restart OmniSharp), by updating the workspace accordingly. Unfortunately there is still a bug in Roslyn where the default namespace change doesn't propagate correctly via `TryApplyChanges` on the solution, so we have a small reflection workaround for that. I will PR the necessary change into Roslyn and once it's available we can remove the workaround.

cc @savpek 



