### PR TITLE
Bump Dotnet.Script.DependencyModel to version 0.50.0

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -8,6 +8,5 @@
         <add key="OmniSharp" value="https://www.myget.org/F/omnisharp/api/v3/index.json" />
         <add key="roslyn-myget" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
         <add key="vs-editor" value="https://www.myget.org/F/vs-editor/api/v3/index.json" />
-        <add key="dotnet-script" value="/Users/bernhardrichter/GitHub/dotnet-script/build/Artifacts/NuGet" />
     </packageSources>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -8,5 +8,6 @@
         <add key="OmniSharp" value="https://www.myget.org/F/omnisharp/api/v3/index.json" />
         <add key="roslyn-myget" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
         <add key="vs-editor" value="https://www.myget.org/F/vs-editor/api/v3/index.json" />
+        <add key="dotnet-script" value="/Users/bernhardrichter/GitHub/dotnet-script/build/Artifacts/NuGet" />
     </packageSources>
 </configuration>

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0"
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <MSBuildPackageVersion>16.0.461</MSBuildPackageVersion>
@@ -11,8 +12,8 @@
   <ItemGroup>
     <PackageReference Update="Cake.Scripting.Transport" Version="0.3.0" />
 
-    <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.6.1" />
-    <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.6.2" />
+    <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.50.0" />
+    <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.50.0" />
 
     <PackageReference Update="Humanizer" Version="2.2.0" />
     <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -1,90 +1,90 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0"
-    xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <PropertyGroup>
-        <MSBuildPackageVersion>16.3.0-preview-19426-01</MSBuildPackageVersion>
-        <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
-        <RoslynPackageVersion>3.4.0-beta1-19460-02</RoslynPackageVersion>
-        <XunitPackageVersion>2.4.0</XunitPackageVersion>
-    </PropertyGroup>
+  <PropertyGroup>
+    <MSBuildPackageVersion>16.3.0-preview-19426-01</MSBuildPackageVersion>
+    <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
+    <RoslynPackageVersion>3.4.0-beta1-19460-02</RoslynPackageVersion>
+    <XunitPackageVersion>2.4.0</XunitPackageVersion>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Update="Cake.Scripting.Transport" Version="0.3.0" />
+  <ItemGroup>
+    <PackageReference Update="Cake.Scripting.Transport" Version="0.3.0" />
 
-        <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.50.0" />
-        <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.50.0" />
+    <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.50.0" />
+    <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.50.0" />
 
-        <PackageReference Update="Humanizer" Version="2.2.0" />
-        <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
+    <PackageReference Update="Humanizer" Version="2.2.0" />
+    <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
 
-        <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
-        <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-        <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="2.1.1" />
-        <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
+    <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
+    <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+    <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="2.1.1" />
+    <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
 
-        <PackageReference Update="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
-        <PackageReference Update="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
-        <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageVersion)" />
-        <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
+    <PackageReference Update="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
+    <PackageReference Update="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
+    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageVersion)" />
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
 
-        <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynPackageVersion)" />
-        <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" />
-        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynPackageVersion)" />
-        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynPackageVersion)" />
-        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
-        <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynPackageVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynPackageVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynPackageVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
 
-        <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-        <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Logging" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+    <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
 
-        <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" />
-        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-        <PackageReference Update="Microsoft.TestPlatform.TranslationLayer" Version="15.7.2" />
-        <PackageReference Update="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" />
-        <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.14.114" />
-        <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.12" />
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Update="Microsoft.TestPlatform.TranslationLayer" Version="15.7.2" />
+    <PackageReference Update="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" />
+    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.14.114" />
+    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.12" />
 
-        <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
 
-        <PackageReference Update="Nuget.Packaging" Version="$(NuGetPackageVersion)" />
-        <PackageReference Update="Nuget.Packaging.Core" Version="$(NuGetPackageVersion)" />
-        <PackageReference Update="Nuget.ProjectModel" Version="$(NuGetPackageVersion)" />
-        <PackageReference Update="Nuget.Versioning" Version="$(NuGetPackageVersion)" />
+    <PackageReference Update="Nuget.Packaging" Version="$(NuGetPackageVersion)" />
+    <PackageReference Update="Nuget.Packaging.Core" Version="$(NuGetPackageVersion)" />
+    <PackageReference Update="Nuget.ProjectModel" Version="$(NuGetPackageVersion)" />
+    <PackageReference Update="Nuget.Versioning" Version="$(NuGetPackageVersion)" />
 
-        <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.13.1" />
+    <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.13.1" />
 
-        <PackageReference Update="SQLitePCLRaw.bundle_green" Version="1.1.2" />
-        <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />
-        <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
-        <PackageReference Update="System.Composition" Version="1.0.31" />
-        <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
-        <PackageReference Update="System.Reflection.Metadata" Version="1.4.2" />
-        <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-        <PackageReference Update="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Update="SQLitePCLRaw.bundle_green" Version="1.1.2" />
+    <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
+    <PackageReference Update="System.Composition" Version="1.0.31" />
+    <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
+    <PackageReference Update="System.Reflection.Metadata" Version="1.4.2" />
+    <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Update="System.ValueTuple" Version="4.4.0" />
 
-        <PackageReference Update="System.Reactive" Version="4.1.2" />
+    <PackageReference Update="System.Reactive" Version="4.1.2" />
 
-        <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
+    <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
 
-        <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitPackageVersion)" />
-        <PackageReference Update="xunit" Version="$(XunitPackageVersion)" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
-    </ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitPackageVersion)" />
+    <PackageReference Update="xunit" Version="$(XunitPackageVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
+  </ItemGroup>
 
 
 

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -1,89 +1,90 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0"
+    xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-    <MSBuildPackageVersion>16.0.461</MSBuildPackageVersion>
-    <NuGetPackageVersion>5.0.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.4.0-beta1-19460-02</RoslynPackageVersion>
-    <XunitPackageVersion>2.4.0</XunitPackageVersion>
-  </PropertyGroup>
+    <PropertyGroup>
+        <MSBuildPackageVersion>16.0.461</MSBuildPackageVersion>
+        <NuGetPackageVersion>5.0.0</NuGetPackageVersion>
+        <RoslynPackageVersion>3.4.0-beta1-19460-02</RoslynPackageVersion>
+        <XunitPackageVersion>2.4.0</XunitPackageVersion>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Cake.Scripting.Transport" Version="0.3.0" />
+    <ItemGroup>
+        <PackageReference Update="Cake.Scripting.Transport" Version="0.3.0" />
 
-    <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.6.1" />
-    <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.6.2" />
+        <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.11.0" />
+        <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.9.0" />
 
-    <PackageReference Update="Humanizer" Version="2.2.0" />
-    <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
+        <PackageReference Update="Humanizer" Version="2.2.0" />
+        <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
 
-    <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
-    <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-    <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="2.1.1" />
-    <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
+        <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
+        <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+        <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="2.1.1" />
+        <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
 
-    <PackageReference Update="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
-    <PackageReference Update="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
-    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageVersion)" />
-    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
 
-    <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
 
-    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+        <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Logging" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
 
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Update="Microsoft.TestPlatform.TranslationLayer" Version="15.7.2" />
-    <PackageReference Update="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" />
-    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.14.114" />
-    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.12" />
+        <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" />
+        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+        <PackageReference Update="Microsoft.TestPlatform.TranslationLayer" Version="15.7.2" />
+        <PackageReference Update="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" />
+        <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.14.114" />
+        <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.12" />
 
-    <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
+        <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
 
-    <PackageReference Update="Nuget.Packaging" Version="$(NuGetPackageVersion)" />
-    <PackageReference Update="Nuget.Packaging.Core" Version="$(NuGetPackageVersion)" />
-    <PackageReference Update="Nuget.ProjectModel" Version="$(NuGetPackageVersion)" />
-    <PackageReference Update="Nuget.Versioning" Version="$(NuGetPackageVersion)" />
+        <PackageReference Update="Nuget.Packaging" Version="$(NuGetPackageVersion)" />
+        <PackageReference Update="Nuget.Packaging.Core" Version="$(NuGetPackageVersion)" />
+        <PackageReference Update="Nuget.ProjectModel" Version="$(NuGetPackageVersion)" />
+        <PackageReference Update="Nuget.Versioning" Version="$(NuGetPackageVersion)" />
 
-    <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.13.1" />
+        <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.13.1" />
 
-    <PackageReference Update="SQLitePCLRaw.bundle_green" Version="1.1.2" />
-    <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
-    <PackageReference Update="System.Composition" Version="1.0.31" />
-    <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
-    <PackageReference Update="System.Reflection.Metadata" Version="1.4.2" />
-    <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-    <PackageReference Update="System.ValueTuple" Version="4.4.0" />
+        <PackageReference Update="SQLitePCLRaw.bundle_green" Version="1.1.2" />
+        <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />
+        <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
+        <PackageReference Update="System.Composition" Version="1.0.31" />
+        <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
+        <PackageReference Update="System.Reflection.Metadata" Version="1.4.2" />
+        <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+        <PackageReference Update="System.ValueTuple" Version="4.4.0" />
 
-    <PackageReference Update="System.Reactive" Version="4.1.2" />
+        <PackageReference Update="System.Reactive" Version="4.1.2" />
 
-    <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
+        <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
 
-    <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitPackageVersion)" />
-    <PackageReference Update="xunit" Version="$(XunitPackageVersion)" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
-  </ItemGroup>
+        <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitPackageVersion)" />
+        <PackageReference Update="xunit" Version="$(XunitPackageVersion)" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
+    </ItemGroup>
 
 
 

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -12,8 +12,8 @@
     <ItemGroup>
         <PackageReference Update="Cake.Scripting.Transport" Version="0.3.0" />
 
-        <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.11.0" />
-        <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.9.0" />
+        <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.50.0" />
+        <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.50.0" />
 
         <PackageReference Update="Humanizer" Version="2.2.0" />
         <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -1,90 +1,90 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0"
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-    <MSBuildPackageVersion>16.3.0-preview-19426-01</MSBuildPackageVersion>
-    <NuGetPackageVersion>5.0.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.4.0-beta1-19460-02</RoslynPackageVersion>
-    <XunitPackageVersion>2.4.0</XunitPackageVersion>
-  </PropertyGroup>
+    <PropertyGroup>
+        <MSBuildPackageVersion>16.3.0-preview-19426-01</MSBuildPackageVersion>
+        <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
+        <RoslynPackageVersion>3.4.0-beta1-19460-02</RoslynPackageVersion>
+        <XunitPackageVersion>2.4.0</XunitPackageVersion>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Cake.Scripting.Transport" Version="0.3.0" />
+    <ItemGroup>
+        <PackageReference Update="Cake.Scripting.Transport" Version="0.3.0" />
 
-    <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.50.0" />
-    <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.50.0" />
+        <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.50.0" />
+        <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.50.0" />
 
-    <PackageReference Update="Humanizer" Version="2.2.0" />
-    <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
+        <PackageReference Update="Humanizer" Version="2.2.0" />
+        <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
 
-    <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
-    <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-    <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="2.1.1" />
-    <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
+        <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
+        <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+        <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="2.1.1" />
+        <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
 
-    <PackageReference Update="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
-    <PackageReference Update="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
-    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageVersion)" />
-    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
 
-    <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
 
-    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+        <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Logging" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
 
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Update="Microsoft.TestPlatform.TranslationLayer" Version="15.7.2" />
-    <PackageReference Update="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" />
-    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.14.114" />
-    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.12" />
+        <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" />
+        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+        <PackageReference Update="Microsoft.TestPlatform.TranslationLayer" Version="15.7.2" />
+        <PackageReference Update="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" />
+        <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.14.114" />
+        <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.12" />
 
-    <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
+        <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
 
-    <PackageReference Update="Nuget.Packaging" Version="$(NuGetPackageVersion)" />
-    <PackageReference Update="Nuget.Packaging.Core" Version="$(NuGetPackageVersion)" />
-    <PackageReference Update="Nuget.ProjectModel" Version="$(NuGetPackageVersion)" />
-    <PackageReference Update="Nuget.Versioning" Version="$(NuGetPackageVersion)" />
+        <PackageReference Update="Nuget.Packaging" Version="$(NuGetPackageVersion)" />
+        <PackageReference Update="Nuget.Packaging.Core" Version="$(NuGetPackageVersion)" />
+        <PackageReference Update="Nuget.ProjectModel" Version="$(NuGetPackageVersion)" />
+        <PackageReference Update="Nuget.Versioning" Version="$(NuGetPackageVersion)" />
 
-    <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.13.1" />
+        <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.13.1" />
 
-    <PackageReference Update="SQLitePCLRaw.bundle_green" Version="1.1.2" />
-    <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
-    <PackageReference Update="System.Composition" Version="1.0.31" />
-    <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
-    <PackageReference Update="System.Reflection.Metadata" Version="1.4.2" />
-    <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-    <PackageReference Update="System.ValueTuple" Version="4.4.0" />
+        <PackageReference Update="SQLitePCLRaw.bundle_green" Version="1.1.2" />
+        <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />
+        <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
+        <PackageReference Update="System.Composition" Version="1.0.31" />
+        <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
+        <PackageReference Update="System.Reflection.Metadata" Version="1.4.2" />
+        <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+        <PackageReference Update="System.ValueTuple" Version="4.4.0" />
 
-    <PackageReference Update="System.Reactive" Version="4.1.2" />
+        <PackageReference Update="System.Reactive" Version="4.1.2" />
 
-    <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
+        <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
 
-    <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitPackageVersion)" />
-    <PackageReference Update="xunit" Version="$(XunitPackageVersion)" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
-  </ItemGroup>
+        <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitPackageVersion)" />
+        <PackageReference Update="xunit" Version="$(XunitPackageVersion)" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
+    </ItemGroup>
 
 
 

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -1,90 +1,89 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0"
-    xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <PropertyGroup>
-        <MSBuildPackageVersion>16.0.461</MSBuildPackageVersion>
-        <NuGetPackageVersion>5.0.0</NuGetPackageVersion>
-        <RoslynPackageVersion>3.4.0-beta1-19460-02</RoslynPackageVersion>
-        <XunitPackageVersion>2.4.0</XunitPackageVersion>
-    </PropertyGroup>
+  <PropertyGroup>
+    <MSBuildPackageVersion>16.0.461</MSBuildPackageVersion>
+    <NuGetPackageVersion>5.0.0</NuGetPackageVersion>
+    <RoslynPackageVersion>3.4.0-beta1-19460-02</RoslynPackageVersion>
+    <XunitPackageVersion>2.4.0</XunitPackageVersion>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Update="Cake.Scripting.Transport" Version="0.3.0" />
+  <ItemGroup>
+    <PackageReference Update="Cake.Scripting.Transport" Version="0.3.0" />
 
-        <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.50.0" />
-        <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.50.0" />
+    <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.6.1" />
+    <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.6.2" />
 
-        <PackageReference Update="Humanizer" Version="2.2.0" />
-        <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
+    <PackageReference Update="Humanizer" Version="2.2.0" />
+    <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
 
-        <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
-        <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-        <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="2.1.1" />
-        <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
+    <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
+    <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+    <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="2.1.1" />
+    <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
 
-        <PackageReference Update="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
-        <PackageReference Update="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
-        <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageVersion)" />
-        <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
+    <PackageReference Update="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
+    <PackageReference Update="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
+    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageVersion)" />
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
 
-        <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynPackageVersion)" />
-        <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" />
-        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynPackageVersion)" />
-        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynPackageVersion)" />
-        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
-        <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynPackageVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynPackageVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynPackageVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
 
-        <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-        <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Logging" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+    <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
 
-        <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" />
-        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-        <PackageReference Update="Microsoft.TestPlatform.TranslationLayer" Version="15.7.2" />
-        <PackageReference Update="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" />
-        <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.14.114" />
-        <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.12" />
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Update="Microsoft.TestPlatform.TranslationLayer" Version="15.7.2" />
+    <PackageReference Update="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" />
+    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.14.114" />
+    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.12" />
 
-        <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
 
-        <PackageReference Update="Nuget.Packaging" Version="$(NuGetPackageVersion)" />
-        <PackageReference Update="Nuget.Packaging.Core" Version="$(NuGetPackageVersion)" />
-        <PackageReference Update="Nuget.ProjectModel" Version="$(NuGetPackageVersion)" />
-        <PackageReference Update="Nuget.Versioning" Version="$(NuGetPackageVersion)" />
+    <PackageReference Update="Nuget.Packaging" Version="$(NuGetPackageVersion)" />
+    <PackageReference Update="Nuget.Packaging.Core" Version="$(NuGetPackageVersion)" />
+    <PackageReference Update="Nuget.ProjectModel" Version="$(NuGetPackageVersion)" />
+    <PackageReference Update="Nuget.Versioning" Version="$(NuGetPackageVersion)" />
 
-        <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.13.1" />
+    <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.13.1" />
 
-        <PackageReference Update="SQLitePCLRaw.bundle_green" Version="1.1.2" />
-        <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />
-        <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
-        <PackageReference Update="System.Composition" Version="1.0.31" />
-        <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
-        <PackageReference Update="System.Reflection.Metadata" Version="1.4.2" />
-        <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-        <PackageReference Update="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Update="SQLitePCLRaw.bundle_green" Version="1.1.2" />
+    <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
+    <PackageReference Update="System.Composition" Version="1.0.31" />
+    <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
+    <PackageReference Update="System.Reflection.Metadata" Version="1.4.2" />
+    <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Update="System.ValueTuple" Version="4.4.0" />
 
-        <PackageReference Update="System.Reactive" Version="4.1.2" />
+    <PackageReference Update="System.Reactive" Version="4.1.2" />
 
-        <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
+    <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
 
-        <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitPackageVersion)" />
-        <PackageReference Update="xunit" Version="$(XunitPackageVersion)" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
-    </ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitPackageVersion)" />
+    <PackageReference Update="xunit" Version="$(XunitPackageVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
+  </ItemGroup>
 
 
 

--- a/src/OmniSharp.Script/ScriptContext.cs
+++ b/src/OmniSharp.Script/ScriptContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Dotnet.Script.DependencyModel.Compilation;
 using Microsoft.CodeAnalysis;
 
 namespace OmniSharp.Script
@@ -21,6 +20,6 @@ namespace OmniSharp.Script
 
         public CompilationDependency[] CompilationDependencies { get; }
 
-        public Type GlobalsType { get; } 
+        public Type GlobalsType { get; }
     }
 }

--- a/src/OmniSharp.Script/ScriptContextProvider.cs
+++ b/src/OmniSharp.Script/ScriptContextProvider.cs
@@ -54,7 +54,7 @@ namespace OmniSharp.Script
             });
         }
 
-        public ScriptContext CreateScriptContext(ScriptOptions scriptOptions)
+        public ScriptContext CreateScriptContext(ScriptOptions scriptOptions, string[] allCsxFiles)
         {
             var currentDomainAssemblies = AppDomain.CurrentDomain.GetAssemblies();
 
@@ -69,7 +69,6 @@ namespace OmniSharp.Script
             CompilationDependency[] compilationDependencies = null;
             try
             {
-                var allCsxFiles = scriptOptions.CsxFiles;
                 _logger.LogInformation($"Searching for compilation dependencies with the fallback framework of '{scriptOptions.DefaultTargetFramework}'.");
                 compilationDependencies = _compilationDependencyResolver.GetDependencies(_env.TargetDirectory, allCsxFiles, scriptOptions.IsNugetEnabled(), scriptOptions.DefaultTargetFramework).ToArray();
             }

--- a/src/OmniSharp.Script/ScriptContextProvider.cs
+++ b/src/OmniSharp.Script/ScriptContextProvider.cs
@@ -42,6 +42,10 @@ namespace OmniSharp.Script
                 var dependencyResolverLogger = loggerFactory.CreateLogger(categoryName);
                 return ((level, message, exception) =>
                 {
+                    if (level == LogLevel.Trace)
+                    {
+                        dependencyResolverLogger.LogTrace(message);
+                    }
                     if (level == LogLevel.Debug)
                     {
                         dependencyResolverLogger.LogDebug(message);
@@ -49,6 +53,18 @@ namespace OmniSharp.Script
                     if (level == LogLevel.Info)
                     {
                         dependencyResolverLogger.LogInformation(message);
+                    }
+                    if (level == LogLevel.Warning)
+                    {
+                        dependencyResolverLogger.LogWarning(message);
+                    }
+                    if (level == LogLevel.Error)
+                    {
+                        dependencyResolverLogger.LogError(exception, message);
+                    }
+                    if (level == LogLevel.Critical)
+                    {
+                        dependencyResolverLogger.LogCritical(exception, message);
                     }
                 });
             });

--- a/src/OmniSharp.Script/ScriptContextProvider.cs
+++ b/src/OmniSharp.Script/ScriptContextProvider.cs
@@ -111,7 +111,13 @@ namespace OmniSharp.Script
                 isDesktopClr = false;
                 HashSet<string> loadedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-                foreach (var compilationAssembly in compilationDependencies.SelectMany(cd => cd.AssemblyPaths).Distinct())
+                // Pick the highest version
+                var resolvedAssemblyPaths = compilationDependencies.SelectMany(cd => cd.AssemblyPaths)
+                    .Select(path => new { AssemblyName = AssemblyName.GetAssemblyName(path), Path = path }).Distinct()
+                    .GroupBy(nameAndPath => nameAndPath.AssemblyName.Name, nameAndPath => nameAndPath)
+                    .Select(gr => gr.OrderBy(nameAndPath => nameAndPath.AssemblyName.Version).Last()).Select(nameAndPath => nameAndPath.Path);
+
+                foreach (var compilationAssembly in resolvedAssemblyPaths)
                 {
                     if (loadedFiles.Add(Path.GetFileName(compilationAssembly)))
                     {

--- a/src/OmniSharp.Script/ScriptContextProvider.cs
+++ b/src/OmniSharp.Script/ScriptContextProvider.cs
@@ -69,7 +69,7 @@ namespace OmniSharp.Script
             CompilationDependency[] compilationDependencies = null;
             try
             {
-                var allCsxFiles = _fileSystemHelper.GetFiles("**/*.csx").ToArray();
+                var allCsxFiles = scriptOptions.CsxFiles;
                 _logger.LogInformation($"Searching for compilation dependencies with the fallback framework of '{scriptOptions.DefaultTargetFramework}'.");
                 compilationDependencies = _compilationDependencyResolver.GetDependencies(_env.TargetDirectory, allCsxFiles, scriptOptions.IsNugetEnabled(), scriptOptions.DefaultTargetFramework).ToArray();
             }

--- a/src/OmniSharp.Script/ScriptOptions.cs
+++ b/src/OmniSharp.Script/ScriptOptions.cs
@@ -1,9 +1,19 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace OmniSharp.Script
 {
     public class ScriptOptions
     {
+        public ScriptOptions()
+        {
+            for (var i = 8600; i <= 8655; i++)
+            {
+                NullableDiagnostics.Add($"CS{i}", ReportDiagnostic.Error);
+            }
+        }
+
         public bool EnableScriptNuGetReferences { get; set; }
 
         public string DefaultTargetFramework { get; set; } = "net461";
@@ -24,5 +34,7 @@ namespace OmniSharp.Script
                 ? RspFilePath
                 : Path.Combine(env.TargetDirectory, RspFilePath);
         }
+
+        public Dictionary<string, ReportDiagnostic> NullableDiagnostics { get; } = new Dictionary<string, ReportDiagnostic>();
     }
 }

--- a/src/OmniSharp.Script/ScriptOptions.cs
+++ b/src/OmniSharp.Script/ScriptOptions.cs
@@ -47,5 +47,7 @@ namespace OmniSharp.Script
         }
 
         public Dictionary<string, ReportDiagnostic> NullableDiagnostics => _nullableDiagnostics.Value;
+
+        public string[] CsxFiles { get; set; }
     }
 }

--- a/src/OmniSharp.Script/ScriptOptions.cs
+++ b/src/OmniSharp.Script/ScriptOptions.cs
@@ -47,7 +47,5 @@ namespace OmniSharp.Script
         }
 
         public Dictionary<string, ReportDiagnostic> NullableDiagnostics => _nullableDiagnostics.Value;
-
-        public string[] CsxFiles { get; set; }
     }
 }

--- a/src/OmniSharp.Script/ScriptOptions.cs
+++ b/src/OmniSharp.Script/ScriptOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.CodeAnalysis;
 
@@ -6,12 +7,22 @@ namespace OmniSharp.Script
 {
     public class ScriptOptions
     {
+        private Lazy<Dictionary<string, ReportDiagnostic>> _nullableDiagnostics;
+
         public ScriptOptions()
         {
+            _nullableDiagnostics = new Lazy<Dictionary<string, ReportDiagnostic>>(CreateNullableDiagnostics);
+        }
+
+        private Dictionary<string, ReportDiagnostic> CreateNullableDiagnostics()
+        {
+            var nullableDiagnostics = new Dictionary<string, ReportDiagnostic>();
             for (var i = 8600; i <= 8655; i++)
             {
-                NullableDiagnostics.Add($"CS{i}", ReportDiagnostic.Error);
+                nullableDiagnostics.Add($"CS{i}", ReportDiagnostic.Error);
             }
+
+            return nullableDiagnostics;
         }
 
         public bool EnableScriptNuGetReferences { get; set; }
@@ -35,6 +46,6 @@ namespace OmniSharp.Script
                 : Path.Combine(env.TargetDirectory, RspFilePath);
         }
 
-        public Dictionary<string, ReportDiagnostic> NullableDiagnostics { get; } = new Dictionary<string, ReportDiagnostic>();
+        public Dictionary<string, ReportDiagnostic> NullableDiagnostics => _nullableDiagnostics.Value;
     }
 }

--- a/src/OmniSharp.Script/ScriptProjectProvider.cs
+++ b/src/OmniSharp.Script/ScriptProjectProvider.cs
@@ -73,7 +73,7 @@ namespace OmniSharp.Script
                         _isDesktopClr ? Path.GetDirectoryName(typeof(object).GetTypeInfo().Assembly.ManifestModule.FullyQualifiedName) : null);
                 }
             }
-            
+
             return null;
         }
 
@@ -100,6 +100,11 @@ namespace OmniSharp.Script
                 .WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default)
                 .WithSpecificDiagnosticOptions(CompilationOptionsHelper.GetDefaultSuppressedDiagnosticOptions());
 
+            if (_scriptOptions.IsNugetEnabled())
+            {
+                compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(_scriptOptions.NullableDiagnostics);
+            }
+
             var topLevelBinderFlagsProperty = typeof(CSharpCompilationOptions).GetProperty(TopLevelBinderFlagsProperty, BindingFlags.Instance | BindingFlags.NonPublic);
             var binderFlagsType = typeof(CSharpCompilationOptions).GetTypeInfo().Assembly.GetType(BinderFlagsType);
 
@@ -124,18 +129,18 @@ namespace OmniSharp.Script
             InjectXMLDocumentationProviderIntoRuntimeMetadataReferenceResolver(defaultResolver);
 
             var decoratedResolver = _scriptOptions.EnableScriptNuGetReferences
-                ? new CachingScriptMetadataResolver(new NuGetMetadataReferenceResolver(defaultResolver)) 
+                ? new CachingScriptMetadataResolver(new NuGetMetadataReferenceResolver(defaultResolver))
                 : new CachingScriptMetadataResolver(defaultResolver);
 
             return decoratedResolver;
         }
- 
+
         public ProjectInfo CreateProject(string csxFileName, IEnumerable<MetadataReference> references, string csxFilePath, Type globalsType, IEnumerable<string> namespaces = null)
         {
             var csharpCommandLineArguments = _commandLineArgs.Value;
 
             // if RSP file was used, include the metadata references from RSP merged with the provided set
-            // otherwise just use the provided metadata references 
+            // otherwise just use the provided metadata references
             if (csharpCommandLineArguments != null && csharpCommandLineArguments.MetadataReferences.Any())
             {
                 var resolvedRspReferences = csharpCommandLineArguments.ResolveMetadataReferences(_compilationOptions.Value.MetadataReferenceResolver);

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -54,15 +54,18 @@ namespace OmniSharp.Script
         {
             if (Initialized) return;
 
-            _scriptOptions = new ScriptOptions();
-            ConfigurationBinder.Bind(configuration, _scriptOptions);
-
-            _scriptContext = new Lazy<ScriptContext>(() => _scriptContextProvider.CreateScriptContext(_scriptOptions));
-
             _logger.LogInformation($"Detecting CSX files in '{_env.TargetDirectory}'.");
 
             // Nothing to do if there are no CSX files
             var allCsxFiles = _fileSystemHelper.GetFiles("**/*.csx").ToArray();
+
+            _scriptOptions = new ScriptOptions();
+            _scriptOptions.CsxFiles = allCsxFiles;
+
+            ConfigurationBinder.Bind(configuration, _scriptOptions);
+
+            _scriptContext = new Lazy<ScriptContext>(() => _scriptContextProvider.CreateScriptContext(_scriptOptions));
+
             if (allCsxFiles.Length == 0)
             {
                 _logger.LogInformation("Could not find any CSX files");
@@ -110,14 +113,14 @@ namespace OmniSharp.Script
                 var csxFileName = Path.GetFileName(csxPath);
                 var project = _scriptContext.Value.ScriptProjectProvider.CreateProject(csxFileName, _scriptContext.Value.MetadataReferences, csxPath, _scriptContext.Value.GlobalsType);
 
-                    if (_scriptOptions.IsNugetEnabled())
-                    {
-                        var scriptMap = _scriptContext.Value.CompilationDependencies.ToDictionary(rdt => rdt.Name, rdt => rdt.Scripts);
-                        var options = project.CompilationOptions.WithSourceReferenceResolver(
-                            new NuGetSourceReferenceResolver(ScriptSourceResolver.Default,
-                                scriptMap));
-                        project = project.WithCompilationOptions(options);
-                    }
+                if (_scriptOptions.IsNugetEnabled())
+                {
+                    var scriptMap = _scriptContext.Value.CompilationDependencies.ToDictionary(rdt => rdt.Name, rdt => rdt.Scripts);
+                    var options = project.CompilationOptions.WithSourceReferenceResolver(
+                        new NuGetSourceReferenceResolver(ScriptSourceResolver.Default,
+                            scriptMap));
+                    project = project.WithCompilationOptions(options);
+                }
 
                 // add CSX project to workspace
                 _workspace.AddProject(project);

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -54,17 +54,16 @@ namespace OmniSharp.Script
         {
             if (Initialized) return;
 
+            _scriptOptions = new ScriptOptions();
+
+            ConfigurationBinder.Bind(configuration, _scriptOptions);
+
             _logger.LogInformation($"Detecting CSX files in '{_env.TargetDirectory}'.");
 
             // Nothing to do if there are no CSX files
             var allCsxFiles = _fileSystemHelper.GetFiles("**/*.csx").ToArray();
 
-            _scriptOptions = new ScriptOptions();
-            _scriptOptions.CsxFiles = allCsxFiles;
-
-            ConfigurationBinder.Bind(configuration, _scriptOptions);
-
-            _scriptContext = new Lazy<ScriptContext>(() => _scriptContextProvider.CreateScriptContext(_scriptOptions));
+            _scriptContext = new Lazy<ScriptContext>(() => _scriptContextProvider.CreateScriptContext(_scriptOptions, allCsxFiles));
 
             if (allCsxFiles.Length == 0)
             {


### PR DESCRIPTION
This PR bumps the `Dotnet.Script.DependencyModel` and `Dotnet.Script.DependencyModel.NuGet` packages to version `0.50.0` adding support for .Net Core 3.0 based scripts. 