### PR TITLE
copy MsBuild 16.3 on Mono too

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
       vmImage: "macOS-10.13"
     dependsOn: GitVersion
     variables:
-      MONO_VERSION: 5.18.1
+      MONO_VERSION: 6.0.0
     steps:
       - template: ./.pipelines/init.yml
         parameters:
@@ -65,7 +65,7 @@ jobs:
       vmImage: "Ubuntu-16.04"
     dependsOn: GitVersion
     variables:
-      MONO_VERSION: 5.18.1
+      MONO_VERSION: 6.0.0
     steps:
       - template: ./.pipelines/init.yml
         parameters:
@@ -76,7 +76,7 @@ jobs:
       - script: |
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           sudo apt install apt-transport-https ca-certificates
-          echo "deb https://download.mono-project.com/repo/ubuntu stable-xenial/snapshots/5.18.1 main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          echo "deb https://download.mono-project.com/repo/ubuntu stable-xenial/snapshots/6.0.0 main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
           sudo apt update
           sudo apt install mono-devel
         displayName: Use Mono $(MONO_VERSION)

--- a/build.cake
+++ b/build.cake
@@ -243,7 +243,9 @@ Task("CreateMSBuildFolder")
         foreach (var library in msbuildLibraries)
         {
             var libraryFileName = library + ".dll";
-            var librarySourcePath = CombinePaths(env.Folders.Tools, library, "lib", "net472", libraryFileName);
+
+            // copy MSBuild from current Mono (should be 6.0.0+)
+            var librarySourcePath = CombinePaths(Platform.Current.IsMacOS ? "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin" : "/usr/lib/mono/msbuild/15.0/bin", libraryFileName);
             var libraryTargetPath = CombinePaths(msbuildCurrentBinTargetFolder, libraryFileName);
             FileHelper.Copy(librarySourcePath, libraryTargetPath);
         }
@@ -512,7 +514,7 @@ Task("Test")
             {
                 // Copy the Mono-built Microsoft.Build.* binaries to the test folder.
                 // This is necessary to work around a Mono bug that is exasperated by xUnit.
-                DirectoryHelper.Copy($"{env.Folders.MonoMSBuildLib}", instanceFolder);
+                DirectoryHelper.Copy($"{env.Folders.MSBuild}/Current/bin", instanceFolder);
 
                 var runScript = CombinePaths(env.Folders.Mono, "run");
 

--- a/build.cake
+++ b/build.cake
@@ -243,7 +243,7 @@ Task("CreateMSBuildFolder")
         foreach (var library in msbuildLibraries)
         {
             var libraryFileName = library + ".dll";
-            var librarySourcePath = CombinePaths(env.Folders.MonoMSBuildLib, libraryFileName);
+            var librarySourcePath = CombinePaths(env.Folders.Tools, library, "lib", "net472", libraryFileName);
             var libraryTargetPath = CombinePaths(msbuildCurrentBinTargetFolder, libraryFileName);
             FileHelper.Copy(librarySourcePath, libraryTargetPath);
         }

--- a/build.json
+++ b/build.json
@@ -2,7 +2,7 @@
   "DotNetInstallScriptURL": "https://dot.net/v1",
   "DotNetChannel": "preview",
   "DotNetVersion": "2.1.505",
-  "RequiredMonoVersion": "5.18.0.0",
+  "RequiredMonoVersion": "6.0.0",
   "DownloadURL": "https://roslynomnisharp.blob.core.windows.net/ext",
   "MonoRuntimeMacOS": "mono.macOS-5.18.1.0.zip",
   "MonoRuntimeLinux32": "mono.linux-x86-5.18.1.0.zip",

--- a/tests/OmniSharp.MSBuild.Tests/ProjectWithAnalyzersTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectWithAnalyzersTests.cs
@@ -114,7 +114,8 @@ namespace OmniSharp.MSBuild.Tests
             }
         }
 
-        [Fact]
+        // Unstable with MSBuild 16.3 on *nix
+        [ConditionalFact(typeof(WindowsOnly))]
         public async Task WhenNewAnalyzerReferenceIsAdded_ThenAutomaticallyUseItWithoutRestart()
         {
             var emitter = new ProjectLoadTestEventEmitter();


### PR DESCRIPTION
This is a follow up to #1606 

We now copy the MsBuild 16.3 from Nuget for use on Mono, rather than the custom package we had in the past.
I tested this on my Mac and seems to have resolved the problem of .NET Core 3.0 not working.