### PR TITLE
upgrade msbuild to 16.3

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -8,5 +8,6 @@
         <add key="OmniSharp" value="https://www.myget.org/F/omnisharp/api/v3/index.json" />
         <add key="roslyn-myget" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
         <add key="vs-editor" value="https://www.myget.org/F/vs-editor/api/v3/index.json" />
+        <add key="msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
     </packageSources>
 </configuration>

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <MSBuildPackageVersion>16.0.461</MSBuildPackageVersion>
+    <MSBuildPackageVersion>16.3.0-preview-19426-01</MSBuildPackageVersion>
     <NuGetPackageVersion>5.0.0</NuGetPackageVersion>
     <RoslynPackageVersion>3.4.0-beta1-19460-02</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>

--- a/src/OmniSharp.Host/MSBuild/Discovery/MSBuildLocator.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/MSBuildLocator.cs
@@ -44,8 +44,8 @@ namespace OmniSharp.MSBuild.Discovery
         public static MSBuildLocator CreateDefault(ILoggerFactory loggerFactory, IAssemblyLoader assemblyLoader, IConfiguration msbuildConfiguration)
             => new MSBuildLocator(loggerFactory, assemblyLoader,
                 ImmutableArray.Create<MSBuildInstanceProvider>(
-                    new DevConsoleInstanceProvider(loggerFactory),
-                    new VisualStudioInstanceProvider(loggerFactory),
+                    //new DevConsoleInstanceProvider(loggerFactory),
+                    //new VisualStudioInstanceProvider(loggerFactory),
                     new MonoInstanceProvider(loggerFactory),
                     new StandAloneInstanceProvider(loggerFactory, allowMonoPaths: true),
                     new UserOverrideInstanceProvider(loggerFactory, msbuildConfiguration)));

--- a/src/OmniSharp.Host/MSBuild/Discovery/MSBuildLocator.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/MSBuildLocator.cs
@@ -44,8 +44,8 @@ namespace OmniSharp.MSBuild.Discovery
         public static MSBuildLocator CreateDefault(ILoggerFactory loggerFactory, IAssemblyLoader assemblyLoader, IConfiguration msbuildConfiguration)
             => new MSBuildLocator(loggerFactory, assemblyLoader,
                 ImmutableArray.Create<MSBuildInstanceProvider>(
-                    //new DevConsoleInstanceProvider(loggerFactory),
-                    //new VisualStudioInstanceProvider(loggerFactory),
+                    new DevConsoleInstanceProvider(loggerFactory),
+                    new VisualStudioInstanceProvider(loggerFactory),
                     new MonoInstanceProvider(loggerFactory),
                     new StandAloneInstanceProvider(loggerFactory, allowMonoPaths: true),
                     new UserOverrideInstanceProvider(loggerFactory, msbuildConfiguration)));

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Cake" version="0.32.1" />
-    <package id="Microsoft.Build" version="16.0.461" />
-    <package id="Microsoft.Build.Framework" version="16.0.461" />
-    <package id="Microsoft.Build.Runtime" version="16.0.461" />
-    <package id="Microsoft.Build.Tasks.Core" version="16.0.461" />
-    <package id="Microsoft.Build.Utilities.Core" version="16.0.461" />
+    <package id="Microsoft.Build" version="16.3.0-preview-19426-01" />
+    <package id="Microsoft.Build.Framework" version="16.3.0-preview-19426-01" />
+    <package id="Microsoft.Build.Runtime" version="16.3.0-preview-19426-01" />
+    <package id="Microsoft.Build.Tasks.Core" version="16.3.0-preview-19426-01" />
+    <package id="Microsoft.Build.Utilities.Core" version="16.3.0-preview-19426-01" />
     <package id="Microsoft.Net.Compilers" version="2.10.0" />
     <package id="Microsoft.DotNet.MSBuildSdkResolver" version="2.2.202-preview-010036" />
     <package id="NuGet.Build.Tasks" version="5.0.0-rtm.5856" />
@@ -16,10 +16,10 @@
     <package id="NuGet.ProjectModel" version="5.0.0-rtm.5856" />
     <package id="NuGet.Protocol" version="5.0.0-rtm.5856" />
     <package id="NuGet.Versioning" version="5.0.0-rtm.5856" />
-    <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="2.2.3" />
-    <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="2.2.3" />
-    <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="2.2.3" />
-    <package id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" version="2.2.3" />
+    <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="3.0.0" />
+    <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="3.0.0" />
+    <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="3.0.0" />
+    <package id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" version="3.0.0" />
     <package id="SQLitePCLRaw.bundle_green" version="1.1.2" />
     <package id="SQLitePCLRaw.core" version="1.1.2" />
     <package id="SQLitePCLRaw.provider.e_sqlite3.net45" version="1.1.2" />


### PR DESCRIPTION
I was able to reproduce the issue from https://github.com/OmniSharp/omnisharp-vscode/issues/3290 on my machine
This hopefully should fix it.

There is a separate issue where the "unresolved dependencies" pop up shows up continuously because of `Microsoft.NetCore.App` not being there in assets.json file anymore but we will handle this separately.