### PR TITLE
updated to Cake 0.37.0

### DIFF
--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.32.1" />
+    <package id="Cake" version="0.37.0" />
     <package id="Microsoft.Build" version="16.4.0" />
     <package id="Microsoft.Build.Framework" version="16.4.0" />
     <package id="Microsoft.Build.Runtime" version="16.4.0" />


### PR DESCRIPTION
Fixes the build failure on linux.
I came up with the fix on my own 😀

The old version doesn't work anymore on Linux build agents and all builds fail.