### PR TITLE
Upgraded to Roslyn 3.5.0-beta3-20058-03 and removed Humanizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All changes to the project will be documented in this file.
 
 ## [1.34.10] - not yet released
+* Update to Roslyn `3.5.0-beta3-20058-03` (PR: [#1680](https://github.com/OmniSharp/omnisharp-roslyn/pull/1680))
 * Fixed a bug where completion items didn't decode symbols corectly (impacted, for example, object initializer completion quality) ([omnisharp-vscode#3465](https://github.com/OmniSharp/omnisharp-vscode/issues/3465), PR: [#1670](https://github.com/OmniSharp/omnisharp-roslyn/pull/1670))
 * Updated to MsBuild 16.4.0 on Linux/MacOS (PR:[#1669](https://github.com/OmniSharp/omnisharp-roslyn/pull/1669))
 

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>16.4.0</MSBuildPackageVersion>
     <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.5.0-beta2-19606-01</RoslynPackageVersion>
+    <RoslynPackageVersion>3.5.0-beta3-20058-03</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 
@@ -15,7 +15,6 @@
     <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.50.0" />
     <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.50.0" />
 
-    <PackageReference Update="Humanizer" Version="2.2.0" />
     <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
 
     <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />

--- a/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
+++ b/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
@@ -14,7 +14,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Humanizer" />
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />
         <PackageReference Include="System.Reactive" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />


### PR DESCRIPTION
Since https://github.com/dotnet/roslyn/pull/36237 was merged into Roslyn, we can now remove the hack where we needed to reference Humanizer.