### PR TITLE
Do not discover abstract types as candidates for code fix providers

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/CachingCodeFixProviderForProjects.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/CachingCodeFixProviderForProjects.cs
@@ -67,20 +67,23 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
                     try
                     {
                         var attribute = x.GetCustomAttribute<ExportCodeFixProviderAttribute>();
-
-                        if (attribute?.Languages != null && attribute.Languages.Contains(project.Language))
+                        if (attribute == null)
                         {
-                            return x.AsType().CreateInstance<CodeFixProvider>();
+                            _logger.LogTrace($"Skipping code fix provider '{x.AsType()}' because it is missing the ExportCodeFixProviderAttribute.");
+                            return null;
                         }
 
-                        _logger.LogInformation($"Skipping code fix provider '{x.AsType()}' because its language doesn't match '{project.Language}'.");
+                        if (attribute.Languages == null || !attribute.Languages.Contains(project.Language))
+                        {
+                            _logger.LogInformation($"Skipping code fix provider '{x.AsType()}' because its language '{attribute.Languages?.FirstOrDefault()}' doesn't match '{project.Language}'.");
+                            return null;
+                        }
 
-                        return null;
+                        return x.AsType().CreateInstance<CodeFixProvider>();
                     }
                     catch (Exception ex)
                     {
                         _logger.LogError($"Creating instance of code fix provider '{x.AsType()}' failed, error: {ex}");
-
                         return null;
                     }
                 })

--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/CachingCodeFixProviderForProjects.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/CachingCodeFixProviderForProjects.cs
@@ -61,7 +61,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
             var codeFixes = project.AnalyzerReferences
                 .OfType<AnalyzerFileReference>()
                 .SelectMany(analyzerFileReference => analyzerFileReference.GetAssembly().DefinedTypes)
-                .Where(x => x.IsSubclassOf(typeof(CodeFixProvider)))
+                .Where(x => !x.IsAbstract && x.IsSubclassOf(typeof(CodeFixProvider)))
                 .Select(x =>
                 {
                     try


### PR DESCRIPTION
Also, do not report code fix providers that are missing `ExportCodeFixProviderAttribute` as INFO - this leads to confusing messages in the logs like:

```
[info]: OmniSharp.Roslyn.CSharp.Services.Refactoring.V2.CachingCodeFixProviderForProjects
        Skipping code fix provider 'Microsoft.CodeQuality.Analyzers.QualityGuidelines.MarkMembersAsStaticFixer' because its language doesn't match 'C#'.
```

This happens for all base types used by code fixes, which are not intended for discovery in the first place.
From now on, we should only attempt to instantiate non-abstract code fixes marked with `ExportCodeFixProviderAttribute`.

cc @savpek 