### PR TITLE
Remove diagnostic id from message

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Helpers/DiagnosticExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/DiagnosticExtensions.cs
@@ -22,7 +22,7 @@ namespace OmniSharp.Helpers
                 Column = span.StartLinePosition.Character,
                 EndLine = span.EndLinePosition.Line,
                 EndColumn = span.EndLinePosition.Character,
-                Text = $"{diagnostic.GetMessage()} ({diagnostic.Id})",
+                Text = diagnostic.GetMessage(),
                 LogLevel = diagnostic.Severity.ToString(),
                 Tags = diagnostic
                     .Descriptor.CustomTags

--- a/tests/OmniSharp.MSBuild.Tests/ProjectWithAnalyzersTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectWithAnalyzersTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Eventing;
 using OmniSharp.FileWatching;
+using OmniSharp.Models.Diagnostics;
 using OmniSharp.Models.FilesChanged;
 using OmniSharp.Services;
 using TestUtility;
@@ -37,7 +38,7 @@ namespace OmniSharp.MSBuild.Tests
                 var diagnostics = await host.RequestCodeCheckAsync(Path.Combine(testProject.Directory, "Program.cs"));
 
                 Assert.NotEmpty(diagnostics.QuickFixes);
-                Assert.Contains(diagnostics.QuickFixes, x => x.ToString().Contains("IDE0060")); // Unused args.
+                Assert.Contains(diagnostics.QuickFixes.OfType<DiagnosticLocation>(), x => x.Id == "IDE0060"); // Unused args.
             }
         }
 
@@ -140,7 +141,7 @@ namespace OmniSharp.MSBuild.Tests
 
                 var diagnostics = await host.RequestCodeCheckAsync(Path.Combine(testProject.Directory, "Program.cs"));
 
-                Assert.Contains(diagnostics.QuickFixes, x => x.Text.Contains("RCS1102")); // Analysis result from roslynator.
+                Assert.Contains(diagnostics.QuickFixes.OfType<DiagnosticLocation>(), x => x.Id == "RCS1102"); // Analysis result from roslynator.
             }
         }
 

--- a/tests/OmniSharp.MSBuild.Tests/ProjectWithComplexAnalyzersTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectWithComplexAnalyzersTests.cs
@@ -1,5 +1,8 @@
-﻿using System.IO;
+﻿
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using OmniSharp.Models.Diagnostics;
 using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
@@ -22,7 +25,7 @@ namespace OmniSharp.MSBuild.Tests
                 var diagnostics = await host.RequestCodeCheckAsync(Path.Combine(testProject.Directory, "Program.cs"));
 
                 Assert.NotEmpty(diagnostics.QuickFixes);
-                Assert.Contains(diagnostics.QuickFixes, x => x.ToString().Contains("CA1303"));
+                Assert.Contains(diagnostics.QuickFixes.OfType<DiagnosticLocation>(), x => x.Id == "CA1303");
                 // warning CA1303: Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from
                 // a resource table instead: "Hello World!"
             }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/BufferManagerMiscFilesFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/BufferManagerMiscFilesFacts.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Models.CodeCheck;
+using OmniSharp.Models.Diagnostics;
 using OmniSharp.Models.FilesChanged;
 using OmniSharp.Models.FindImplementations;
 using OmniSharp.Models.FindSymbols;
@@ -36,7 +37,8 @@ namespace OmniSharp.Tests
                     var request = new CodeCheckRequest() { FileName = filePath };
                     var actual = await host.GetResponse<CodeCheckRequest, QuickFixResponse>(OmniSharpEndpoints.CodeCheck, request);
                     Assert.Single(actual.QuickFixes);
-                    Assert.Equal("; expected (CS1002)", actual.QuickFixes.First().Text);
+                    Assert.Equal("; expected", actual.QuickFixes.First().Text);
+                    Assert.Equal("CS1002", actual.QuickFixes.OfType<DiagnosticLocation>().First().Id);
                 }
             }
         }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CustomRoslynAnalyzerFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CustomRoslynAnalyzerFacts.cs
@@ -110,7 +110,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
                 var result = await host.RequestCodeCheckAsync("testFile_66.cs");
 
-                Assert.Contains(result.QuickFixes.OfType<DiagnosticLocation>(), f => f.Text.Contains(testAnalyzerRef.Id.ToString()));
+                Assert.Contains(result.QuickFixes.OfType<DiagnosticLocation>(), f => f.Id == testAnalyzerRef.Id.ToString());
             }
         }
 
@@ -131,7 +131,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
                 var result = await host.RequestCodeCheckAsync();
 
-                Assert.Contains(result.QuickFixes.Where(x => x.FileName == testFile.FileName), f => f.Text.Contains("CS"));
+                Assert.Contains(result.QuickFixes.OfType<DiagnosticLocation>().Where(x => x.FileName == testFile.FileName), f => f.Id.Contains("CS"));
             }
         }
 
@@ -157,7 +157,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
                 var result = await host.RequestCodeCheckAsync();
 
-                Assert.Contains(result.QuickFixes.OfType<DiagnosticLocation>(), f => f.Text.Contains("CS0162") && f.LogLevel == "Hidden");
+                Assert.Contains(result.QuickFixes.OfType<DiagnosticLocation>(), f => f.Id == "CS0162" && f.LogLevel == "Hidden");
             }
         }
 
@@ -178,7 +178,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 var result = await host.RequestCodeCheckAsync("testFile_2.cs");
 
                 var bar = result.QuickFixes.ToList();
-                Assert.Contains(result.QuickFixes.OfType<DiagnosticLocation>(), f => f.Text.Contains(testAnalyzerRef.Id.ToString()) && f.LogLevel == "Hidden");
+                Assert.Contains(result.QuickFixes.OfType<DiagnosticLocation>(), f => f.Id == testAnalyzerRef.Id.ToString() && f.LogLevel == "Hidden");
             }
         }
 
@@ -207,7 +207,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 host.Workspace.UpdateDiagnosticOptionsForProject(projectId, testRules.ToImmutableDictionary());
 
                 var result = await host.RequestCodeCheckAsync("testFile_3.cs");
-                Assert.DoesNotContain(result.QuickFixes, f => f.Text.Contains(testAnalyzerRef.Id.ToString()));
+                Assert.DoesNotContain(result.QuickFixes.OfType<DiagnosticLocation>(), f => f.Id == testAnalyzerRef.Id.ToString());
             }
         }
 
@@ -227,7 +227,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 host.Workspace.UpdateDiagnosticOptionsForProject(projectId, testRules.ToImmutableDictionary());
 
                 var result = await host.RequestCodeCheckAsync("testFile_4.cs");
-                Assert.Contains(result.QuickFixes, f => f.Text.Contains(testAnalyzerRef.Id.ToString()));
+                Assert.Contains(result.QuickFixes.OfType<DiagnosticLocation>(), f => f.Id == testAnalyzerRef.Id.ToString());
             }
         }
 
@@ -254,7 +254,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 Assert.True(workspaceUpdatedCheck.WaitOne(timeout: TimeSpan.FromSeconds(15)));
 
                 var result = await host.RequestCodeCheckAsync("testFile_4.cs");
-                Assert.DoesNotContain(result.QuickFixes, f => f.Text.Contains(testAnalyzerRef.Id.ToString()));
+                Assert.DoesNotContain(result.QuickFixes.OfType<DiagnosticLocation>(), f => f.Id == testAnalyzerRef.Id.ToString());
             }
         }
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsFacts.cs
@@ -29,7 +29,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 host.AddFilesToWorkspace(new TestFile("a.cs", "class C { int n = true; }"));
                 var quickFixes = await host.RequestCodeCheckAsync("a.cs");
 
-                Assert.Contains(quickFixes.QuickFixes.Select(x => x.ToString()), x => x.Contains("CS0029"));
+                Assert.Contains(quickFixes.QuickFixes.OfType<DiagnosticLocation>(), x => x.Id == "CS0029");
                 Assert.Equal("a.cs", quickFixes.QuickFixes.First().FileName);
             }
         }
@@ -50,8 +50,8 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
                 var quickFixes = await host.RequestCodeCheckAsync();
 
-                Assert.Contains(quickFixes.QuickFixes, x => x.Text.Contains("CS0029") && x.FileName == "a.cs");
-                Assert.Contains(quickFixes.QuickFixes, x => x.Text.Contains("CS0029") && x.FileName == "b.cs");
+                Assert.Contains(quickFixes.QuickFixes.OfType<DiagnosticLocation>(), x => x.Id == "CS0029" && x.FileName == "a.cs");
+                Assert.Contains(quickFixes.QuickFixes.OfType<DiagnosticLocation>(), x => x.Id == "CS0029" && x.FileName == "b.cs");
             }
         }
 
@@ -70,8 +70,8 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
                 var quickFixes = await host.RequestCodeCheckAsync();
 
-                Assert.Contains(quickFixes.QuickFixes, x => x.Text.Contains("CS0029") && x.FileName == "a.cs");
-                Assert.Contains(quickFixes.QuickFixes, x => x.Text.Contains("CS0029") && x.FileName == "b.cs");
+                Assert.Contains(quickFixes.QuickFixes.OfType<DiagnosticLocation>(), x => x.Id == "CS0029" && x.FileName == "a.cs");
+                Assert.Contains(quickFixes.QuickFixes.OfType<DiagnosticLocation>(), x => x.Id == "CS0029" && x.FileName == "b.cs");
             }
         }
 
@@ -93,7 +93,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
                 var quickFixes = await host.RequestCodeCheckAsync();
 
-                Assert.DoesNotContain(quickFixes.QuickFixes, x => x.Text.Contains("CS0029") && x.FileName == "a.cs");
+                Assert.DoesNotContain(quickFixes.QuickFixes.OfType<DiagnosticLocation>(), x => x.Id == "CS0029" && x.FileName == "a.cs");
             }
         }
 
@@ -106,7 +106,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                     new TestFile("a.cs", "class C1 { int n = true; }"));
 
                 var quickFixes = await host.RequestCodeCheckAsync("a.cs");
-                Assert.Contains(quickFixes.QuickFixes, x => x.Text.Contains("IDE0044"));
+                Assert.Contains(quickFixes.QuickFixes.OfType<DiagnosticLocation>(), x => x.Id == "IDE0044");
             }
         }
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/EditorConfigFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/EditorConfigFacts.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Models;
 using OmniSharp.Models.CodeFormat;
+using OmniSharp.Models.Diagnostics;
 using OmniSharp.Models.V2.CodeActions;
 using OmniSharp.Options;
 using OmniSharp.Roslyn.CSharp.Services.Formatting;
@@ -187,8 +188,8 @@ class Foo
             {
                 var result = await host.RequestCodeCheckAsync();
 
-                Assert.Contains(result.QuickFixes.Where(x => x.FileName == testFile.FileName), f => f.Text == "Use framework type (IDE0049)");
-                Assert.Contains(result.QuickFixes.Where(x => x.FileName == testFile.FileName), f => f.Text == "Use explicit type instead of 'var' (IDE0008)");
+                Assert.Contains(result.QuickFixes.OfType<DiagnosticLocation>().Where(x => x.FileName == testFile.FileName), f => f.Text == "Use framework type" && f.Id == "IDE0049");
+                Assert.Contains(result.QuickFixes.OfType<DiagnosticLocation>().Where(x => x.FileName == testFile.FileName), f => f.Text == "Use explicit type instead of 'var'" && f.Id == "IDE0008");
             }
         }
 
@@ -216,7 +217,7 @@ class Foo
             {
                 var result = await host.RequestCodeCheckAsync();
 
-                Assert.Contains(result.QuickFixes.Where(x => x.FileName == testFile.FileName), f => f.Text == "Naming rule violation: Missing prefix: 'xxx_' (IDE1006)");
+                Assert.Contains(result.QuickFixes.OfType<DiagnosticLocation>().Where(x => x.FileName == testFile.FileName), f => f.Text == "Naming rule violation: Missing prefix: 'xxx_'" && f.Id == "IDE1006");
             }
         }
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/ReAnalysisFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/ReAnalysisFacts.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Abstractions.Models.V1.ReAnalyze;
 using OmniSharp.Models.ChangeBuffer;
+using OmniSharp.Models.Diagnostics;
 using OmniSharp.Models.Events;
 using OmniSharp.Roslyn.CSharp.Services.Buffer;
 using OmniSharp.Roslyn.CSharp.Services.Diagnostics;
@@ -53,7 +54,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
                 // Reference to B is lost, a.cs should contain error about invalid reference to it.
                 // error CS0246: The type or namespace name 'B' could not be found
-                Assert.Contains(quickFixes.QuickFixes.Select(x => x.ToString()), x => x.Contains("CS0246"));
+                Assert.Contains(quickFixes.QuickFixes.OfType<DiagnosticLocation>(), x => x.Id == "CS0246");
             }
         }
 


### PR DESCRIPTION
Relates to https://github.com/OmniSharp/omnisharp-roslyn/issues/1622

In VSCode, the diagnostic id should better be passed in the `code` attribute. Having it also in the message lead to duplication in the UI.