### PR TITLE
run the complex analyzer test only on Windows

### DIFF
--- a/tests/OmniSharp.MSBuild.Tests/ProjectWithComplexAnalyzersTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectWithComplexAnalyzersTests.cs
@@ -12,8 +12,8 @@ namespace OmniSharp.MSBuild.Tests
         {
         }
 
-        // possible thread starvation on Linux when running in Azure DevOps
-        [ConditionalFact(typeof(NotOnLinux))]
+        // possible thread starvation on *nix when running in Azure DevOps
+        [ConditionalFact(typeof(WindowsOnly))]
         public async Task CanLoadComplexAnalyzers()
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectWithComplexAnalyzers"))

--- a/tests/TestUtility/ConditionalFactAttribute.cs
+++ b/tests/TestUtility/ConditionalFactAttribute.cs
@@ -54,10 +54,4 @@ namespace TestUtility
         public override bool ShouldSkip => !PlatformHelper.IsWindows;
         public override string SkipReason => "Can only be run on Windows";
     }
-
-    public class NotOnLinux : SkipCondition
-    {
-        public override bool ShouldSkip => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-        public override string SkipReason => "Cannot be run on Linux";
-    }
 }


### PR DESCRIPTION
This is a follow up to https://github.com/OmniSharp/omnisharp-roslyn/pull/1562#issuecomment-522892213
While everything seemed fine in the PR/branch builds, we ran into the same thread starvation/deadlock issue on master build on MacOS.

Let's change the test to run on Windows for now and see if it helps.