### PR TITLE
renamed NullableContextOptions to Nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to the project will be documented in this file.
 
 ## [1.34.1] - not yet released
 * Fixed a regression introduced in 1.32.20 which caused `AllowUnsafeCode` in csproj to also enable `TreatWarningsAsErrors` behavior ([#1565](https://github.com/OmniSharp/omnisharp-roslyn/issues/1565), PR: [#1567](https://github.com/OmniSharp/omnisharp-roslyn/pull/1567))
+* Added support for reading C# 8.0 `Nullable` setting from csproj files (and dropped support for `NullableContextOptions` - based on the LDM decision to [rename the MSBuild property](https://github.com/dotnet/roslyn/issues/35432) ([#1573](https://github.com/OmniSharp/omnisharp-roslyn/pull/1573))
 
 ## [1.34.0] - 2019-07-15
 * Added support for Roslyn code actions that normally need UI - they used to be explicitly sipped by OmniSharp, now it surfaces them with predefined defaults instead. ([#1220](https://github.com/OmniSharp/omnisharp-roslyn/issues/1220), PR: [#1406](https://github.com/OmniSharp/omnisharp-roslyn/pull/1406)) These are:

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
@@ -179,7 +179,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 var languageVersion = PropertyConverter.ToLanguageVersion(project.GetPropertyValue(PropertyNames.LangVersion));
                 var allowUnsafeCode = PropertyConverter.ToBoolean(project.GetPropertyValue(PropertyNames.AllowUnsafeBlocks), defaultValue: false);
                 var outputKind = PropertyConverter.ToOutputKind(project.GetPropertyValue(PropertyNames.OutputType));
-                var nullableContextOptions = PropertyConverter.ToNullableContextOptions(project.GetPropertyValue(PropertyNames.NullableContextOptions));
+                var nullableContextOptions = PropertyConverter.ToNullableContextOptions(project.GetPropertyValue(PropertyNames.Nullable));
                 var documentationFile = project.GetPropertyValue(PropertyNames.DocumentationFile);
                 var preprocessorSymbolNames = PropertyConverter.ToPreprocessorSymbolNames(project.GetPropertyValue(PropertyNames.DefineConstants));
                 var suppressedDiagnosticIds = PropertyConverter.ToSuppressedDiagnosticIds(project.GetPropertyValue(PropertyNames.NoWarn));
@@ -218,7 +218,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 var languageVersion = PropertyConverter.ToLanguageVersion(projectInstance.GetPropertyValue(PropertyNames.LangVersion));
                 var allowUnsafeCode = PropertyConverter.ToBoolean(projectInstance.GetPropertyValue(PropertyNames.AllowUnsafeBlocks), defaultValue: false);
                 var outputKind = PropertyConverter.ToOutputKind(projectInstance.GetPropertyValue(PropertyNames.OutputType));
-                var nullableContextOptions = PropertyConverter.ToNullableContextOptions(projectInstance.GetPropertyValue(PropertyNames.NullableContextOptions));
+                var nullableContextOptions = PropertyConverter.ToNullableContextOptions(projectInstance.GetPropertyValue(PropertyNames.Nullable));
                 var documentationFile = projectInstance.GetPropertyValue(PropertyNames.DocumentationFile);
                 var preprocessorSymbolNames = PropertyConverter.ToPreprocessorSymbolNames(projectInstance.GetPropertyValue(PropertyNames.DefineConstants));
                 var suppressedDiagnosticIds = PropertyConverter.ToSuppressedDiagnosticIds(projectInstance.GetPropertyValue(PropertyNames.NoWarn));

--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
@@ -21,7 +21,7 @@
         public const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);
         public const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
         public const string NoWarn = nameof(NoWarn);
-        public const string NullableContextOptions = nameof(NullableContextOptions);
+        public const string Nullable = nameof(Nullable);
         public const string OutputPath = nameof(OutputPath);
         public const string Platform = nameof(Platform);
         public const string ProjectAssetsFile = nameof(ProjectAssetsFile);

--- a/test-assets/test-projects/CSharp8AndNullableContext/CSharp8AndNullableContext.csproj
+++ b/test-assets/test-projects/CSharp8AndNullableContext/CSharp8AndNullableContext.csproj
@@ -7,4 +7,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-</Project>
+</Project> 

--- a/test-assets/test-projects/CSharp8AndNullableContext/CSharp8AndNullableContext.csproj
+++ b/test-assets/test-projects/CSharp8AndNullableContext/CSharp8AndNullableContext.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -125,7 +125,7 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
                 var targetFramework = Assert.Single(projectFileInfo.TargetFrameworks);
-                Assert.Equal("netcoreapp2.1", targetFramework);
+                Assert.Equal("netcoreapp3.0", targetFramework);
                 Assert.Equal(LanguageVersion.CSharp8, projectFileInfo.LanguageVersion);
                 Assert.Equal(NullableContextOptions.Enable, projectFileInfo.NullableContextOptions);
                 Assert.Equal("Debug", projectFileInfo.Configuration);


### PR DESCRIPTION
since vs 16.2p1 the msbuild property to enable nullable reference types is called `Nullable` instead of `NullableContextOptions` (this is LDM decision).

see related PRs here: https://github.com/dotnet/roslyn/pull/35516 and here https://github.com/dotnet/docs/pull/12497

issue reported by @shoe-diamente - thanks!