### PR TITLE
Codify azure devops branch based triggers and pr configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,17 @@
+
+trigger:
+  batch: true
+  branches:
+    include:
+      - master
+      - refs/tags/*
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - master
+
 resources:
   repositories:
     - repository: rsg


### PR DESCRIPTION
It appears the latest azure devops doesn't trigger off the old configuration (was used be done through the UI like 8 months ago).

cc @rchande @filipw @mholo65 
