### PR TITLE
fixed default diagnostic suppressions for script project system

### DIFF
--- a/src/OmniSharp.Roslyn/Utilities/CompilationOptionsHelper.cs
+++ b/src/OmniSharp.Roslyn/Utilities/CompilationOptionsHelper.cs
@@ -35,5 +35,21 @@ namespace OmniSharp.Helpers
 
             return suppressedDiagnostics.ToImmutableDictionary();
         }
+
+        public static ImmutableDictionary<string, ReportDiagnostic> GetDefaultSuppressedDiagnosticOptions(Dictionary<string, ReportDiagnostic> otherDiagnostics)
+        {
+            if (otherDiagnostics == null || !otherDiagnostics.Any()) return GetDefaultSuppressedDiagnosticOptions();
+
+            var combinedDiagnostics = GetDefaultSuppressedDiagnosticOptions();
+            foreach (var diagnostic in otherDiagnostics)
+            {
+                if (!combinedDiagnostics.ContainsKey(diagnostic.Key))
+                {
+                    combinedDiagnostics.Add(diagnostic.Key, diagnostic.Value);
+                }
+            }
+
+            return combinedDiagnostics.ToImmutableDictionary();
+        }
     }
 }

--- a/src/OmniSharp.Script/ScriptProjectProvider.cs
+++ b/src/OmniSharp.Script/ScriptProjectProvider.cs
@@ -98,12 +98,9 @@ namespace OmniSharp.Script
                 .WithMetadataReferenceResolver(CreateMetadataReferenceResolver())
                 .WithSourceReferenceResolver(ScriptSourceResolver.Default)
                 .WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default)
-                .WithSpecificDiagnosticOptions(CompilationOptionsHelper.GetDefaultSuppressedDiagnosticOptions());
-
-            if (_scriptOptions.IsNugetEnabled())
-            {
-                compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(_scriptOptions.NullableDiagnostics);
-            }
+                .WithSpecificDiagnosticOptions(!_scriptOptions.IsNugetEnabled()
+                    ? CompilationOptionsHelper.GetDefaultSuppressedDiagnosticOptions()
+                    : CompilationOptionsHelper.GetDefaultSuppressedDiagnosticOptions(_scriptOptions.NullableDiagnostics)); // for .NET Core 3.0 dotnet-script use extra nullable diagnostics
 
             var topLevelBinderFlagsProperty = typeof(CSharpCompilationOptions).GetProperty(TopLevelBinderFlagsProperty, BindingFlags.Instance | BindingFlags.NonPublic);
             var binderFlagsType = typeof(CSharpCompilationOptions).GetTypeInfo().Assembly.GetType(BinderFlagsType);


### PR DESCRIPTION
Follow up to #1609 
The diagnostics were inadvertently overridden instead of merged.

cc @seesharper 