### PR TITLE
Fixed analyzer timeout issue.

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -235,12 +235,12 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
                 }
                 else if (allAnalyzers.Any()) // Analyzers cannot be called with empty analyzer list.
                 {
-                    var semanticDiagnosticsWithAnalyzers = await compiled
-                        .WithAnalyzers(allAnalyzers, workspaceAnalyzerOptions)
+                    var compilationWithAnalyzers = compiled.WithAnalyzers(allAnalyzers, new CompilationWithAnalyzersOptions(workspaceAnalyzerOptions, null, false, false, false));
+
+                    var semanticDiagnosticsWithAnalyzers = await compilationWithAnalyzers
                         .GetAnalyzerSemanticDiagnosticsAsync(documentSemanticModel, filterSpan: null, perDocumentTimeout.Token);
 
-                    var syntaxDiagnosticsWithAnalyzers = await compiled
-                        .WithAnalyzers(allAnalyzers, workspaceAnalyzerOptions)
+                    var syntaxDiagnosticsWithAnalyzers = await compilationWithAnalyzers
                         .GetAnalyzerSyntaxDiagnosticsAsync(documentSemanticModel.SyntaxTree, perDocumentTimeout.Token);
 
                     diagnostics = semanticDiagnosticsWithAnalyzers

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
@@ -267,7 +267,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
 
         private void OnAnalyzerException(Exception ex, DiagnosticAnalyzer analyzer, Diagnostic diagnostic)
         {
-            _logger.LogError($"Exception in diagnostic analyzer." +
+            _logger.LogDebug($"Exception in diagnostic analyzer." +
                 $"\n            analyzer: {analyzer}" +
                 $"\n            diagnostic: {diagnostic}" +
                 $"\n            exception: {ex.Message}");


### PR DESCRIPTION
Hello.  
I think that the cause of this [timeout issue](https://github.com/OmniSharp/omnisharp-roslyn/issues/1552) is in [GetAnalyzerSemanticDiagnosticsAsync](https://github.com/OmniSharp/omnisharp-roslyn/blob/61d7b82b79058d6250afe4d4db0d9e6bf7ffeac7/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs#L240).  
This function may not return a response.  
I checked the difference with [AnalyzerRunner](https://github.com/dotnet/roslyn/blob/version-3.1.0/src/Tools/AnalyzerRunner/Program.cs#L211) and made a correction.  
And it seems like it worked.

I'm glad if this information helps a little.