### PR TITLE
updated to msbuild 16.4.0 and Microsoft.NETFramework.ReferenceAssemblies 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All changes to the project will be documented in this file.
 
 ## [1.34.9] - not yet released
+* Updated to MsBuild 16.4.0 (PR:[#1662](https://github.com/OmniSharp/omnisharp-roslyn/pull/1662))
 * Line pragma is now respected in find references ([#1649](https://github.com/OmniSharp/omnisharp-roslyn/issues/1649), PR:[#1660](https://github.com/OmniSharp/omnisharp-roslyn/pull/1660))
 * Do not set mono paths when running in standalone mode ([omnisharp-vscode#3410](https://github.com/OmniSharp/omnisharp-vscode/issues/3410), [omnisharp-vscode#3340](https://github.com/OmniSharp/omnisharp-vscode/issues/3340), [#1650](https://github.com/OmniSharp/omnisharp-roslyn/issues/1650), PR:[#1656](https://github.com/OmniSharp/omnisharp-roslyn/pull/1656))
 * Fixed a bug where OmniSharp would crash on startup if the path contained `=` sign ([omnisharp-vscode#3436](https://github.com/OmniSharp/omnisharp-vscode/issues/3436), PR:[#1661](https://github.com/OmniSharp/omnisharp-roslyn/pull/1661))

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -50,7 +50,7 @@
     <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.1" />
     <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
 
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" />
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Update="Microsoft.TestPlatform.TranslationLayer" Version="15.7.2" />
     <PackageReference Update="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" />

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -3,7 +3,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <MSBuildPackageVersion>16.3.0-preview-19426-01</MSBuildPackageVersion>
+    <MSBuildPackageVersion>16.4.0</MSBuildPackageVersion>
     <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
     <RoslynPackageVersion>3.5.0-beta1-19571-01</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Cake" version="0.32.1" />
-    <package id="Microsoft.Build" version="16.3.0" />
-    <package id="Microsoft.Build.Framework" version="16.3.0" />
-    <package id="Microsoft.Build.Runtime" version="16.3.0" />
-    <package id="Microsoft.Build.Tasks.Core" version="16.3.0" />
-    <package id="Microsoft.Build.Utilities.Core" version="16.3.0" />
+    <package id="Microsoft.Build" version="16.4.0" />
+    <package id="Microsoft.Build.Framework" version="16.4.0" />
+    <package id="Microsoft.Build.Runtime" version="16.4.0" />
+    <package id="Microsoft.Build.Tasks.Core" version="16.4.0" />
+    <package id="Microsoft.Build.Utilities.Core" version="16.4.0" />
     <package id="Microsoft.Net.Compilers" version="3.3.1" />
     <package id="Microsoft.DotNet.MSBuildSdkResolver" version="3.0.101-servicing.19476.7" />
     <package id="NuGet.Build.Tasks" version="5.3.1" />


### PR DESCRIPTION
stable releases are public so we can drop the pre-release references

please note that on *nix we copy msbuild from Mono so until 6.6.0 is released, we still use 6.4.0 which has msbuild 16.3