### PR TITLE
Make sure we include msbuild 16.3 in Linux distro

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
 
   - job: Linux
     pool:
-      vmImage: "Ubuntu-18.04"
+      vmImage: "Ubuntu-16.04"
     dependsOn: GitVersion
     variables:
       MONO_VERSION: 6.4.0
@@ -76,7 +76,7 @@ jobs:
       - script: |
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           sudo apt install apt-transport-https ca-certificates
-          echo "deb https://download.mono-project.com/repo/ubuntu stable-xenial/snapshots/6.4.0.198 main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          echo "deb https://download.mono-project.com/repo/ubuntu vs-xenial/snapshots/6.4.0.198 main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
           sudo apt update
           sudo apt install mono-devel
         displayName: Use Mono $(MONO_VERSION)
@@ -106,7 +106,7 @@ jobs:
           Artifacts: $(Artifacts)
   - job: Release
     pool:
-      vmImage: "Ubuntu-18.04"
+      vmImage: "Ubuntu-16.04"
     dependsOn:
       - macOS
       - Linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
 
   - job: Linux
     pool:
-      vmImage: "Ubuntu-16.04"
+      vmImage: "Ubuntu-18.04"
     dependsOn: GitVersion
     variables:
       MONO_VERSION: 6.4.0
@@ -106,7 +106,7 @@ jobs:
           Artifacts: $(Artifacts)
   - job: Release
     pool:
-      vmImage: "Ubuntu-16.04"
+      vmImage: "Ubuntu-18.04"
     dependsOn:
       - macOS
       - Linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,7 @@ jobs:
           echo "deb https://download.mono-project.com/repo/ubuntu vs-xenial/snapshots/6.4.0.198 main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
           sudo apt update
           sudo apt install mono-devel
+          sudo apt install msbuild
         displayName: Use Mono $(MONO_VERSION)
       - script: |
           chmod 755 ./build.sh

--- a/build.cake
+++ b/build.cake
@@ -252,7 +252,7 @@ Task("CreateMSBuildFolder")
             var libraryFileName = library + ".dll";
 
             // copy MSBuild from current Mono (should be 6.4.0+)
-            var librarySourcePath = CombinePaths(Platform.Current.IsMacOS ? "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin" : "/usr/lib/mono/msbuild/15.0/bin", libraryFileName);
+            var librarySourcePath = CombinePaths(Platform.Current.IsMacOS ? "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin" : "/usr/lib/mono/msbuild/Current/bin", libraryFileName);
             var libraryTargetPath = CombinePaths(msbuildCurrentBinTargetFolder, libraryFileName);
             if (FileHelper.Exists(librarySourcePath))
             {


### PR DESCRIPTION
This should finally allow us to close the famous issue https://github.com/OmniSharp/omnisharp-vscode/issues/3290

This is a follow up to #1606 which fixed the problem on Windows (confirmed by users) and follow up to #1607 which fixed the problem on Mac (also confirmed by users.

We still had the issue on Linux even though I wasn't able to initially reproduce it locally. Turns out, when we run on Azure DevOps we have Mono 6.0.0 (MSBuild 16.3) and Mono 6.4.0 (MSBuild 16.3) side by side and we copied from a wrong place... 😇 Also changed the distro from stable-xenial to vs-xenial.