### PR TITLE
Update Roslyn to 3.5.0-beta2-19606-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to the project will be documented in this file.
 * Line pragma is now respected in find references ([#1649](https://github.com/OmniSharp/omnisharp-roslyn/issues/1649), PR:[#1660](https://github.com/OmniSharp/omnisharp-roslyn/pull/1660))
 * Do not set mono paths when running in standalone mode ([omnisharp-vscode#3410](https://github.com/OmniSharp/omnisharp-vscode/issues/3410), [omnisharp-vscode#3340](https://github.com/OmniSharp/omnisharp-vscode/issues/3340), [#1650](https://github.com/OmniSharp/omnisharp-roslyn/issues/1650), PR:[#1656](https://github.com/OmniSharp/omnisharp-roslyn/pull/1656))
 * Fixed a bug where OmniSharp would crash on startup if the path contained `=` sign ([omnisharp-vscode#3436](https://github.com/OmniSharp/omnisharp-vscode/issues/3436), PR:[#1661](https://github.com/OmniSharp/omnisharp-roslyn/pull/1661))
+* Update to Roslyn `3.5.0-beta2-19606-01` (PR:[#1663](https://github.com/OmniSharp/omnisharp-roslyn/pull/1663))
 
 ## [1.34.8] - 2019-11-21
 * Update to Roslyn `3.5.0-beta1-19571-01` (PR:[#1653](https://github.com/OmniSharp/omnisharp-roslyn/pull/1653))

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>16.3.0-preview-19426-01</MSBuildPackageVersion>
     <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.5.0-beta1-19571-01</RoslynPackageVersion>
+    <RoslynPackageVersion>3.5.0-beta2-19606-01</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 

--- a/tests/OmniSharp.Cake.Tests/CodeActionsV2Facts.cs
+++ b/tests/OmniSharp.Cake.Tests/CodeActionsV2Facts.cs
@@ -44,7 +44,7 @@ namespace OmniSharp.Cake.Tests
                 }";
 
             var refactorings = await FindRefactoringNamesAsync(code);
-            Assert.Contains("Extract Method", refactorings);
+            Assert.Contains("Extract method", refactorings);
         }
 
         [Fact]
@@ -64,7 +64,8 @@ namespace OmniSharp.Cake.Tests
             {
                 "using System.Text.RegularExpressions;",
                 "System.Text.RegularExpressions.Regex",
-                "Extract Method",
+                "Extract method",
+                "Extract local function",
                 "Introduce local for 'Regex.Match(\"foo\", \"bar\")'"
             };
             Assert.Equal(expected, refactorings);
@@ -91,7 +92,7 @@ namespace OmniSharp.Cake.Tests
                 EndColumn = 8
             };
 
-            var response = await RunRefactoringAsync(code, "Extract Method");
+            var response = await RunRefactoringAsync(code, "Extract method");
             var modifiedFile = response.Changes.FirstOrDefault() as ModifiedFileResponse;
 
             Assert.Single(response.Changes);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CodeActionsV2Facts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CodeActionsV2Facts.cs
@@ -105,7 +105,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 }";
 
             var refactorings = await FindRefactoringNamesAsync(code, roslynAnalyzersEnabled);
-            Assert.Contains("Extract Method", refactorings);
+            Assert.Contains("Extract method", refactorings);
         }
 
         [Theory]
@@ -137,7 +137,8 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 "Generate type 'Console' -> Generate class 'Console' in new file",
                 "Generate type 'Console' -> Generate class 'Console'",
                 "Generate type 'Console' -> Generate nested class 'Console'",
-                "Extract Method",
+                "Extract local function",
+                "Extract method",
                 "Introduce local for 'Console.Write(\"should be using System;\")'"
             } : new List<string>
             {
@@ -151,7 +152,8 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 "Generate type 'Console' -> Generate class 'Console' in new file",
                 "Generate type 'Console' -> Generate class 'Console'",
                 "Generate type 'Console' -> Generate nested class 'Console'",
-                "Extract Method",
+                "Extract local function",
+                "Extract method",
                 "Introduce local for 'Console.Write(\"should be using System;\")'"
             };
             Assert.Equal(expected.OrderBy(x => x), refactorings.OrderBy(x => x));
@@ -183,7 +185,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                         Console.Write(""should be using System;"");
                     }
                 }";
-            var response = await RunRefactoringAsync(code, "Extract Method", isAnalyzersEnabled: roslynAnalyzersEnabled);
+            var response = await RunRefactoringAsync(code, "Extract method", isAnalyzersEnabled: roslynAnalyzersEnabled);
             AssertIgnoringIndent(expected, ((ModifiedFileResponse)response.Changes.First()).Buffer);
         }
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CodeActionsWithOptionsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CodeActionsWithOptionsFacts.cs
@@ -185,7 +185,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                     public string PropertyHere { get; set; }
                 }
                 ";
-            var response = await RunRefactoringAsync(code, "Extract Interface...");
+            var response = await RunRefactoringAsync(code, "Extract interface...");
 
             AssertIgnoringIndent(expected, ((ModifiedFileResponse)response.Changes.First()).Buffer);
         }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -6,7 +6,7 @@
     <package id="Microsoft.Build.Runtime" version="16.3.0" />
     <package id="Microsoft.Build.Tasks.Core" version="16.3.0" />
     <package id="Microsoft.Build.Utilities.Core" version="16.3.0" />
-    <package id="Microsoft.Net.Compilers" version="3.3.1" />
+    <package id="Microsoft.Net.Compilers" version="3.4.0" />
     <package id="Microsoft.DotNet.MSBuildSdkResolver" version="3.0.101-servicing.19476.7" />
     <package id="NuGet.Build.Tasks" version="5.3.1" />
     <package id="NuGet.Commands" version="5.3.1" />


### PR DESCRIPTION
Updates to a 16.5 Preview2 build of roslyn
### Changes from [fb3f812](https://www.github.com/dotnet/roslyn/commit/fb3f812) to [e8ab154](https://www.github.com/dotnet/roslyn/commit/e8ab154):
[View Complete Diff of Changes](https://www.github.com/dotnet/roslyn/compare/fb3f812...e8ab154)
- [More tests for [MaybeNull] (39983)](https://www.github.com/dotnet/roslyn/pull/39983)
- [Nullable collections (40029)](https://www.github.com/dotnet/roslyn/pull/40029)
- [Make finding checksum async (40091)](https://www.github.com/dotnet/roslyn/pull/40091)
- [Fix AllowNull/DisallowNull in object initializers (40127)](https://www.github.com/dotnet/roslyn/pull/40127)
- [Convert operand expressions in an error case (40093)](https://www.github.com/dotnet/roslyn/pull/40093)
- [Remove the nullable wrappers from the Workspaces layer (40030)](https://www.github.com/dotnet/roslyn/pull/40030)
- [Diagnostics refactoring (40078)](https://www.github.com/dotnet/roslyn/pull/40078)
- [Implicit numeric casts shouldn't be recommended to be removed if doing so loses precision (39543)](https://www.github.com/dotnet/roslyn/pull/39543)
- [Prefer user-defined conversion over a switch expression conversion (39953)](https://www.github.com/dotnet/roslyn/pull/39953)
- [Store nested conversion in the target-typed switch expression conversion (40107)](https://www.github.com/dotnet/roslyn/pull/40107)
- [Remove diagnostics from error list on document close or reset for tha… (39892)](https://www.github.com/dotnet/roslyn/pull/39892)
- [Update list of C# Next features and reviewers (39987)](https://www.github.com/dotnet/roslyn/pull/39987)
- [Add code action to extract local functions (39745)](https://www.github.com/dotnet/roslyn/pull/39745)
- [Fix for configuring code style for "infer member names in anonymous types" persists the wrong setting (40017)](https://www.github.com/dotnet/roslyn/pull/40017)
- [Always restore when running a bootstrap build (40025)](https://www.github.com/dotnet/roslyn/pull/40025)
- [DiagnosticIncrementalAnalyzer refactoring (39956)](https://www.github.com/dotnet/roslyn/pull/39956)
- [Simplify how we compute and store the location we use to persist the sqlite storage cache. (39655)](https://www.github.com/dotnet/roslyn/pull/39655)
- [Move LiveShare off of the deprecated constructors and project shims (39938)](https://www.github.com/dotnet/roslyn/pull/39938)
- [Move reporting of iterator diagnostics to avoid race condition (39990)](https://www.github.com/dotnet/roslyn/pull/39990)
- [Fix NGEN priority of csc.exe, vbc.exe, csi.exe (40016)](https://www.github.com/dotnet/roslyn/pull/40016)
- [Extra check for EnumeratorCancellation parameter type (39978)](https://www.github.com/dotnet/roslyn/pull/39978)
- [Extend profiling inputs drop time to 90 days (40009)](https://www.github.com/dotnet/roslyn/pull/40009)
- [Change to telemetry logger (39982)](https://www.github.com/dotnet/roslyn/pull/39982)
- [Emit CS8370 instead of CS1674 for ref struct disposable (39949)](https://www.github.com/dotnet/roslyn/pull/39949)
- [Move the ClosedFileDiagnostic option used by TS back to Features layer (39980)](https://www.github.com/dotnet/roslyn/pull/39980)
- [Do not convert PDBs when building bootstrap compiler (39972)](https://www.github.com/dotnet/roslyn/pull/39972)
- [Ensure that work coordinator sees change to "RunAnalyzers" project pr… (39973)](https://www.github.com/dotnet/roslyn/pull/39973)
- [Avoid warning assigning to readonly property marked [AllowNull] (39939)](https://www.github.com/dotnet/roslyn/pull/39939)
- [Properly respect 'var' settings when generating equals/GetHashCode (39958)](https://www.github.com/dotnet/roslyn/pull/39958)
- [Update FormattingDiagnosticIds.cs (39957)](https://www.github.com/dotnet/roslyn/pull/39957)
- [Re-add ServiceFeatureOnOffOptions.ClosedFileDiagnostic to fix the bre… (39955)](https://www.github.com/dotnet/roslyn/pull/39955)
- [Improvement for completion of unimported types (39813)](https://www.github.com/dotnet/roslyn/pull/39813)
- [Decouple command filters and contained documents from language service (39910)](https://www.github.com/dotnet/roslyn/pull/39910)
- [Track additional state for "maybe null even if not nullable" (39778)](https://www.github.com/dotnet/roslyn/pull/39778)
- [Address a number of variance safety issues with code in interfaces. (39839)](https://www.github.com/dotnet/roslyn/pull/39839)
- [Cleanup hoisted locals at async state machine end (#34239) (39735)](https://www.github.com/dotnet/roslyn/pull/39735)
- [Add "Active file" analysis scope for background analysis in the IDE (39699)](https://www.github.com/dotnet/roslyn/pull/39699)
- [Add new feature to switch existing interface impl to/from implicit/explicit impls. (39756)](https://www.github.com/dotnet/roslyn/pull/39756)
- [Fix assertion failure in CFG-builder (39866)](https://www.github.com/dotnet/roslyn/pull/39866)
- [Filter optprof to specific tests (35700)](https://www.github.com/dotnet/roslyn/pull/35700)
- [Fix so move to namespace also works for enums when selected (39798)](https://www.github.com/dotnet/roslyn/pull/39798)
- [Remove capturing lambdas from the language parser. (39829)](https://www.github.com/dotnet/roslyn/pull/39829)
- [Disable the goldbar for suggesting install of FxCop analyzers (39819)](https://www.github.com/dotnet/roslyn/pull/39819)
- [Cleanup hoisted locals at async state machine end (34239)](https://www.github.com/dotnet/roslyn/pull/34239)