### PR TITLE
 run script tests as part of the build script

### DIFF
--- a/build.json
+++ b/build.json
@@ -23,7 +23,8 @@
     "OmniSharp.Stdio.Tests",
     "OmniSharp.DotNetTest.Tests",
     "OmniSharp.Tests",
-    "OmniSharp.Cake.Tests"
+    "OmniSharp.Cake.Tests",
+    "OmniSharp.Script.Tests"
   ],
   "TestAssets": [
     "NUnitTestProject",

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -66,6 +66,7 @@ namespace OmniSharp.Script
             if (allCsxFiles.Length == 0)
             {
                 _logger.LogInformation("Could not find any CSX files");
+                Initialized = true;
 
                 // Watch CSX files in order to add/remove them in workspace
                 _fileSystemWatcher.Watch(CsxExtension, OnCsxFileChanged);

--- a/test-assets/test-scripts/SingleCsiScriptWithCustomRsp/test.rsp
+++ b/test-assets/test-scripts/SingleCsiScriptWithCustomRsp/test.rsp
@@ -1,2 +1,2 @@
-/u:System.Web
-/r:System.Web
+/u:System.Xml
+/r:System.Xml

--- a/tests/OmniSharp.Script.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.Script.Tests/WorkspaceInformationTests.cs
@@ -67,9 +67,9 @@ namespace OmniSharp.Script.Tests
                 Assert.Equal(typeof(CommandLineScriptGlobals), project.GlobalsType);
 
                 // should have RSP inherited settings
-                VerifyAssemblyReference(project, "system.web");
+                VerifyAssemblyReference(project, "system.xml");
                 var commonUsingStatement = Assert.Single(project.CommonUsings);
-                Assert.Equal("System.Web", commonUsingStatement);
+                Assert.Equal("System.Xml", commonUsingStatement);
             }
         }
 


### PR DESCRIPTION
This is discovered as investigation of https://github.com/OmniSharp/omnisharp-roslyn/pull/1568#discussion_r306826127

Turns out the build script has never executed scripting tests 🙈😂

One test was broken since https://github.com/OmniSharp/omnisharp-roslyn/pull/1543 - but it never showed up in the build script, cause that skipped scripting tests...
This PR adds scripting tests to the builds script and fixes the initialization logic that made the test fail.