### PR TITLE
updated to Roslyn 3.3.1 beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to the project will be documented in this file.
 ## [1.34.3] - not yet released
 * Added support for `CheckForOverflowUnderflow ` in csproj files (PR: [#1587](https://github.com/OmniSharp/omnisharp-roslyn/pull/1587))
 * Updated LSP libraries to 0.13 which fixes problems with clients not supporting dynamic registrations. ([#1505](https://github.com/OmniSharp/omnisharp-roslyn/issues/1505), [#1525](https://github.com/OmniSharp/omnisharp-roslyn/issues/1525), PR: [#1562](https://github.com/OmniSharp/omnisharp-roslyn/pull/1562))
+* Update to Roslyn `3.3.1-beta3-19456-04` (PR:[#1596](https://github.com/OmniSharp/omnisharp-roslyn/pull/1596))
 
 ## [1.34.2] - 2019-08-16 
 * Update to Roslyn `3.3.0-beta2-19401-05` which fixes a 1.34.1 regression resulting in StackOverflowException on code analysis of partial classes (PR: [#1579](https://github.com/OmniSharp/omnisharp-roslyn/pull/1579))

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>16.0.461</MSBuildPackageVersion>
     <NuGetPackageVersion>5.0.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.3.0-beta2-19401-05</RoslynPackageVersion>
+    <RoslynPackageVersion>3.3.1-beta3-19456-04</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
We are always very early adopters of Roslyn but this time we are a bit late 3.3.1 beta3 is already even on public Nuget feed.