### PR TITLE
Support #line directive in find references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All changes to the project will be documented in this file.
 
 ## [1.34.9] - not yet released
+* Line pragma is now respected in find references ([#1649](https://github.com/OmniSharp/omnisharp-roslyn/issues/1649), PR:[#1660](https://github.com/OmniSharp/omnisharp-roslyn/pull/1660))
 * Do not set mono paths when running in standalone mode ([omnisharp-vscode#3410](https://github.com/OmniSharp/omnisharp-vscode/issues/3410), [omnisharp-vscode#3340](https://github.com/OmniSharp/omnisharp-vscode/issues/3340), [#1650](https://github.com/OmniSharp/omnisharp-roslyn/issues/1650), PR:[#1656](https://github.com/OmniSharp/omnisharp-roslyn/pull/1656))
 
 ## [1.34.8] - 2019-11-21

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
@@ -25,9 +25,9 @@ namespace OmniSharp.Helpers
                 Text = text.Trim(),
                 FileName = path,
                 Line = line,
-                Column = lineSpan.StartLinePosition.Character,
+                Column = lineSpan.HasMappedPath ? 0 : lineSpan.StartLinePosition.Character, // when a #line directive maps into a separate file, assume columns (0,0)
                 EndLine = lineSpan.EndLinePosition.Line,
-                EndColumn = lineSpan.EndLinePosition.Character,
+                EndColumn = lineSpan.HasMappedPath ? 0 : lineSpan.EndLinePosition.Character,
                 Projects = documents.Select(document => document.Project.Name).ToArray()
             };
         }

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
@@ -13,7 +13,7 @@ namespace OmniSharp.Helpers
             if (!location.IsInSource)
                 throw new Exception("Location is not in the source tree");
 
-            var lineSpan = location.GetLineSpan();
+            var lineSpan = location.GetMappedLineSpan();
             var path = lineSpan.Path;
             var documents = workspace.GetDocuments(path);
 


### PR DESCRIPTION
Fixes #1649 
If the mapping goes to an external file, we assume column 0,0