### PR TITLE
do not set mono paths in standalone mode

### DIFF
--- a/src/OmniSharp.Host/MSBuild/Discovery/MSBuildLocator.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/MSBuildLocator.cs
@@ -47,13 +47,13 @@ namespace OmniSharp.MSBuild.Discovery
                     new DevConsoleInstanceProvider(loggerFactory),
                     new VisualStudioInstanceProvider(loggerFactory),
                     new MonoInstanceProvider(loggerFactory),
-                    new StandAloneInstanceProvider(loggerFactory, allowMonoPaths: true),
+                    new StandAloneInstanceProvider(loggerFactory),
                     new UserOverrideInstanceProvider(loggerFactory, msbuildConfiguration)));
 
-        public static MSBuildLocator CreateStandAlone(ILoggerFactory loggerFactory, IAssemblyLoader assemblyLoader, bool allowMonoPaths)
+        public static MSBuildLocator CreateStandAlone(ILoggerFactory loggerFactory, IAssemblyLoader assemblyLoader)
             => new MSBuildLocator(loggerFactory, assemblyLoader,
                 ImmutableArray.Create<MSBuildInstanceProvider>(
-                    new StandAloneInstanceProvider(loggerFactory, allowMonoPaths)));
+                    new StandAloneInstanceProvider(loggerFactory)));
 
         public void RegisterInstance(MSBuildInstance instance)
         {

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
@@ -38,22 +38,6 @@ namespace OmniSharp.MSBuild.Discovery.Providers
                 // a particular assembly in the GAC as a "guarantee". However, we don't include that
                 // in our Mono package. So, we'll just bypass the check.
                 propertyOverrides.Add("BypassFrameworkInstallChecks", "true");
-
-                // To better support older versions of Mono that don't include
-                // MSBuild 15, we attempt to set property overrides to the locations
-                // of Mono's 'xbuild' and 'xbuild-frameworks' paths.
-                if (_allowMonoPaths)
-                {
-                    if (TryGetMonoXBuildPath(out var xbuildPath))
-                    {
-                        extensionsPath = xbuildPath;
-                    }
-
-                    if (TryGetMonoXBuildFrameworksPath(out var xbuildFrameworksPath))
-                    {
-                        propertyOverrides.Add("TargetFrameworkRootPath", xbuildFrameworksPath);
-                    }
-                }
             }
 
             propertyOverrides.Add("MSBuildToolsPath", toolsPath);

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
@@ -51,47 +51,5 @@ namespace OmniSharp.MSBuild.Discovery.Providers
                     propertyOverrides.ToImmutable(),
                     setMSBuildExePathVariable: true));
         }
-
-        private static bool TryGetMonoXBuildPath(out string path)
-        {
-            path = null;
-
-            var monoXBuildDirPath = PlatformHelper.GetMonoXBuildDirPath();
-            if (monoXBuildDirPath == null)
-            {
-                return false;
-            }
-
-            var monoXBuild15DirPath = Path.Combine(monoXBuildDirPath, "15.0");
-            if (Directory.Exists(monoXBuild15DirPath))
-            {
-                path = monoXBuildDirPath;
-                return true;
-            }
-
-
-            var monoXBuildCurrentDirPath = Path.Combine(monoXBuildDirPath, "Current");
-            if (Directory.Exists(monoXBuildCurrentDirPath))
-            {
-                path = monoXBuildDirPath;
-                return true;
-            }
-
-            return false;
-        }
-
-        private static bool TryGetMonoXBuildFrameworksPath(out string path)
-        {
-            path = null;
-
-            var monoMSBuildXBuildFrameworksDirPath = PlatformHelper.GetMonoXBuildFrameworksDirPath();
-            if (monoMSBuildXBuildFrameworksDirPath == null)
-            {
-                return false;
-            }
-
-            path = monoMSBuildXBuildFrameworksDirPath;
-            return true;
-        }
     }
 }

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
@@ -8,12 +8,9 @@ namespace OmniSharp.MSBuild.Discovery.Providers
 {
     internal class StandAloneInstanceProvider : MSBuildInstanceProvider
     {
-        private readonly bool _allowMonoPaths;
-
-        public StandAloneInstanceProvider(ILoggerFactory loggerFactory, bool allowMonoPaths)
+        public StandAloneInstanceProvider(ILoggerFactory loggerFactory)
             : base(loggerFactory)
         {
-            _allowMonoPaths = allowMonoPaths;
         }
 
         public override ImmutableArray<MSBuildInstance> GetInstances()

--- a/tests/OmniSharp.MSBuild.Tests/AbstractMSBuildTestFixture.cs
+++ b/tests/OmniSharp.MSBuild.Tests/AbstractMSBuildTestFixture.cs
@@ -22,7 +22,7 @@ namespace OmniSharp.MSBuild.Tests
         {
             _assemblyLoader = new AssemblyLoader(this.LoggerFactory);
             _analyzerAssemblyLoader = new AnalyzerAssemblyLoader();
-            _msbuildLocator = MSBuildLocator.CreateStandAlone(this.LoggerFactory, _assemblyLoader, allowMonoPaths: false);
+            _msbuildLocator = MSBuildLocator.CreateStandAlone(this.LoggerFactory, _assemblyLoader);
 
             // Some tests require MSBuild to be discovered early
             // to ensure that the Microsoft.Build.* assemblies can be located

--- a/tests/TestUtility/TestServiceProvider.cs
+++ b/tests/TestUtility/TestServiceProvider.cs
@@ -155,7 +155,7 @@ namespace TestUtility
             => new MemoryCache(new MemoryCacheOptions());
 
         private static IMSBuildLocator CreateMSBuildLocator(ILoggerFactory loggerFactory, IAssemblyLoader assemblyLoader)
-            => MSBuildLocator.CreateStandAlone(loggerFactory, assemblyLoader, allowMonoPaths: false);
+            => MSBuildLocator.CreateStandAlone(loggerFactory, assemblyLoader);
 
         private static IOptionsMonitor<OmniSharpOptions> CreateOptionsMonitor(IConfigurationRoot configurationRoot)
         {


### PR DESCRIPTION
Since we now run in stand alone mode on top of mono 6.4.0 and raised the global mono minimum version to 6.4.0, we should not need to set mono paths in stand alone mode anymore. 

This fixes https://github.com/OmniSharp/omnisharp-vscode/issues/3410 and fixes https://github.com/OmniSharp/omnisharp-vscode/issues/3340 and a couple of other issues that I need to dig up (also lots of errors were reported as comments under old closed issues). In short the problem was, if you have old Mono (say 5.4.0) installed, we don't pick it as global Mono as it's < 6.4.0 and run in standalone mode. However we still set:

```
TargetFrameworkRootPath = /Library/Frameworks/Mono.framework/Versions/5.4.0/lib/mono/xbuild-frameworks
MSBuildExtensionsPath = /Library/Frameworks/Mono.framework/Versions/5.4.0/lib/mono/xbuild
```

which causes .NET Core 3.0 to fail.

By the way, the tests explicitly avoided to set any mono paths, so any problem with this, and users reported plenty, only ever manifested itself only once running OmniSharp server in real world.