### PR TITLE
added implement type options

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/ImplementTypeWorkspaceOptionsProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/ImplementTypeWorkspaceOptionsProvider.cs
@@ -31,17 +31,18 @@ namespace OmniSharp.Roslyn.CSharp.Services
         {
             if (omniSharpOptions.ImplementTypeOptions.InsertionBehavior != null)
             {
-                var insertionBehaviorOptionValue = _implementTypeOptions.Value.GetField("InsertionBehavior", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) as IOption;
-                if (insertionBehaviorOptionValue != null)
+                if (_implementTypeOptions.Value.GetField("InsertionBehavior", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) is IOption insertionBehaviorOptionValue)
                 {
                     currentOptionSet = currentOptionSet.WithChangedOption(new OptionKey(insertionBehaviorOptionValue, LanguageNames.CSharp), (int)omniSharpOptions.ImplementTypeOptions.InsertionBehavior);
                 }
             }
 
-            var propertyGenerationBehaviorOptionValue = _implementTypeOptions.Value.GetField("PropertyGenerationBehavior", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) as IOption;
-            if (propertyGenerationBehaviorOptionValue != null)
+            if (omniSharpOptions.ImplementTypeOptions.PropertyGenerationBehavior != null)
             {
-                currentOptionSet = currentOptionSet.WithChangedOption(new OptionKey(propertyGenerationBehaviorOptionValue, LanguageNames.CSharp), (int)omniSharpOptions.ImplementTypeOptions.PropertyGenerationBehavior);
+                if (_implementTypeOptions.Value.GetField("PropertyGenerationBehavior", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) is IOption propertyGenerationBehaviorOptionValue)
+                {
+                    currentOptionSet = currentOptionSet.WithChangedOption(new OptionKey(propertyGenerationBehaviorOptionValue, LanguageNames.CSharp), (int)omniSharpOptions.ImplementTypeOptions.PropertyGenerationBehavior);
+                }
             }
 
             return currentOptionSet;

--- a/src/OmniSharp.Roslyn.CSharp/Services/ImplementTypeWorkspaceOptionsProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/ImplementTypeWorkspaceOptionsProvider.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Composition;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Options;
+using OmniSharp.Options;
+using OmniSharp.Roslyn.Options;
+using OmniSharp.Services;
+using OmniSharp.Utilities;
+
+namespace OmniSharp.Roslyn.CSharp.Services
+{
+    [Export(typeof(IWorkspaceOptionsProvider)), Shared]
+    public class ImplementTypeWorkspaceOptionsProvider : IWorkspaceOptionsProvider
+    {
+        private readonly IAssemblyLoader _assemblyLoader;
+        private readonly Lazy<Assembly> _csharpFeatureAssembly;
+        private readonly Lazy<Type> _implementTypeOptions;
+
+        [ImportingConstructor]
+        public ImplementTypeWorkspaceOptionsProvider(IAssemblyLoader assemblyLoader)
+        {
+            _assemblyLoader = assemblyLoader;
+            _csharpFeatureAssembly = _assemblyLoader.LazyLoad(Configuration.RoslynFeatures);
+            _implementTypeOptions = _csharpFeatureAssembly.LazyGetType("Microsoft.CodeAnalysis.ImplementType.ImplementTypeOptions");
+        }
+
+        public int Order => 110;
+
+        public OptionSet Process(OptionSet currentOptionSet, OmniSharpOptions omniSharpOptions, IOmniSharpEnvironment omnisharpEnvironment)
+        {
+            if (omniSharpOptions.ImplementTypeOptions.InsertionBehavior != null)
+            {
+                var insertionBehaviorOptionValue = _implementTypeOptions.Value.GetField("InsertionBehavior", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) as IOption;
+                if (insertionBehaviorOptionValue != null)
+                {
+                    currentOptionSet = currentOptionSet.WithChangedOption(new OptionKey(insertionBehaviorOptionValue, LanguageNames.CSharp), (int)omniSharpOptions.ImplementTypeOptions.InsertionBehavior);
+                }
+            }
+
+            var propertyGenerationBehaviorOptionValue = _implementTypeOptions.Value.GetField("PropertyGenerationBehavior", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) as IOption;
+            if (propertyGenerationBehaviorOptionValue != null)
+            {
+                currentOptionSet = currentOptionSet.WithChangedOption(new OptionKey(propertyGenerationBehaviorOptionValue, LanguageNames.CSharp), (int)omniSharpOptions.ImplementTypeOptions.PropertyGenerationBehavior);
+            }
+
+            return currentOptionSet;
+        }
+    }
+}

--- a/src/OmniSharp.Shared/Options/ImplementTypeOptions.cs
+++ b/src/OmniSharp.Shared/Options/ImplementTypeOptions.cs
@@ -3,7 +3,7 @@
     public class ImplementTypeOptions
     {
         public ImplementTypeInsertionBehavior? InsertionBehavior { get; set; }
-        public ImplementTypePropertyGenerationBehavior PropertyGenerationBehavior { get; set; } = ImplementTypePropertyGenerationBehavior.PreferAutoProperties;
+        public ImplementTypePropertyGenerationBehavior? PropertyGenerationBehavior { get; set; }
     }
 
     public enum ImplementTypeInsertionBehavior

--- a/src/OmniSharp.Shared/Options/ImplementTypeOptions.cs
+++ b/src/OmniSharp.Shared/Options/ImplementTypeOptions.cs
@@ -1,0 +1,20 @@
+﻿namespace OmniSharp.Options
+{
+    public class ImplementTypeOptions
+    {
+        public ImplementTypeInsertionBehavior? InsertionBehavior { get; set; }
+        public ImplementTypePropertyGenerationBehavior PropertyGenerationBehavior { get; set; } = ImplementTypePropertyGenerationBehavior.PreferAutoProperties;
+    }
+
+    public enum ImplementTypeInsertionBehavior
+    {
+        WithOtherMembersOfTheSameKind = 0,
+        AtTheEnd = 1,
+    }
+
+    public enum ImplementTypePropertyGenerationBehavior
+    {
+        PreferThrowingProperties = 0,
+        PreferAutoProperties = 1,
+    }
+}

--- a/src/OmniSharp.Shared/Options/OmniSharpOptions.cs
+++ b/src/OmniSharp.Shared/Options/OmniSharpOptions.cs
@@ -12,6 +12,8 @@ namespace OmniSharp.Options
 
         public RenameOptions RenameOptions { get; set; } = new RenameOptions();
 
+        public ImplementTypeOptions ImplementTypeOptions { get; set; } = new ImplementTypeOptions();
+
         public OmniSharpExtensionsOptions Plugins { get; set; } = new OmniSharpExtensionsOptions();
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/ImplementTypeFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/ImplementTypeFacts.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using OmniSharp.Models;
+using OmniSharp.Models.V2.CodeActions;
+using OmniSharp.Roslyn.CSharp.Services.Refactoring.V2;
+using TestUtility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OmniSharp.Roslyn.CSharp.Tests
+{
+    public class ImplementTypeFacts : AbstractCodeActionsTestFixture
+    {
+        public ImplementTypeFacts(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Theory]
+        [InlineData("PreferAutoProperties", "public string Name { get; set; }")]
+        [InlineData("PreferThrowingProperties", "public string Name { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }")]
+        [InlineData(null, "public string Name { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }")]
+        public async Task ImplementInterface(string implementTypePropertyGenerationBehavior, string expectedChange)
+        {
+            const string code = @"
+interface IFoo
+{
+    string Name { get; set; }
+}
+
+class Foo : I$$Foo
+{
+}";
+
+            var testFile = new TestFile("test.cs", code);
+            var hostProperties = implementTypePropertyGenerationBehavior != null ? new Dictionary<string, string>
+            {
+                ["ImplementTypeOptions:PropertyGenerationBehavior"] = implementTypePropertyGenerationBehavior
+            } : null;
+            using (var host = CreateOmniSharpHost(new[] { testFile }, hostProperties))
+            {
+                var requestHandler = host.GetRequestHandler<RunCodeActionService>(OmniSharpEndpoints.V2.RunCodeAction);
+                var point = testFile.Content.GetPointFromPosition();
+
+                var request = new RunCodeActionRequest
+                {
+                    Line = point.Line,
+                    Column = point.Offset,
+                    FileName = testFile.FileName,
+                    Buffer = testFile.Content.Code,
+                    Identifier = "False;False;AssemblyName;global::IFoo;Microsoft.CodeAnalysis.ImplementInterface.AbstractImplementInterfaceService+ImplementInterfaceCodeAction",
+                    WantsTextChanges = true,
+                    WantsAllCodeActionOperations = true
+                };
+
+                var response = await requestHandler.Handle(request);
+                var changes = response.Changes.ToArray();
+
+                Assert.Single(changes);
+                Assert.NotNull(changes[0].FileName);
+                AssertIgnoringIndent(expectedChange, ((ModifiedFileResponse)changes[0]).Changes.First().NewText);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Similar to #1495 except for implement type options.
This allows users to set i.e. property generation style (see https://github.com/OmniSharp/omnisharp-vscode/issues/2392).

This can be configured in Visual Studio so makes sense that we expose it too. The defaults remain like in Roslyn.