### PR TITLE
upgrade GitVersion to 5.0.1 (fixes build on Ubuntu 18.04 and other distros)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
   DotNetVersion: "2.1.505"
   CakeVersion: "0.32.1"
   NuGetVersion: "4.9.2"
-  GitVersionVersion: "5.0.0-beta2-65"
+  GitVersionVersion: "5.0.1"
   Coverage: "$(Agent.BuildDirectory)/c"
   VstsCoverage: "$(Coverage)"
   Artifacts: $(Build.SourcesDirectory)/artifacts/

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -1,5 +1,5 @@
 #addin "nuget:?package=Newtonsoft.Json&version=11.0.2"
-#tool "nuget:?package=GitVersion.CommandLine&prerelease&version=5.1.0"
+#tool "nuget:?package=GitVersion.CommandLine&prerelease&version=5.0.1"
 
 #load "platform.cake"
 

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -1,5 +1,5 @@
 #addin "nuget:?package=Newtonsoft.Json&version=11.0.2"
-#tool "nuget:?package=GitVersion.CommandLine&prerelease&version=5.0.0-beta2-65"
+#tool "nuget:?package=GitVersion.CommandLine&prerelease&version=5.1.0"
 
 #load "platform.cake"
 


### PR DESCRIPTION
This fixes the build crash with GitVersion on Ubuntu 18.04

fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1548
fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1500
fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1251
fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1202
fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1048 