### PR TITLE
updated metadata on the nuget packages

### DIFF
--- a/build/Settings.props
+++ b/build/Settings.props
@@ -9,7 +9,14 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <NoWarn>NU1701;NU5104</NoWarn>
     <IsPackable>false</IsPackable>
-
+    <Authors>OmniSharp contributors</Authors>
+    <PackageTags>omnisharp;lsp;csharp;roslyn;language</PackageTags>
+    <PackageIconUrl>https://avatars0.githubusercontent.com/u/9420663</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/OmniSharp/omnisharp-roslyn</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/OmniSharp/omnisharp-roslyn.git</RepositoryUrl>
+      
     <OutputPath>$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\$(Configuration)\$(MSBuildProjectName)'))\</OutputPath>
     <BaseIntermediateOutputPath>$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
   </PropertyGroup>

--- a/build/Settings.props
+++ b/build/Settings.props
@@ -9,7 +9,7 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <NoWarn>NU1701;NU5104</NoWarn>
     <IsPackable>false</IsPackable>
-    <Authors>OmniSharp contributors</Authors>
+    <Authors>OmniSharp Contributors</Authors>
     <PackageTags>omnisharp;lsp;csharp;roslyn;language</PackageTags>
     <PackageIconUrl>https://avatars0.githubusercontent.com/u/9420663</PackageIconUrl>
     <PackageProjectUrl>https://github.com/OmniSharp/omnisharp-roslyn</PackageProjectUrl>


### PR DESCRIPTION
since the packages are now published to public nuget feed (i.e. https://www.nuget.org/packages/OmniSharp.Abstractions/) we need better metadata:

 - license
 - logo
 - keywords
 - repository information