### PR TITLE
Update Roslyn to 3.5.0-beta1-19571-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All changes to the project will be documented in this file.
 
 ## [1.34.8] - not yet released
-* Update to Roslyn `3.5.0-beta1-19564-02` (PR:[#1652](https://github.com/OmniSharp/omnisharp-roslyn/pull/1652))
+* Update to Roslyn `3.5.0-beta1-19571-01` (PR:[#1653](https://github.com/OmniSharp/omnisharp-roslyn/pull/1653))
 
 ## [1.34.7] - 2019-11-06
 * Updated the embedded Mono to 6.4.0 (PR:[#1640](https://github.com/OmniSharp/omnisharp-roslyn/pull/1640))

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>16.3.0-preview-19426-01</MSBuildPackageVersion>
     <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.5.0-beta1-19564-02</RoslynPackageVersion>
+    <RoslynPackageVersion>3.5.0-beta1-19571-01</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
This updates Roslyn to the build we expect to ship in 16.5 preview 1.