### PR TITLE
 updated to Roslyn 3.3.0-beta2-19401-05 to address a StackOverflowException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.34.2] - not yet released
+* Update to Roslyn `3.3.0-beta2-19401-05` which fixes a 1.34.1 regression resulting in StackOverflowException on code analysis of partial classes (PR: [#1579](https://github.com/OmniSharp/omnisharp-roslyn/pull/1579))
+
 ## [1.34.1] - 2019-07-31
 * Added support for "sync namespace" refactoring ([#1475](https://github.com/OmniSharp/omnisharp-roslyn/issues/1475), PR: [#1563](https://github.com/OmniSharp/omnisharp-roslyn/pull/1563))
 * Fixed a regression introduced in 1.32.20 which caused `AllowUnsafeCode` in csproj to also enable `TreatWarningsAsErrors` behavior ([#1565](https://github.com/OmniSharp/omnisharp-roslyn/issues/1565), PR: [#1567](https://github.com/OmniSharp/omnisharp-roslyn/pull/1567))

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>16.0.461</MSBuildPackageVersion>
     <NuGetPackageVersion>5.0.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.3.0-beta2-19376-02</RoslynPackageVersion>
+    <RoslynPackageVersion>3.3.0-beta2-19401-05</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
With the update to Roslyn `3.3.0-beta2-19376-02` we introduced a critical `StackOverflowException` when performing code analysis on partial classes.
This is a bug described in https://github.com/dotnet/roslyn/issues/37567

It was fixed in https://github.com/dotnet/roslyn/pull/37623 and is available in `3.3.0-beta2-19401-05`.
We should merge this and release 1.34.2 soonest as the current version is unusable with analyzers+partial classes.

cc @akshita31 @jonsequitur who lured us into updating to that specific build in the first place 😀