### PR TITLE
Updated build process to use Mono 6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.34.10] - not yet released
+* Updated to MsBuild 16.4.0 on Linux/MacOS (PR:[#1669](https://github.com/OmniSharp/omnisharp-roslyn/pull/1669))
+
 ## [1.34.9] - 2019-12-10
-* Updated to MsBuild 16.4.0 (PR:[#1662](https://github.com/OmniSharp/omnisharp-roslyn/pull/1662))
+* Updated to MsBuild 16.4.0 on Windows (PR:[#1662](https://github.com/OmniSharp/omnisharp-roslyn/pull/1662))
 * Line pragma is now respected in find references ([#1649](https://github.com/OmniSharp/omnisharp-roslyn/issues/1649), PR:[#1660](https://github.com/OmniSharp/omnisharp-roslyn/pull/1660))
 * Do not set mono paths when running in standalone mode ([omnisharp-vscode#3410](https://github.com/OmniSharp/omnisharp-vscode/issues/3410), [omnisharp-vscode#3340](https://github.com/OmniSharp/omnisharp-vscode/issues/3340), [#1650](https://github.com/OmniSharp/omnisharp-roslyn/issues/1650), PR:[#1656](https://github.com/OmniSharp/omnisharp-roslyn/pull/1656))
 * Fixed a bug where OmniSharp would crash on startup if the path contained `=` sign ([omnisharp-vscode#3436](https://github.com/OmniSharp/omnisharp-vscode/issues/3436), PR:[#1661](https://github.com/OmniSharp/omnisharp-roslyn/pull/1661))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
       vmImage: "macOS-10.13"
     dependsOn: GitVersion
     variables:
-      MONO_VERSION: 6.4.0
+      MONO_VERSION: 6.6.0
     steps:
       - template: ./.pipelines/init.yml
         parameters:
@@ -79,7 +79,7 @@ jobs:
       vmImage: "Ubuntu-16.04"
     dependsOn: GitVersion
     variables:
-      MONO_VERSION: 6.4.0
+      MONO_VERSION: 6.6.0
     steps:
       - template: ./.pipelines/init.yml
         parameters:
@@ -90,7 +90,7 @@ jobs:
       - script: |
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           sudo apt install apt-transport-https ca-certificates
-          echo "deb https://download.mono-project.com/repo/ubuntu vs-xenial/snapshots/6.4.0.198 main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          echo "deb https://download.mono-project.com/repo/ubuntu vs-xenial/snapshots/$MONO_VERSION.198 main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
           sudo apt update
           sudo apt install mono-devel
           sudo apt install msbuild

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
           DotNetVersion: $(DotNetVersion)
           NuGetVersion: $(NuGetVersion)
       - script: |
-          curl -o mono.pkg https://download.mono-project.com/archive/$MONO_VERSION/macos-10-universal/MonoFramework-MDK-$MONO_VERSION.198.macos10.xamarin.universal.pkg
+          curl -o mono.pkg https://download.mono-project.com/archive/$MONO_VERSION/macos-10-universal/MonoFramework-MDK-$MONO_VERSION.161.macos10.xamarin.universal.pkg
           sudo installer -pkg mono.pkg -target /
           sudo cp -rf /Library/Frameworks/Mono.framework/Versions/$MONO_VERSION/ /Library/Frameworks/Mono.framework/Versions/Current/
           MONOPREFIX=/Library/Frameworks/Mono.framework/Versions/$MONO_VERSION
@@ -90,7 +90,7 @@ jobs:
       - script: |
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           sudo apt install apt-transport-https ca-certificates
-          echo "deb https://download.mono-project.com/repo/ubuntu vs-xenial/snapshots/$MONO_VERSION.198 main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          echo "deb https://download.mono-project.com/repo/ubuntu stable-xenial/snapshots/$MONO_VERSION.161 main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
           sudo apt update
           sudo apt install mono-devel
           sudo apt install msbuild

--- a/build.json
+++ b/build.json
@@ -2,7 +2,7 @@
   "DotNetInstallScriptURL": "https://dot.net/v1",
   "DotNetChannel": "Current",
   "DotNetVersion": "3.0.100",
-  "RequiredMonoVersion": "6.4.0",
+  "RequiredMonoVersion": "6.6.0",
   "DownloadURL": "https://roslynomnisharp.blob.core.windows.net/ext",
   "MonoRuntimeMacOS": "mono.macOS-6.4.0.198.zip",
   "MonoRuntimeLinux32": "mono.linux-x86-6.4.0.198.zip",


### PR DESCRIPTION
Mono 6.6.0 is now stable and it comes with MSBuild 16.4.0
Since we copy MsBuild from global Mono at build time, updated the build steps to use Mono 6.6.0.

This follows up to #1662 which moved us to MsBuild 16.4.0 on Windows,  but on *nix we stayed on 16.3 since we copied it at package time from Mono 6.4.0.