### PR TITLE
Added support for organizing imports in formatting

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Workers/Formatting/FormattingWorker.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Formatting/FormattingWorker.cs
@@ -89,6 +89,11 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Formatting
                 : document.Project.Solution.Workspace.Options;
             var newDocument = await Formatter.FormatAsync(document, TextSpan.FromBounds(start, end), optionSet);
 
+            if (omnisharpOptions.FormattingOptions.OrganizeImports)
+            {
+                newDocument = await Formatter.OrganizeImportsAsync(document);
+            }
+
             return await TextChanges.GetAsync(newDocument, document);
         }
 
@@ -98,6 +103,12 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Formatting
                 ? await document.Project.Solution.Workspace.Options.WithEditorConfigOptions(document.FilePath, loggerFactory)
                 : document.Project.Solution.Workspace.Options;
             var newDocument = await Formatter.FormatAsync(document, optionSet);
+
+            if (omnisharpOptions.FormattingOptions.OrganizeImports)
+            {
+                newDocument = await Formatter.OrganizeImportsAsync(document);
+            }
+
             var text = await newDocument.GetTextAsync();
 
             return text.ToString();
@@ -109,6 +120,11 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Formatting
                 ? await document.Project.Solution.Workspace.Options.WithEditorConfigOptions(document.FilePath, loggerFactory)
                 : document.Project.Solution.Workspace.Options;
             var newDocument = await Formatter.FormatAsync(document, optionSet);
+
+            if (omnisharpOptions.FormattingOptions.OrganizeImports)
+            {
+                newDocument = await Formatter.OrganizeImportsAsync(document);
+            }
 
             return await TextChanges.GetAsync(newDocument, document);
         }

--- a/src/OmniSharp.Shared/Options/FormattingOptions.cs
+++ b/src/OmniSharp.Shared/Options/FormattingOptions.cs
@@ -59,6 +59,8 @@ namespace OmniSharp.Options
             NewLineForClausesInQuery = true;
         }
 
+        public bool OrganizeImports { get; set; }
+
         public bool EnableEditorConfigSupport { get; set; }
 
         public string NewLine { get; set; }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
@@ -264,7 +264,7 @@ using System;
 
 namespace Bar
 {
-    class Foo {}
+    class Foo { }
 }");
 
             using (var host = CreateOmniSharpHost(new[] { testFile }, configurationData: new Dictionary<string, string>
@@ -284,13 +284,13 @@ using Dummy;
 
 namespace Bar
 {
-    class Foo {}
+    class Foo { }
 }", response.Buffer);
             }
         }
 
         [Fact]
-        public async Task DoersntOrganizeImportsWhenDisabled()
+        public async Task DoesntOrganizeImportsWhenDisabled()
         {
             var testFile = new TestFile("dummy.cs", @"
 using System.IO;
@@ -299,7 +299,7 @@ using System;
 
 namespace Bar
 {
-    class Foo {}
+    class Foo { }
 }");
 
             using (var host = CreateOmniSharpHost(new[] { testFile }, configurationData: new Dictionary<string, string>
@@ -319,7 +319,7 @@ using System;
 
 namespace Bar
 {
-    class Foo {}
+    class Foo { }
 }", response.Buffer);
             }
         }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormattingFacts.cs
@@ -254,6 +254,76 @@ class C {
             }
         }
 
+        [Fact]
+        public async Task OrganizesImports()
+        {
+            var testFile = new TestFile("dummy.cs", @"
+using System.IO;
+using Dummy;
+using System;
+
+namespace Bar
+{
+    class Foo {}
+}");
+
+            using (var host = CreateOmniSharpHost(new[] { testFile }, configurationData: new Dictionary<string, string>
+            {
+                ["FormattingOptions:OrganizeImports"] = "true"
+            }))
+            {
+                var requestHandler = host.GetRequestHandler<CodeFormatService>(OmniSharpEndpoints.CodeFormat);
+
+                var request = new CodeFormatRequest { FileName = testFile.FileName };
+                var response = await requestHandler.Handle(request);
+
+                Assert.Equal(@"
+using System;
+using System.IO;
+using Dummy;
+
+namespace Bar
+{
+    class Foo {}
+}", response.Buffer);
+            }
+        }
+
+        [Fact]
+        public async Task DoersntOrganizeImportsWhenDisabled()
+        {
+            var testFile = new TestFile("dummy.cs", @"
+using System.IO;
+using Dummy;
+using System;
+
+namespace Bar
+{
+    class Foo {}
+}");
+
+            using (var host = CreateOmniSharpHost(new[] { testFile }, configurationData: new Dictionary<string, string>
+            {
+                ["FormattingOptions:OrganizeImports"] = "false"
+            }))
+            {
+                var requestHandler = host.GetRequestHandler<CodeFormatService>(OmniSharpEndpoints.CodeFormat);
+
+                var request = new CodeFormatRequest { FileName = testFile.FileName };
+                var response = await requestHandler.Handle(request);
+
+                Assert.Equal(@"
+using System.IO;
+using Dummy;
+using System;
+
+namespace Bar
+{
+    class Foo {}
+}", response.Buffer);
+            }
+        }
+
         private static void AssertFormatTargetKind(SyntaxKind kind, string input)
         {
             var content = TestContent.Parse(input);


### PR DESCRIPTION
The organize imports formatting feature is now public in Roslyn.
Added as a flag since we have an approach to make all these things configurable and opt-in.