### PR TITLE
raise minimum Mono version to 6.4.0

### DIFF
--- a/build.json
+++ b/build.json
@@ -2,7 +2,7 @@
   "DotNetInstallScriptURL": "https://dot.net/v1",
   "DotNetChannel": "preview",
   "DotNetVersion": "2.1.505",
-  "RequiredMonoVersion": "6.0.0",
+  "RequiredMonoVersion": "6.4.0",
   "DownloadURL": "https://roslynomnisharp.blob.core.windows.net/ext",
   "MonoRuntimeMacOS": "mono.macOS-5.18.1.0.zip",
   "MonoRuntimeLinux32": "mono.linux-x86-5.18.1.0.zip",

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/MonoInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/MonoInstanceProvider.cs
@@ -69,9 +69,9 @@ namespace OmniSharp.MSBuild.Discovery.Providers
                 return NoInstances;
             }
 
-            if (monoVersion < new Version("5.18.1"))
+            if (monoVersion < new Version("6.4.0"))
             {
-                Logger.LogDebug($"Found Mono MSBuild but it could not be used because it is version {monoVersion} and in needs to be >= 5.18.1");
+                Logger.LogDebug($"Found Mono MSBuild but it could not be used because it is version {monoVersion} and in needs to be >= 6.4.0");
                 return NoInstances;
             }
 
@@ -91,7 +91,7 @@ namespace OmniSharp.MSBuild.Discovery.Providers
 
                 if (Platform.Current.OperatingSystem == Utilities.OperatingSystem.Linux)
                 {
-                    Logger.LogWarning(@"It looks like you have Mono 5.2.0 or greater installed but MSBuild could not be found.
+                    Logger.LogWarning(@"It looks like you have Mono 6.4.0 or greater installed but MSBuild could not be found.
 Try installing MSBuild into Mono (e.g. 'sudo apt-get install msbuild') to enable better MSBuild support.");
                 }
 
@@ -112,7 +112,7 @@ Try installing MSBuild into Mono (e.g. 'sudo apt-get install msbuild') to enable
                 new MSBuildInstance(
                     nameof(DiscoveryType.Mono),
                     toolsPath,
-                    new Version(16, 0),
+                    new Version(16, 3),
                     DiscoveryType.Mono,
                     propertyOverrides.ToImmutable()));
         }

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
@@ -65,7 +65,7 @@ namespace OmniSharp.MSBuild.Discovery.Providers
                 new MSBuildInstance(
                     nameof(DiscoveryType.StandAlone),
                     toolsPath,
-                    new Version(16, 0), // we now ship with embedded MsBuild 16.x
+                    new Version(16, 3), // we now ship with embedded MsBuild 16.3
                     DiscoveryType.StandAlone,
                     propertyOverrides.ToImmutable(),
                     setMSBuildExePathVariable: true));

--- a/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
@@ -187,7 +187,7 @@ namespace OmniSharp.MSBuild.Tests
             return new MSBuildInstance(
                 "Stand Alone :(",
                 TestIO.GetRandomTempFolderPath(),
-                Version.Parse("16.0.0.0"),
+                Version.Parse("16.3.0.0"),
                 DiscoveryType.StandAlone
             );
         }


### PR DESCRIPTION
It is required for netcoreapp3.0 as it comes with MSBuild 16.3.
Since we don't discover Mono per-project type but globally at OmniSharp start, the only reasonable choice at the moment - to avoid lots of error reports from users, which we do have these days - is to raise the minimum discovered version to 6.4.0.