### PR TITLE
Prevents project manager from updating default excluded source files

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
@@ -56,6 +56,7 @@ namespace OmniSharp.MSBuild.ProjectFile
             public bool RunAnalyzers { get; }
             public bool RunAnalyzersDuringLiveAnalysis { get; }
             public string DefaultNamespace { get; }
+            public ImmutableArray<string> DefaultItemExcludes { get; }
 
             private ProjectData()
             {
@@ -72,6 +73,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 AdditionalFiles = ImmutableArray<string>.Empty;
                 ReferenceAliases = ImmutableDictionary<string, string>.Empty;
                 ProjectReferenceAliases = ImmutableDictionary<string, string>.Empty;
+                DefaultItemExcludes = ImmutableArray<string>.Empty;
             }
 
             private ProjectData(
@@ -160,7 +162,8 @@ namespace OmniSharp.MSBuild.ProjectFile
                 bool runAnalyzersDuringLiveAnalysis,
                 RuleSet ruleset,
                 ImmutableDictionary<string, string> referenceAliases,
-                ImmutableDictionary<string, string> projectReferenceAliases)
+                ImmutableDictionary<string, string> projectReferenceAliases,
+                ImmutableArray<string> defaultItemExcludes)
                 : this(guid, name, assemblyName, targetPath, outputPath, intermediateOutputPath, projectAssetsFile,
                       configuration, platform, targetFramework, targetFrameworks, outputKind, languageVersion, nullableContextOptions, allowUnsafeCode, checkForOverflowUnderflow,
                       documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, signAssembly, assemblyOriginatorKeyFile, treatWarningsAsErrors, defaultNamespace, runAnalyzers, runAnalyzersDuringLiveAnalysis, ruleset)
@@ -173,6 +176,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 AdditionalFiles = additionalFiles.EmptyIfDefault();
                 ReferenceAliases = referenceAliases;
                 ProjectReferenceAliases = projectReferenceAliases;
+                DefaultItemExcludes = defaultItemExcludes.EmptyIfDefault();
             }
 
             public static ProjectData Create(MSB.Evaluation.Project project)
@@ -257,6 +261,8 @@ namespace OmniSharp.MSBuild.ProjectFile
 
                 var ruleset = ResolveRulesetIfAny(projectInstance);
 
+                var defaultItemExcludes = PropertyConverter.SplitList(projectInstance.GetPropertyValue(PropertyNames.DefaultItemExcludes), ';').ToImmutableArray();
+
                 var sourceFiles = GetFullPaths(
                     projectInstance.GetItems(ItemNames.Compile), filter: FileNameIsNotGenerated);
 
@@ -324,7 +330,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                     outputKind, languageVersion, nullableContextOptions, allowUnsafeCode, checkForOverflowUnderflow, documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds,
                     signAssembly, assemblyOriginatorKeyFile,
                     sourceFiles, projectReferences.ToImmutable(), references.ToImmutable(), packageReferences, analyzers, additionalFiles, treatWarningsAsErrors, defaultNamespace, runAnalyzers, runAnalyzersDuringLiveAnalysis, ruleset,
-                    referenceAliases.ToImmutableDictionary(), projectReferenceAliases.ToImmutable());
+                    referenceAliases.ToImmutableDictionary(), projectReferenceAliases.ToImmutable(), defaultItemExcludes);
             }
 
             private static RuleSet ResolveRulesetIfAny(MSB.Execution.ProjectInstance projectInstance)

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.Versioning;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using OmniSharp.FileSystem;
 using OmniSharp.MSBuild.Logging;
 using OmniSharp.MSBuild.Notification;
 
@@ -141,5 +142,10 @@ namespace OmniSharp.MSBuild.ProjectFile
                     return string.Equals(fileName, "UnityEngine.dll", StringComparison.OrdinalIgnoreCase)
                         || string.Equals(fileName, "UnityEditor.dll", StringComparison.OrdinalIgnoreCase);
                 });
+
+        public bool IsFileExcluded(string filePath)
+        {
+            return FileSystemHelper.IsPathExcluded(filePath, Directory, DefaultItemExcludes);
+        }
     }
 }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -58,6 +58,7 @@ namespace OmniSharp.MSBuild.ProjectFile
         public bool RunAnalyzers => _data.RunAnalyzers;
         public bool RunAnalyzersDuringLiveAnalysis => _data.RunAnalyzersDuringLiveAnalysis;
         public string DefaultNamespace => _data.DefaultNamespace;
+        public ImmutableArray<string> DefaultItemExcludes => _data.DefaultItemExcludes;
 
         public ProjectIdInfo ProjectIdInfo { get; }
 

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoCollection.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoCollection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using OmniSharp.FileSystem;
 
 namespace OmniSharp.MSBuild.ProjectFile
 {
@@ -75,6 +76,15 @@ namespace OmniSharp.MSBuild.ProjectFile
                     Add(value);
                 }
             }
+        }
+
+        public ProjectFileInfo TryGetItemByFile(string filePath)
+        {
+            var key = FileSystemHelper.FindParentPath(filePath, _itemMap.Keys);
+
+            return key == null
+                ? null
+                : _itemMap[key];
         }
     }
 }

--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
@@ -13,6 +13,7 @@
         public const string Configuration = nameof(Configuration);
         public const string CscToolExe = nameof(CscToolExe);
         public const string CscToolPath = nameof(CscToolPath);
+        public const string DefaultItemExcludes = nameof(DefaultItemExcludes);
         public const string DefineConstants = nameof(DefineConstants);
         public const string DesignTimeBuild = nameof(DesignTimeBuild);
         public const string DocumentationFile = nameof(DocumentationFile);

--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -539,9 +539,15 @@ namespace OmniSharp.MSBuild
                 // Only add cs files. Also, make sure the path is a file, and not a directory name that happens to end in ".cs"
                 if (string.Equals(Path.GetExtension(path), ".cs", StringComparison.CurrentCultureIgnoreCase) && File.Exists(path))
                 {
-                    // Use the buffer manager to add the new file to the appropriate projects
-                    // Hosts that don't pass the FileChangeType may wind up updating the buffer twice
-                    _workspace.BufferManager.UpdateBufferAsync(new UpdateBufferRequest() { FileName = path, FromDisk = true }).Wait();
+                    var projectFileInfo = _projectFiles.TryGetItemByFile(path);
+
+                    // Verify if the file is excluded before updating
+                    if (!projectFileInfo.IsFileExcluded(path))
+                    {
+                        // Use the buffer manager to add the new file to the appropriate projects
+                        // Hosts that don't pass the FileChangeType may wind up updating the buffer twice
+                        _workspace.BufferManager.UpdateBufferAsync(new UpdateBufferRequest() { FileName = path, FromDisk = true }).Wait();
+                    }
                 }
             }
         }

--- a/src/OmniSharp.Shared/FileSystem/FileSystemHelper.cs
+++ b/src/OmniSharp.Shared/FileSystem/FileSystemHelper.cs
@@ -66,6 +66,50 @@ namespace OmniSharp.FileSystem
         }
 
         /// <summary>
+        /// Verifies whether the path is excluded by any of the given patterns
+        /// </summary>
+        /// <param name="path">The path that will be verified</param>
+        /// <param name="targetDirectory">The target directory</param>
+        /// <param name="excludePatterns">A list of patterns to be excluded</param>
+        public static bool IsPathExcluded(
+            string filePath,
+            string targetDirectory,
+            IEnumerable<string> excludePatterns)
+        {
+            if (!IsChildPath(filePath, targetDirectory))
+            {
+                return false;
+            }
+
+            filePath = Path.GetFullPath(filePath);
+            targetDirectory = Path.GetFullPath(targetDirectory);
+
+            var targetDirectoryLength = targetDirectory.Length;
+
+            // Checks whether the target directory has a leading path separator.
+            // If it does not, one more char should be accounted in its length
+            if (!targetDirectory.EndsWith(s_directorySeparatorChar, StringComparison.InvariantCulture))
+            {
+                targetDirectoryLength += 1;
+            }
+
+            // Removes the target directory part of the file to get the relative path
+            var relativeFilePath = filePath.Substring(
+                targetDirectoryLength,
+                filePath.Length - targetDirectoryLength);
+
+            var matcher = new Matcher();
+            matcher.AddInclude(relativeFilePath);
+
+            if (excludePatterns != null)
+            {
+                matcher.AddExcludePatterns(excludePatterns);
+            }
+
+            return !matcher.GetResultsInFullPath(targetDirectory).Any();
+        }
+
+        /// <summary>
         /// Verifies whether the path specified is a child of the specified parent path
         /// </summary>
         /// <param name="path">Path that will be verified</param>

--- a/src/OmniSharp.Shared/FileSystem/FileSystemHelper.cs
+++ b/src/OmniSharp.Shared/FileSystem/FileSystemHelper.cs
@@ -64,5 +64,31 @@ namespace OmniSharp.FileSystem
             var relativePath = Uri.UnescapeDataString(relativeUri.ToString()).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
             return relativePath;
         }
+
+        /// <summary>
+        /// Verifies whether the path specified is a child of the specified parent path
+        /// </summary>
+        /// <param name="path">Path that will be verified</param>
+        /// <param name="parentPath">The possible parent path</param>
+        public static bool IsChildPath(string path, string parentPath)
+        {
+            if (path == null || parentPath == null)
+            {
+                return false;
+            }
+
+            path = Path.GetFullPath(path);
+            parentPath = Path.GetFullPath(parentPath);
+
+            if (path.Length < parentPath.Length)
+            {
+                return false;
+            }
+
+            return string.Equals(
+                path.Substring(0, parentPath.Length),
+                parentPath,
+                StringComparison.Ordinal);
+        }
     }
 }

--- a/src/OmniSharp.Shared/FileSystem/FileSystemHelper.cs
+++ b/src/OmniSharp.Shared/FileSystem/FileSystemHelper.cs
@@ -90,5 +90,28 @@ namespace OmniSharp.FileSystem
                 parentPath,
                 StringComparison.Ordinal);
         }
+
+        /// <summary>
+        /// Find the first occurrence of a set of candidate paths that is the parent
+        /// of the specified path
+        /// </summary>
+        /// <param name="path">The path that will be verified</param>
+        /// <param name="candidateParentPaths">A set of possible parent paths</param>
+        public static string FindParentPath(
+            string path,
+            IEnumerable<string> candidateParentPaths)
+        {
+            if (path == null || candidateParentPaths == null)
+            {
+                return null;
+            }
+
+            return candidateParentPaths.FirstOrDefault(
+                parentPath => IsChildPath(
+                    path,
+                    Path.HasExtension(parentPath)
+                        ? Path.GetDirectoryName(parentPath)
+                        : parentPath));
+        }
     }
 }

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -196,5 +196,22 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.Equal(ReportDiagnostic.Default, compilationOptions.GeneralDiagnosticOption);
             }
         }
+
+        [Fact]
+        public async Task Check_file_should_be_excluded_from_HelloWorld_project()
+        {
+            using (var host = CreateOmniSharpHost())
+            using (var testProject = await _testAssets.GetTestProjectAsync("HelloWorld"))
+            {
+                var projectFilePath = Path.Combine(testProject.Directory, "HelloWorld.csproj");
+                var projectFileInfo = CreateProjectFileInfo(host, testProject, projectFilePath);
+                var filePath = Path.Combine(testProject.Directory, projectFileInfo.IntermediateOutputPath, "AssemblyInfo.cs");
+
+                var isExcluded = projectFileInfo.IsFileExcluded(filePath);
+
+                Assert.True(isExcluded);
+                Assert.Contains(projectFileInfo.DefaultItemExcludes, i => i.Contains("obj"));
+            }
+        }
     }
 }

--- a/tests/OmniSharp.Tests/FileSystemHelperFacts.cs
+++ b/tests/OmniSharp.Tests/FileSystemHelperFacts.cs
@@ -186,6 +186,31 @@ namespace OmniSharp.Tests
             Assert.Equal(expectedPath, result);
         }
 
+        [Fact]
+        public void IsFileExcluded_VerifyThatFileIsNotExcluded_IfNotChildOfTargetPath()
+        {
+            const string file = "/src/project/excluded/file.cs";
+            const string targetDirectory = "/test/project";
+            var excludePatterns = new[] { "**/excluded" };
+
+            bool result = FileSystemHelper.IsPathExcluded(file, targetDirectory, excludePatterns);
+
+            Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData("/src/project")]
+        [InlineData("/src/project/")]
+        public void IsFileExcluded_VerifyThatFileIsExcluded(string targetDirectory)
+        {
+            const string file = "/src/project/excluded/file.cs";
+            var excludePatterns = new[] { "**/excluded" };
+
+            bool result = FileSystemHelper.IsPathExcluded(file, targetDirectory, excludePatterns);
+
+            Assert.True(result);
+        }
+
         private FileSystemHelper CreateFileSystemHelper(params string[] excludePatterns)
         {
             var environment = new OmniSharpEnvironment(TestAssets.Instance.TestAssetsFolder, 1000, LogLevel.Information, null);

--- a/tests/OmniSharp.Tests/FileSystemHelperFacts.cs
+++ b/tests/OmniSharp.Tests/FileSystemHelperFacts.cs
@@ -132,6 +132,60 @@ namespace OmniSharp.Tests
             Assert.False(result);
         }
 
+        [Fact]
+        public void FindParentPath()
+        {
+            const string expectedPath = "/src/project";
+
+            const string path = "/src/project/file.cs";
+            var candidateParentPaths = new[]
+            {
+                "/src/project/obj",
+                expectedPath,
+                "/test/project.test",
+            };
+
+            string result = FileSystemHelper.FindParentPath(path, candidateParentPaths);
+
+            Assert.Equal(expectedPath, result);
+        }
+
+        [Fact]
+        public void FindParentPath_ReturnsNullIfNoParentFound()
+        {
+            const string path = "/src/project/";
+            var candidateParentPaths = new[] { "/test/project" };
+
+            string result = FileSystemHelper.FindParentPath(path, candidateParentPaths);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void FindParentPath_ReturnsNullIfPathOrParentPathsIsNull()
+        {
+            string result = FileSystemHelper.FindParentPath(null, null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void FindParentPath_GetParentPath_GivenCandidatePathsAsFile()
+        {
+            const string expectedPath = "/src/project/project.csproj";
+            const string path = "/src/project/file.cs";
+            var candidateParentPaths = new[]
+            {
+                "/src/project/obj",
+                "/src/project/obj/",
+                expectedPath,
+            };
+
+            string result = FileSystemHelper.FindParentPath(path, candidateParentPaths);
+
+            Assert.Equal(expectedPath, result);
+        }
+
         private FileSystemHelper CreateFileSystemHelper(params string[] excludePatterns)
         {
             var environment = new OmniSharpEnvironment(TestAssets.Instance.TestAssetsFolder, 1000, LogLevel.Information, null);

--- a/tests/OmniSharp.Tests/FileSystemHelperFacts.cs
+++ b/tests/OmniSharp.Tests/FileSystemHelperFacts.cs
@@ -91,6 +91,47 @@ namespace OmniSharp.Tests
             Assert.Null(ex);
         }
 
+        [Fact]
+        public void IsChildPath_CheckThatPathIsChildPath()
+        {
+            const string path = "/src/project/test.csproj";
+            const string root = "/src/project";
+
+            bool result = FileSystemHelper.IsChildPath(path, root);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsChildPath_CheckThatIsNotChildPath_WithShortPath()
+        {
+            const string path = "/src";
+            const string root = "/src/project";
+
+            bool result = FileSystemHelper.IsChildPath(path, root);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsChildPath_CheckThatIsNotChildPath_WithDifferentPaths()
+        {
+            const string path = "/src/project/file.cs";
+            const string root = "/src/other-project";
+
+            bool result = FileSystemHelper.IsChildPath(path, root);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsChildPath_CheckThatIsNotChildPath_WithAnyOfThePathsNull()
+        {
+            bool result = FileSystemHelper.IsChildPath(null, null);
+
+            Assert.False(result);
+        }
+
         private FileSystemHelper CreateFileSystemHelper(params string[] excludePatterns)
         {
             var environment = new OmniSharpEnvironment(TestAssets.Instance.TestAssetsFolder, 1000, LogLevel.Information, null);


### PR DESCRIPTION
Prevents OmniSharp project manager of updating source files described in the _MSBuild_ property `<DefaultItemExcludes>`.

This should fix the following issues:
- #1589
- OmniSharp/omnisharp-vscode#3249
- OmniSharp/omnisharp-vscode#3082
- OmniSharp/omnisharp-vscode#3207

Thank you for OmniSharp. It is an honor to contribute 😄