### PR TITLE
retarget test projects to .NET Core 2.1 (LTS)

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -118,14 +118,6 @@ Task("InstallDotNetCoreSdk")
             version: buildPlan.DotNetVersion,
             installFolder: env.Folders.DotNetSdk);
 
-        foreach (var runtimeVersion in buildPlan.DotNetSharedRuntimeVersions)
-        {
-            InstallDotNetSdk(env, buildPlan,
-                version: runtimeVersion,
-                installFolder: env.Folders.DotNetSdk,
-                sharedRuntime: true);
-        }
-
         // Add non-legacy .NET SDK to PATH
         var oldPath = Environment.GetEnvironmentVariable("PATH");
         var newPath = env.Folders.DotNetSdk + (string.IsNullOrEmpty(oldPath) ? "" : System.IO.Path.PathSeparator + oldPath);

--- a/build.json
+++ b/build.json
@@ -2,9 +2,6 @@
   "DotNetInstallScriptURL": "https://dot.net/v1",
   "DotNetChannel": "preview",
   "DotNetVersion": "2.1.505",
-  "DotNetSharedRuntimeVersions": [
-    "1.1.2"
-  ],
   "RequiredMonoVersion": "5.18.0.0",
   "DownloadURL": "https://roslynomnisharp.blob.core.windows.net/ext",
   "MonoRuntimeMacOS": "mono.macOS-5.18.1.0.zip",

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -344,7 +344,6 @@ public class BuildPlan
     public string DotNetInstallScriptURL { get; set; }
     public string DotNetChannel { get; set; }
     public string DotNetVersion { get; set; }
-    public string[] DotNetSharedRuntimeVersions { get; set; }
     public string RequiredMonoVersion { get; set; }
     public string DownloadURL { get; set; }
     public string MonoRuntimeMacOS { get; set; }

--- a/test-assets/test-projects/DeepProjectTransitiveReference/App/App.csproj
+++ b/test-assets/test-projects/DeepProjectTransitiveReference/App/App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test-assets/test-projects/HelloWorldSlim/HelloWorldSlim.csproj
+++ b/test-assets/test-projects/HelloWorldSlim/HelloWorldSlim.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test-assets/test-projects/MSTestProject/MSTestProject.csproj
+++ b/test-assets/test-projects/MSTestProject/MSTestProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test-assets/test-projects/NUnitTestProject/NUnitTestProject.csproj
+++ b/test-assets/test-projects/NUnitTestProject/NUnitTestProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test-assets/test-projects/NetStandardAndNetCoreApp/NetStandardAndNetCoreApp.csproj
+++ b/test-assets/test-projects/NetStandardAndNetCoreApp/NetStandardAndNetCoreApp.csproj
@@ -1,21 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard1.5</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <OutputType>exe</OutputType>
     <DefineConstants>NETCOREAPP;$(DefineConstants)</DefineConstants>
-    <PackageTargetFallback>dnxcore50</PackageTargetFallback>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs" />
     <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
-    <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.0.1</Version>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.NETCore.App"  />
     <PackageReference Include="Newtonsoft.Json">
       <Version>7.0.1</Version>
     </PackageReference>

--- a/test-assets/test-projects/ProjectAndSolution/ProjectAndSolution.csproj
+++ b/test-assets/test-projects/ProjectAndSolution/ProjectAndSolution.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test-assets/test-projects/ProjectAndSolutionWithProjectSection/ProjectAndSolutionWithProjectSection.csproj
+++ b/test-assets/test-projects/ProjectAndSolutionWithProjectSection/ProjectAndSolutionWithProjectSection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test-assets/test-projects/ProjectWithGeneratedFile/ProjectWithGeneratedFile.csproj
+++ b/test-assets/test-projects/ProjectWithGeneratedFile/ProjectWithGeneratedFile.csproj
@@ -27,7 +27,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test-assets/test-projects/ProjectWithMismatchedFileName/ProjectWithMismatchedFileName.csproj
+++ b/test-assets/test-projects/ProjectWithMismatchedFileName/ProjectWithMismatchedFileName.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test-assets/test-projects/ProjectWithMissingType/ProjectWithMissingType.csproj
+++ b/test-assets/test-projects/ProjectWithMissingType/ProjectWithMissingType.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 

--- a/test-assets/test-projects/ProjectWithMultiTFMLib/App/App.csproj
+++ b/test-assets/test-projects/ProjectWithMultiTFMLib/App/App.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test-assets/test-projects/TwoProjectsWithSolution/App/App.csproj
+++ b/test-assets/test-projects/TwoProjectsWithSolution/App/App.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test-assets/test-projects/XunitTestProject/XunitTestProject.csproj
+++ b/test-assets/test-projects/XunitTestProject/XunitTestProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/OmniSharp.Cake.Tests/TestAssets/multi.cake.g.txt
+++ b/tests/OmniSharp.Cake.Tests/TestAssets/multi.cake.g.txt
@@ -2533,7 +2533,7 @@ public void DotNetCoreBuild(System.String project)
 ///             <code>
 ///                 var settings = new DotNetCoreBuildSettings
 ///                 {
-///                     Framework = "netcoreapp2.1",
+///                     Framework = "netcoreapp1.0",
 ///                     Configuration = "Debug",
 ///                     OutputDirectory = "./artifacts/"
 ///                 };
@@ -2639,7 +2639,7 @@ public void DotNetCoreRun(System.String project, Cake.Core.IO.ProcessArgumentBui
 ///             <code>
 ///                 var settings = new DotNetCoreRunSettings
 ///                 {
-///                     Framework = "netcoreapp2.1",
+///                     Framework = "netcoreapp1.0",
 ///                     Configuration = "Release"
 ///                 };
 ///            
@@ -2676,7 +2676,7 @@ public void DotNetCorePublish(System.String project)
 ///             <code>
 ///                 var settings = new DotNetCorePublishSettings
 ///                 {
-///                     Framework = "netcoreapp2.1",
+///                     Framework = "netcoreapp1.0",
 ///                     Configuration = "Release",
 ///                     OutputDirectory = "./artifacts/"
 ///                 };
@@ -2809,7 +2809,7 @@ public void DotNetCoreClean(System.String project)
 ///             <code>
 ///                 var settings = new DotNetCoreCleanSettings
 ///                 {
-///                     Framework = "netcoreapp2.1",
+///                     Framework = "netcoreapp1.0",
 ///                     Configuration = "Debug",
 ///                     OutputDirectory = "./artifacts/"
 ///                 };

--- a/tests/OmniSharp.Cake.Tests/TestAssets/multi.cake.g.txt
+++ b/tests/OmniSharp.Cake.Tests/TestAssets/multi.cake.g.txt
@@ -2533,7 +2533,7 @@ public void DotNetCoreBuild(System.String project)
 ///             <code>
 ///                 var settings = new DotNetCoreBuildSettings
 ///                 {
-///                     Framework = "netcoreapp1.0",
+///                     Framework = "netcoreapp2.1",
 ///                     Configuration = "Debug",
 ///                     OutputDirectory = "./artifacts/"
 ///                 };
@@ -2639,7 +2639,7 @@ public void DotNetCoreRun(System.String project, Cake.Core.IO.ProcessArgumentBui
 ///             <code>
 ///                 var settings = new DotNetCoreRunSettings
 ///                 {
-///                     Framework = "netcoreapp1.0",
+///                     Framework = "netcoreapp2.1",
 ///                     Configuration = "Release"
 ///                 };
 ///            
@@ -2676,7 +2676,7 @@ public void DotNetCorePublish(System.String project)
 ///             <code>
 ///                 var settings = new DotNetCorePublishSettings
 ///                 {
-///                     Framework = "netcoreapp1.0",
+///                     Framework = "netcoreapp2.1",
 ///                     Configuration = "Release",
 ///                     OutputDirectory = "./artifacts/"
 ///                 };
@@ -2809,7 +2809,7 @@ public void DotNetCoreClean(System.String project)
 ///             <code>
 ///                 var settings = new DotNetCoreCleanSettings
 ///                 {
-///                     Framework = "netcoreapp1.0",
+///                     Framework = "netcoreapp2.1",
 ///                     Configuration = "Debug",
 ///                     OutputDirectory = "./artifacts/"
 ///                 };

--- a/tests/OmniSharp.Cake.Tests/TestAssets/single.cake.g.txt
+++ b/tests/OmniSharp.Cake.Tests/TestAssets/single.cake.g.txt
@@ -2533,7 +2533,7 @@ public void DotNetCoreBuild(System.String project)
 ///             <code>
 ///                 var settings = new DotNetCoreBuildSettings
 ///                 {
-///                     Framework = "netcoreapp2.1",
+///                     Framework = "netcoreapp1.0",
 ///                     Configuration = "Debug",
 ///                     OutputDirectory = "./artifacts/"
 ///                 };
@@ -2639,7 +2639,7 @@ public void DotNetCoreRun(System.String project, Cake.Core.IO.ProcessArgumentBui
 ///             <code>
 ///                 var settings = new DotNetCoreRunSettings
 ///                 {
-///                     Framework = "netcoreapp2.1",
+///                     Framework = "netcoreapp1.0",
 ///                     Configuration = "Release"
 ///                 };
 ///            
@@ -2676,7 +2676,7 @@ public void DotNetCorePublish(System.String project)
 ///             <code>
 ///                 var settings = new DotNetCorePublishSettings
 ///                 {
-///                     Framework = "netcoreapp2.1",
+///                     Framework = "netcoreapp1.0",
 ///                     Configuration = "Release",
 ///                     OutputDirectory = "./artifacts/"
 ///                 };
@@ -2809,7 +2809,7 @@ public void DotNetCoreClean(System.String project)
 ///             <code>
 ///                 var settings = new DotNetCoreCleanSettings
 ///                 {
-///                     Framework = "netcoreapp2.1",
+///                     Framework = "netcoreapp1.0",
 ///                     Configuration = "Debug",
 ///                     OutputDirectory = "./artifacts/"
 ///                 };

--- a/tests/OmniSharp.Cake.Tests/TestAssets/single.cake.g.txt
+++ b/tests/OmniSharp.Cake.Tests/TestAssets/single.cake.g.txt
@@ -2533,7 +2533,7 @@ public void DotNetCoreBuild(System.String project)
 ///             <code>
 ///                 var settings = new DotNetCoreBuildSettings
 ///                 {
-///                     Framework = "netcoreapp1.0",
+///                     Framework = "netcoreapp2.1",
 ///                     Configuration = "Debug",
 ///                     OutputDirectory = "./artifacts/"
 ///                 };
@@ -2639,7 +2639,7 @@ public void DotNetCoreRun(System.String project, Cake.Core.IO.ProcessArgumentBui
 ///             <code>
 ///                 var settings = new DotNetCoreRunSettings
 ///                 {
-///                     Framework = "netcoreapp1.0",
+///                     Framework = "netcoreapp2.1",
 ///                     Configuration = "Release"
 ///                 };
 ///            
@@ -2676,7 +2676,7 @@ public void DotNetCorePublish(System.String project)
 ///             <code>
 ///                 var settings = new DotNetCorePublishSettings
 ///                 {
-///                     Framework = "netcoreapp1.0",
+///                     Framework = "netcoreapp2.1",
 ///                     Configuration = "Release",
 ///                     OutputDirectory = "./artifacts/"
 ///                 };
@@ -2809,7 +2809,7 @@ public void DotNetCoreClean(System.String project)
 ///             <code>
 ///                 var settings = new DotNetCoreCleanSettings
 ///                 {
-///                     Framework = "netcoreapp1.0",
+///                     Framework = "netcoreapp2.1",
 ///                     Configuration = "Debug",
 ///                     OutputDirectory = "./artifacts/"
 ///                 };

--- a/tests/OmniSharp.DotNetTest.Tests/GetTestStartInfoFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/GetTestStartInfoFacts.cs
@@ -20,7 +20,7 @@ namespace OmniSharp.DotNetTest.Tests
                 XunitTestProject,
                 methodName: "Main.Test.MainTest.Test",
                 testFramework: "xunit",
-                targetFrameworkVersion: ".NETCoreApp, Version=1.1");
+                targetFrameworkVersion: ".NETCoreApp, Version=2.1");
         }
 
         // NUnit does not work with .NET CLI RTM yet. https://github.com/nunit/dotnet-test-nunit/issues/108

--- a/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
@@ -22,7 +22,7 @@ namespace OmniSharp.DotNetTest.Tests
                 methodName: "Main.Test.MainTest.Test",
                 testFramework: "xunit",
                 shouldPass: true,
-                targetFrameworkVersion: ".NETCoreApp, Version=1.1");
+                targetFrameworkVersion: ".NETCoreApp, Version=2.1");
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace OmniSharp.DotNetTest.Tests
                 methodName: "Main.Test.MainTest.DataDrivenTest1",
                 testFramework: "xunit",
                 shouldPass: false,
-                targetFrameworkVersion: ".NETCoreApp, Version=1.1");
+                targetFrameworkVersion: ".NETCoreApp, Version=2.1");
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace OmniSharp.DotNetTest.Tests
                 methodName: "Main.Test.MainTest.DataDrivenTest2",
                 testFramework: "xunit",
                 shouldPass: true,
-                targetFrameworkVersion: ".NETCoreApp, Version=1.1");
+                targetFrameworkVersion: ".NETCoreApp, Version=2.1");
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace OmniSharp.DotNetTest.Tests
                 methodName: "Main.Test.MainTest.UsesDisplayName",
                 testFramework: "xunit",
                 shouldPass: true,
-                targetFrameworkVersion: ".NETCoreApp, Version=1.1");
+                targetFrameworkVersion: ".NETCoreApp, Version=2.1");
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace OmniSharp.DotNetTest.Tests
                 methodName: "Main.Test.MainTest.TestWithSimilarName",
                 testFramework: "xunit",
                 shouldPass: true,
-                targetFrameworkVersion: ".NETCoreApp, Version=1.1");
+                targetFrameworkVersion: ".NETCoreApp, Version=2.1");
 
             Assert.Single(response.Results);
         }
@@ -79,7 +79,7 @@ namespace OmniSharp.DotNetTest.Tests
                 methodName: "Main.Test.MainTest.FailingTest",
                 testFramework: "xunit",
                 shouldPass: false,
-                targetFrameworkVersion: ".NETCoreApp, Version=1.1");
+                targetFrameworkVersion: ".NETCoreApp, Version=2.1");
 
             Assert.Single(response.Results);
             Assert.NotEmpty(response.Results[0].ErrorMessage);
@@ -94,7 +94,7 @@ namespace OmniSharp.DotNetTest.Tests
                 methodName: "Main.Test.MainTest.CheckStandardOutput",
                 testFramework: "xunit",
                 shouldPass: true,
-                targetFrameworkVersion: ".NETCoreApp, Version=1.1");
+                targetFrameworkVersion: ".NETCoreApp, Version=2.1");
 
             Assert.Single(response.Results);
             Assert.NotEmpty(response.Results[0].StandardOutput);

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -80,9 +80,9 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
                 var targetFramework = Assert.Single(projectFileInfo.TargetFrameworks);
-                Assert.Equal("netcoreapp1.0", targetFramework);
-                Assert.Equal("bin/Debug/netcoreapp1.0/", projectFileInfo.OutputPath.EnsureForwardSlashes());
-                Assert.Equal("obj/Debug/netcoreapp1.0/", projectFileInfo.IntermediateOutputPath.EnsureForwardSlashes());
+                Assert.Equal("netcoreapp2.1", targetFramework);
+                Assert.Equal("bin/Debug/netcoreapp2.1/", projectFileInfo.OutputPath.EnsureForwardSlashes());
+                Assert.Equal("obj/Debug/netcoreapp2.1/", projectFileInfo.IntermediateOutputPath.EnsureForwardSlashes());
                 Assert.Equal(3, projectFileInfo.SourceFiles.Length); // Program.cs, AssemblyInfo.cs, AssemblyAttributes.cs
                 Assert.Equal("Debug", projectFileInfo.Configuration);
                 Assert.Equal("AnyCPU", projectFileInfo.Platform);
@@ -102,10 +102,10 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
                 Assert.Equal(2, projectFileInfo.TargetFrameworks.Length);
-                Assert.Equal("netcoreapp1.0", projectFileInfo.TargetFrameworks[0]);
+                Assert.Equal("netcoreapp2.1", projectFileInfo.TargetFrameworks[0]);
                 Assert.Equal("netstandard1.5", projectFileInfo.TargetFrameworks[1]);
-                Assert.Equal("bin/Debug/netcoreapp1.0/", projectFileInfo.OutputPath.EnsureForwardSlashes());
-                Assert.Equal("obj/Debug/netcoreapp1.0/", projectFileInfo.IntermediateOutputPath.EnsureForwardSlashes());
+                Assert.Equal("bin/Debug/netcoreapp2.1/", projectFileInfo.OutputPath.EnsureForwardSlashes());
+                Assert.Equal("obj/Debug/netcoreapp2.1/", projectFileInfo.IntermediateOutputPath.EnsureForwardSlashes());
                 Assert.Equal(3, projectFileInfo.SourceFiles.Length); // Program.cs, AssemblyInfo.cs, AssemblyAttributes.cs
                 Assert.Equal("Debug", projectFileInfo.Configuration);
                 Assert.Equal("AnyCPU", projectFileInfo.Platform);

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -31,8 +31,8 @@ namespace OmniSharp.MSBuild.Tests
                 var project = Assert.Single(workspaceInfo.Projects);
 
                 Assert.Equal("ProjectAndSolution", project.AssemblyName);
-                Assert.Equal("bin/Debug/netcoreapp1.1/", project.OutputPath.EnsureForwardSlashes());
-                Assert.Equal("obj/Debug/netcoreapp1.1/", project.IntermediateOutputPath.EnsureForwardSlashes());
+                Assert.Equal("bin/Debug/netcoreapp2.1/", project.OutputPath.EnsureForwardSlashes());
+                Assert.Equal("obj/Debug/netcoreapp2.1/", project.IntermediateOutputPath.EnsureForwardSlashes());
                 var expectedTargetPath = $"{testProject.Directory}/{project.OutputPath}ProjectAndSolution.dll".EnsureForwardSlashes();
                 Assert.Equal(expectedTargetPath, project.TargetPath.EnsureForwardSlashes());
                 Assert.Equal("Debug", project.Configuration);
@@ -40,9 +40,9 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.True(project.IsExe);
                 Assert.False(project.IsUnityProject);
 
-                Assert.Equal(".NETCoreApp,Version=v1.1", project.TargetFramework);
+                Assert.Equal(".NETCoreApp,Version=v2.1", project.TargetFramework);
                 var targetFramework = Assert.Single(project.TargetFrameworks);
-                Assert.Equal("netcoreapp1.1", targetFramework.ShortName);
+                Assert.Equal("netcoreapp2.1", targetFramework.ShortName);
             }
         }
 
@@ -57,8 +57,8 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.Equal("ProjectAndSolutionWithProjectSection.sln", Path.GetFileName(workspaceInfo.SolutionPath));
                 Assert.NotNull(workspaceInfo.Projects);
                 var project = Assert.Single(workspaceInfo.Projects);
-                Assert.Equal(".NETCoreApp,Version=v1.1", project.TargetFramework);
-                Assert.Equal("netcoreapp1.1", project.TargetFrameworks[0].ShortName);
+                Assert.Equal(".NETCoreApp,Version=v2.1", project.TargetFramework);
+                Assert.Equal("netcoreapp2.1", project.TargetFrameworks[0].ShortName);
             }
         }
 
@@ -76,8 +76,8 @@ namespace OmniSharp.MSBuild.Tests
 
                 var firstProject = workspaceInfo.Projects[0];
                 Assert.Equal("App.csproj", Path.GetFileName(firstProject.Path));
-                Assert.Equal(".NETCoreApp,Version=v1.1", firstProject.TargetFramework);
-                Assert.Equal("netcoreapp1.1", firstProject.TargetFrameworks[0].ShortName);
+                Assert.Equal(".NETCoreApp,Version=v2.1", firstProject.TargetFramework);
+                Assert.Equal("netcoreapp2.1", firstProject.TargetFrameworks[0].ShortName);
 
                 var secondProject = workspaceInfo.Projects[1];
                 Assert.Equal("Lib.csproj", Path.GetFileName(secondProject.Path));


### PR DESCRIPTION
We dropped .NET Core 1.x support a while ago (#1539) however some of the test projects were still targeting 1.x (!).
The result was the test suite was testing something we didn't support 😂

This PR moves test projects to 2.1 LTS and updates the build accordingly (build should be faster now too).