### PR TITLE
Add NuGetSdkResolver to minimal msbuild

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -7,6 +7,7 @@
         <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
         <add key="OmniSharp" value="https://www.myget.org/F/omnisharp/api/v3/index.json" />
         <add key="roslyn-myget" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+        <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
         <add key="vs-editor" value="https://myget.org/F/vs-editor/api/v3/index.json" />
     </packageSources>
 </configuration>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -8,14 +8,20 @@
     <package id="Microsoft.Build.Utilities.Core" version="16.4.0" />
     <package id="Microsoft.Net.Compilers" version="3.4.0" />
     <package id="Microsoft.DotNet.MSBuildSdkResolver" version="3.0.101-servicing.19476.7" />
-    <package id="NuGet.Build.Tasks" version="5.3.1" />
-    <package id="NuGet.Commands" version="5.3.1" />
-    <package id="NuGet.Common" version="5.3.1" />
-    <package id="NuGet.Configuration" version="5.3.1" />
-    <package id="NuGet.Frameworks" version="5.3.1" />
-    <package id="NuGet.ProjectModel" version="5.3.1" />
-    <package id="NuGet.Protocol" version="5.3.1" />
-    <package id="NuGet.Versioning" version="5.3.1" />
+    <package id="Microsoft.Build.NuGetSdkResolver" version="5.4.0-rtm.6292" />
+    <package id="Newtonsoft.Json" version="9.0.1" />
+    <package id="NuGet.Build.Tasks" version="5.4.0-rtm.6292" />
+    <package id="NuGet.Commands" version="5.4.0-rtm.6292" />
+    <package id="NuGet.Common" version="5.4.0-rtm.6292" />
+    <package id="NuGet.Configuration" version="5.4.0-rtm.6292" />
+    <package id="NuGet.Credentials" version="5.4.0-rtm.6292" />
+    <package id="NuGet.DependencyResolver.Core" version="5.4.0-rtm.6292" />
+    <package id="NuGet.Frameworks" version="5.4.0-rtm.6292" />
+    <package id="NuGet.LibraryModel" version="5.4.0-rtm.6292" />
+    <package id="NuGet.Packaging" version="5.4.0-rtm.6292" />
+    <package id="NuGet.ProjectModel" version="5.4.0-rtm.6292" />
+    <package id="NuGet.Protocol" version="5.4.0-rtm.6292" />
+    <package id="NuGet.Versioning" version="5.4.0-rtm.6292" />
     <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="3.0.0" />
     <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="3.0.0" />
     <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="3.0.0" />


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1678

Tested with dotnet/format repo which relies on the 'Microsoft.DotNet.Arcade.Sdk'