### PR TITLE
updated to Roslyn 3.4.0-beta3-19516-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All changes to the project will be documented in this file.
 
 ## [1.34.6] - not yet released
+* Update to Roslyn `3.4.0-beta3-19516-01` (PR:[#1634](https://github.com/OmniSharp/omnisharp-roslyn/pull/1634))
 * Raised minimum Mono version to 6.4.0 to provide better .NET Core 3.0 support ([#1629](https://github.com/OmniSharp/omnisharp-roslyn/pull/1629))
 * Fixed a concurrency bug in scripting/Cake support ([#1627](https://github.com/OmniSharp/omnisharp-roslyn/pull/1627))
 * Correctly respect request cancellation token in metadata service ([#1631](https://github.com/OmniSharp/omnisharp-roslyn/pull/1631))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to the project will be documented in this file.
 
 ## [1.34.6] - not yet released
 * Update to Roslyn `3.4.0-beta3-19516-01` (PR:[#1634](https://github.com/OmniSharp/omnisharp-roslyn/pull/1634))
+* Fixed a bug that caused CS0019 diagnostic to be erroneously reported when comparing to `default` ([#1619](https://github.com/OmniSharp/omnisharp-roslyn/issues/1619), PR:[#1634](https://github.com/OmniSharp/omnisharp-roslyn/pull/1634))
 * Raised minimum Mono version to 6.4.0 to provide better .NET Core 3.0 support ([#1629](https://github.com/OmniSharp/omnisharp-roslyn/pull/1629))
 * Fixed a concurrency bug in scripting/Cake support ([#1627](https://github.com/OmniSharp/omnisharp-roslyn/pull/1627))
 * Correctly respect request cancellation token in metadata service ([#1631](https://github.com/OmniSharp/omnisharp-roslyn/pull/1631))

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>16.3.0-preview-19426-01</MSBuildPackageVersion>
     <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.4.0-beta1-19460-02</RoslynPackageVersion>
+    <RoslynPackageVersion>3.4.0-beta3-19516-01</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -154,7 +154,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
                     // 1 point for having a parameter
                     score += 1;
                 }
-                else if (invocationEnum.Current.ConvertedType.Equals(definitionEnum.Current.Type))
+                else if (SymbolEqualityComparer.Default.Equals(invocationEnum.Current.ConvertedType, definitionEnum.Current.Type))
                 {
                     // 2 points for having a parameter and being
                     // the same type

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Intellisense/SnippetGenerator.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Intellisense/SnippetGenerator.cs
@@ -73,7 +73,7 @@ namespace OmniSharp
                     _sb.Append(arg);
                     RenderSnippetEndMarker();
 
-                    if (!Equals(arg, last))
+                    if (!SymbolEqualityComparer.Default.Equals(arg, last))
                     {
                         _sb.Append(", ");
                     }
@@ -107,7 +107,7 @@ namespace OmniSharp
                     _sb.Append(parameter.ToDisplayString(_format));
                     RenderSnippetEndMarker();
 
-                    if (!Equals(parameter, last))
+                    if (!SymbolEqualityComparer.Default.Equals(parameter, last))
                     {
                         _sb.Append(", ");
                     }
@@ -127,7 +127,7 @@ namespace OmniSharp
             {
                 var arg = typeArguments[i];
                 var param = typeParameters[i];
-                if (Equals(arg, param))
+                if (SymbolEqualityComparer.Default.Equals(arg, param))
                 {
                     // this type parameter has not been resolved
                     nonInferredTypeArguments.Add(arg);

--- a/src/OmniSharp.Roslyn/Extensions/SymbolExtensions.cs
+++ b/src/OmniSharp.Roslyn/Extensions/SymbolExtensions.cs
@@ -207,7 +207,7 @@ namespace OmniSharp.Extensions
         {
             // Traverse up until we find a named type that is parented by the namespace
             var topLevelNamedType = symbol;
-            while (!Equals(topLevelNamedType.ContainingSymbol, symbol.ContainingNamespace) ||
+            while (!SymbolEqualityComparer.Default.Equals(topLevelNamedType.ContainingSymbol, symbol.ContainingNamespace) ||
                 topLevelNamedType.Kind != SymbolKind.NamedType)
             {
                 topLevelNamedType = topLevelNamedType.ContainingSymbol;

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsFacts.cs
@@ -143,5 +143,20 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                     .Tags);
             }
         }
+
+        [Fact]
+        // issue: https://github.com/OmniSharp/omnisharp-roslyn/issues/1619
+        public async Task DoesNotErroneouslyReportCS0019_WhenComparingToDefault()
+        {
+            using (var host = GetHost(roslynAnalyzersEnabled: true))
+            {
+                host.AddFilesToWorkspace(
+                    new TestFile("a.cs", "class C1 { bool Test(object input) => input == default; }"));
+
+                var quickFixes = await host.RequestCodeCheckAsync("a.cs");
+                var allDiagnostics = quickFixes.QuickFixes.OfType<DiagnosticLocation>().Where(x => x.Id == "CS0019");
+                Assert.Empty(allDiagnostics);
+            }
+        }
     }
 }


### PR DESCRIPTION
We have fallen behind the schedule a bit (especially with .NET Core 3.1 Preview 1 out already). We had consumed `3.4.0-beta1-19460-02` over a month ago but even Nuget publicly has a newer version now.

This PR pulls in the latest build intended for VS 16.4.