### PR TITLE
Fixed "go to metadata"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.34.5] - not yet released
+* Fixed 1.34.4 regression that caused "go to metadata" to not work ([#1624](https://github.com/OmniSharp/omnisharp-roslyn/issues/1624), PR: [#1625](https://github.com/OmniSharp/omnisharp-roslyn/pull/1625))
+
 ## [1.34.4] - 2019-09-30
 * Upgraded to MSBuild 16.3 and Mono MSBuild 16.3 (from Mono 6.4.0) to support .NET Core 3.0 RTM (PR: [#1616](https://github.com/OmniSharp/omnisharp-roslyn/pull/1616), [#1612](https://github.com/OmniSharp/omnisharp-roslyn/pull/1612), [#1606](https://github.com/OmniSharp/omnisharp-roslyn/pull/1606))
 * Fixed behavior when there are multiple handlers are defined for a language for a given request (PR: [#1582](https://github.com/OmniSharp/omnisharp-roslyn/pull/1582))

--- a/src/OmniSharp.Abstractions/Models/v1/GotoDefinition/GotoDefinitionResponse.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/GotoDefinition/GotoDefinitionResponse.cs
@@ -11,6 +11,6 @@ namespace OmniSharp.Models.GotoDefinition
         [JsonConverter(typeof(ZeroBasedIndexConverter))]
         public int Column { get; set; }
         public MetadataSource MetadataSource { get; set; }
-        public bool IsEmpty => FileName == null || FileName == string.Empty;
+        public bool IsEmpty => string.IsNullOrWhiteSpace(FileName) && MetadataSource == null;
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
@@ -371,6 +371,7 @@ class Bar {
             var response = await GetResponseAsync(new[] { testFile }, wantMetadata: true);
 
             Assert.NotNull(response.MetadataSource);
+            Assert.False(response.IsEmpty);
             Assert.Equal(expectedAssemblyName, response.MetadataSource.AssemblyName);
             Assert.Equal(expectedTypeName, response.MetadataSource.TypeName);
 


### PR DESCRIPTION
Unfortunately https://github.com/OmniSharp/omnisharp-roslyn/pull/1582 introduced a pretty bad regression - as it broke "go to metadata".
This then shipped with 1.34.4. 😩

This PR fixes it and introduces an extra assert that would have caught the regression.

Fixes #1624 