### PR TITLE
correctly use cancellation token in Metadata service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to the project will be documented in this file.
 ## [1.34.6] - not yet released
 * Raised minimum Mono version to 6.4.0 to provide better .NET Core 3.0 support ([#1629](https://github.com/OmniSharp/omnisharp-roslyn/pull/1629))
 * Fixed a concurrency bug in scripting/Cake support ([#1627](https://github.com/OmniSharp/omnisharp-roslyn/pull/1627))
+* Correctly respect request cancellation token in metadata service ([#1631](https://github.com/OmniSharp/omnisharp-roslyn/pull/1631))
 
 ## [1.34.5] - 2019-10-08
 * Fixed 1.34.4 regression that caused "go to metadata" to not work ([#1624](https://github.com/OmniSharp/omnisharp-roslyn/issues/1624), PR: [#1625](https://github.com/OmniSharp/omnisharp-roslyn/pull/1625))

--- a/src/OmniSharp.Roslyn/MetadataHelper.cs
+++ b/src/OmniSharp.Roslyn/MetadataHelper.cs
@@ -95,7 +95,7 @@ namespace OmniSharp.Roslyn
                 var service = _csharpMetadataAsSourceService.CreateInstance(temporaryDocument.Project.LanguageServices);
                 var method = _csharpMetadataAsSourceService.GetMethod(AddSourceToAsync);
 
-                var documentTask = method.Invoke<Task<Document>>(service, new object[] { temporaryDocument, await metadataProject.GetCompilationAsync(), topLevelSymbol, default(CancellationToken) });
+                var documentTask = method.Invoke<Task<Document>>(service, new object[] { temporaryDocument, await metadataProject.GetCompilationAsync(), topLevelSymbol, cancellationToken });
                 metadataDocument = await documentTask;
 
                 _metadataDocumentCache[fileName] = metadataDocument;


### PR DESCRIPTION
`GetAndAddDocumentFromMetadata` doesn't respect the passed-in cancellation token.