### PR TITLE
Fix using task assemblies which reference older v4/v12 msbuild assemblies

### DIFF
--- a/mono-packaging/copy-mono.sh
+++ b/mono-packaging/copy-mono.sh
@@ -63,8 +63,6 @@ mono_version=`mono --version | head -n 1 | sed 's/[^0-9.]*\([0-9.]*\).*/\1/'`
 
 gac_assemblies=(
     "Microsoft.Build.Engine/4.0.0.0__b03f5f7f11d50a3a/Microsoft.Build.Engine.dll"
-    "Microsoft.Build.Tasks.v4.0/4.0.0.0__b03f5f7f11d50a3a/Microsoft.Build.Tasks.v4.0.dll"
-    "Microsoft.Build.Utilities.v4.0/4.0.0.0__b03f5f7f11d50a3a/Microsoft.Build.Utilities.v4.0.dll"
     "Mono.Data.Tds/4.0.0.0__0738eb9f132ed756/Mono.Data.Tds.dll"
     "Mono.Posix/4.0.0.0__0738eb9f132ed756/Mono.Posix.dll"
     "Mono.Security/4.0.0.0__0738eb9f132ed756/Mono.Security.dll"

--- a/mono-packaging/copy-msbuild.sh
+++ b/mono-packaging/copy-msbuild.sh
@@ -54,7 +54,11 @@ msbuild_libraries=(
     "Microsoft.Build.dll"
     "Microsoft.Build.Framework.dll"
     "Microsoft.Build.Tasks.Core.dll"
+    "Microsoft.Build.Tasks.v4.0.dll"
+    "Microsoft.Build.Tasks.v12.0.dll"
     "Microsoft.Build.Utilities.Core.dll"
+    "Microsoft.Build.Utilities.v4.0.dll"
+    "Microsoft.Build.Utilities.v12.0.dll"
 )
 
 msbuild_runtime=(


### PR DESCRIPTION
Mono/msbuild has facade assemblies for
`Microsoft.Build.{Tasks,Utilities}.v{4,12}.0` which typeforward to the
newer `*Core*` assemblies. Without these available in the msbuild bin
dir, mono will load the older (incomplete and deprecated) xbuild
versions of these from the gac, which can cause projects to break.

Here is mono loading the v4 assembly from gac:

```
Mono: Assembly Loader loaded assembly from location: '/Users/radical/.nuget/packages/grpc.tools/1.22.0-pre1/build/_protobuf/net45/Protobuf.MSBuild.dll'.
Mono: Loading reference 1 of /Users/radical/.nuget/packages/grpc.tools/1.22.0-pre1/build/_protobuf/net45/Protobuf.MSBuild.dll asmctx LOADFROM, looking for Microsoft.Build.Utilities.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
Mono: Domain OmniSharp.exe search path is:
Mono: 	path[0] = '/Users/radical/.vscode/extensions/ms-vscode.csharp-1.21.1/.omnisharp/1.34.2/omnisharp/'
Mono: End of domain OmniSharp.exe search path.
Mono: Assembly Loader probing location: '/Users/radical/.vscode/extensions/ms-vscode.csharp-1.21.1/.omnisharp/1.34.2/lib/mono/gac/Microsoft.Build.Utilities.v4.0/4.0.0.0__b03f5f7f11d50a3a/Microsoft.Build.Utilities.v4.0.dll'.
Mono: Image addref Microsoft.Build.Utilities.v4.0[0x7f9075d60a60] (asmctx DEFAULT) -> /Users/radical/.vscode/extensions/ms-vscode.csharp-1.21.1/.omnisharp/1.34.2/lib/mono/gac/Microsoft.Build.Utilities.v4.0/4.0.0.0__b03f5f7f11d50a3a/Microsoft.Build.Utilities.v4.0.dll[0x7f90c7ecbe00]: 2
Mono: Prepared to set up assembly 'Microsoft.Build.Utilities.v4.0' (/Users/radical/.vscode/extensions/ms-vscode.csharp-1.21.1/.omnisharp/1.34.2/lib/mono/gac/Microsoft.Build.Utilities.v4.0/4.0.0.0__b03f5f7f11d50a3a/Microsoft.Build.Utilities.v4.0.dll)
Mono: Assembly Microsoft.Build.Utilities.v4.0[0x7f9075d60a60] added to domain OmniSharp.exe, ref_count=1
```

In OmniSharp/omnisharp-vscode#3258 , the task
`ProtoCompile` failed because it tried to use the property
`ToolTask.UseCommandProcessor` which wasn't available in the
older(incomplete) xbuild assembly:

```
System.MissingMethodException: Method not found: void Microsoft.Build.Utilities.ToolTask.set_UseCommandProcessor(bool)
  at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute () [0x00029] in <4e0a1f1d78cf4c1ebd6f9a3dbcebf3bb>:0
  at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask (Microsoft.Build.BackEnd.ITaskExecutionHost taskExecutionHost, Microsoft.Build.BackEnd.Logging.TaskLoggingContext taskLoggingContext, Microsoft.Build.BackEnd.TaskHost taskHost, Microsoft.Build.BackEnd.ItemBucket bucket, Microsoft.Build.BackEnd.TaskExecutionMode howToExecuteTask) [0x00212] in <4e0a1f1d78cf4c1ebd6f9a3dbcebf3bb>:0
```

Solution: Copy over the facade assemblies from mono/msbuild. And don't
copy the xbuild assemblies from the gac.

Fixes: OmniSharp/omnisharp-vscode#3258 .