### PR TITLE
fixed symbol decoding from completion items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All changes to the project will be documented in this file.
 
 ## [1.34.10] - not yet released
+* Fixed a bug where completion items didn't decode symbols corectly (impacted, for example, object initializer completion quality) ([omnisharp-vscode#3465](https://github.com/OmniSharp/omnisharp-vscode/issues/3465), PR: [#1670](https://github.com/OmniSharp/omnisharp-roslyn/pull/1670))
 * Updated to MsBuild 16.4.0 on Linux/MacOS (PR:[#1669](https://github.com/OmniSharp/omnisharp-roslyn/pull/1669))
 
 ## [1.34.9] - 2019-12-10

--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
@@ -21,9 +21,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
         private const string ParitalMethodCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.PartialMethodCompletionProvider";
         private const string ProviderName = nameof(ProviderName);
         private const string SymbolCompletionItem = "Microsoft.CodeAnalysis.Completion.Providers.SymbolCompletionItem";
-        private const string SymbolCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.SymbolCompletionProvider";
         private const string SymbolKind = nameof(SymbolKind);
         private const string SymbolName = nameof(SymbolName);
+        private const string SymbolsKey = nameof(Symbols);
         private const string Symbols = nameof(Symbols);
         private static readonly Type _symbolCompletionItemType;
         private static MethodInfo _getSymbolsAsync;
@@ -49,7 +49,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
 
         public static async Task<IEnumerable<ISymbol>> GetCompletionSymbolsAsync(this CompletionItem completionItem, IEnumerable<ISymbol> recommendedSymbols, Document document)
         {
-            if (completionItem.GetType() == _symbolCompletionItemType)
+            var properties = completionItem.Properties;
+
+            if (completionItem.GetType() == _symbolCompletionItemType || properties.ContainsKey(SymbolsKey))
             {
                 var decodedSymbolsTask = _getSymbolsAsync.InvokeStatic<Task<ImmutableArray<ISymbol>>>(new object[] { completionItem, document, default(CancellationToken) });
                 if (decodedSymbolsTask != null)
@@ -57,8 +59,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
                     return await decodedSymbolsTask;
                 }
             }
-
-            var properties = completionItem.Properties;
 
             // if the completion provider encoded symbols into Properties, we can return them
             if (properties.ContainsKey(SymbolName) && properties.ContainsKey(SymbolKind))

--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
@@ -23,7 +23,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
         private const string SymbolCompletionItem = "Microsoft.CodeAnalysis.Completion.Providers.SymbolCompletionItem";
         private const string SymbolKind = nameof(SymbolKind);
         private const string SymbolName = nameof(SymbolName);
-        private const string SymbolsKey = nameof(Symbols);
         private const string Symbols = nameof(Symbols);
         private static readonly Type _symbolCompletionItemType;
         private static MethodInfo _getSymbolsAsync;
@@ -51,7 +50,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
         {
             var properties = completionItem.Properties;
 
-            if (completionItem.GetType() == _symbolCompletionItemType || properties.ContainsKey(SymbolsKey))
+            if (completionItem.GetType() == _symbolCompletionItemType || properties.ContainsKey(Symbols))
             {
                 var decodedSymbolsTask = _getSymbolsAsync.InvokeStatic<Task<ImmutableArray<ISymbol>>>(new object[] { completionItem, document, default(CancellationToken) });
                 if (decodedSymbolsTask != null)

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -259,6 +259,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
             var completions = await FindCompletionsAsync(filename, source);
             ContainsCompletions(completions.Select(c => c.CompletionText), "Foo");
+            ContainsCompletions(completions.Select(c => c.ReturnType), "string");
         }
 
         [Theory]


### PR DESCRIPTION
This got broken a while ago - around these changes https://github.com/OmniSharp/omnisharp-roslyn/commit/1f10506972481e5db2b44caa117e94f54e7f17be. It was fragile, as it's reflection.
 
It impacts the quality of some of the completion item driven completions, which we don't use a lot but nevertheless - i.e. object initializer, which were missing symbol information.

fixes https://github.com/OmniSharp/omnisharp-vscode/issues/3465