### PR TITLE
fixed out of bounds in line mapping

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
@@ -22,11 +22,11 @@ namespace OmniSharp.Helpers
 
             var documents = workspace.GetDocuments(lineSpan.Path);
             var sourceText = GetSourceText(location, documents, lineSpan.HasMappedPath);
-            var text = GetText(location, sourceText, lineSpan.StartLinePosition.Line);
+            var text = GetLineText(location, sourceText, lineSpan.StartLinePosition.Line);
 
             return new QuickFix
             {
-                Text = text,
+                Text = text.Trim(),
                 FileName = lineSpan.Path,
                 Line = lineSpan.StartLinePosition.Line,
                 Column = lineSpan.HasMappedPath ? 0 : lineSpan.StartLinePosition.Character, // when a #line directive maps into a separate file, assume columns (0,0)
@@ -41,10 +41,11 @@ namespace OmniSharp.Helpers
                 // otherwise use the SourceText of current location
                 if (hasMappedPath)
                 {
-                    if (documents != null && documents.Any() && documents.First().TryGetText(out SourceText sourceText))
+                    SourceText source = null;
+                    if (documents != null && documents.Any() && documents.FirstOrDefault(d => d.TryGetText(out source)) != null)
                     {
                         // we have a mapped document that exists in workspace
-                        return sourceText;
+                        return source;
                     }
 
                     // we have a mapped document that doesn't exist in workspace
@@ -56,7 +57,7 @@ namespace OmniSharp.Helpers
                 return location.SourceTree.GetText();
             }
 
-            static string GetText(Location location, SourceText sourceText, int startLine)
+            static string GetLineText(Location location, SourceText sourceText, int startLine)
             {
                 // bounds check in case the mapping is incorrect, since user can put whatever line they want
                 if (sourceText != null && sourceText.Lines.Count > startLine)

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
@@ -42,7 +42,7 @@ namespace OmniSharp.Helpers
                 if (hasMappedPath)
                 {
                     SourceText source = null;
-                    if (documents != null && documents.Any() && documents.FirstOrDefault(d => d.TryGetText(out source)) != null)
+                    if (documents != null && documents.FirstOrDefault(d => d.TryGetText(out source)) != null)
                     {
                         // we have a mapped document that exists in workspace
                         return source;

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Models;
 
 namespace OmniSharp.Helpers
@@ -21,13 +22,41 @@ namespace OmniSharp.Helpers
             var documents = workspace.GetDocuments(path);
 
             var line = lineSpan.StartLinePosition.Line;
-            var text = location.SourceTree.GetText().Lines[line].ToString();
+            var endLine = lineSpan.EndLinePosition.Line;
+
+            string text;
+            SourceText sourceText = null;
+
+            // if we have a mapped linespan and we found a corresponding document, pick that one
+            // otherwise use the SourceText of current location
+            if (lineSpan.HasMappedPath && documents != null && documents.Any())
+            {
+                documents.First().TryGetText(out sourceText);
+            }
+
+            if (sourceText == null)
+            {
+                sourceText = location.SourceTree.GetText();
+            }
+
+            // bounds check in case the mapping is incorrect, since user can put whatever line they want
+            if (sourceText.Lines.Count > line)
+            {
+                text = sourceText.Lines[line].ToString();
+            }
+            else
+            {
+                var fallBackLineSpan = location.GetLineSpan();
+
+                // in case we fall out of bounds, we shouldn't crash, fallback to text from the unmapped span and the current file
+                text = location.SourceTree.GetText().Lines[fallBackLineSpan.StartLinePosition.Line].ToString();
+            }
 
             return new QuickFix
             {
-                Text = text.Trim(),
+                Text = text,
                 FileName = path,
-                Line = line,
+                Line = lineSpan.StartLinePosition.Line,
                 Column = lineSpan.HasMappedPath ? 0 : lineSpan.StartLinePosition.Character, // when a #line directive maps into a separate file, assume columns (0,0)
                 EndLine = lineSpan.EndLinePosition.Line,
                 EndColumn = lineSpan.HasMappedPath ? 0 : lineSpan.EndLinePosition.Character,

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -18,50 +19,59 @@ namespace OmniSharp.Helpers
             var lineSpan = Path.GetExtension(location.SourceTree.FilePath).Equals(".cake", StringComparison.OrdinalIgnoreCase)
                 ? location.GetLineSpan()
                 : location.GetMappedLineSpan();
-            var path = lineSpan.Path;
-            var documents = workspace.GetDocuments(path);
 
-            var line = lineSpan.StartLinePosition.Line;
-            var endLine = lineSpan.EndLinePosition.Line;
-
-            string text;
-            SourceText sourceText = null;
-
-            // if we have a mapped linespan and we found a corresponding document, pick that one
-            // otherwise use the SourceText of current location
-            if (lineSpan.HasMappedPath && documents != null && documents.Any())
-            {
-                documents.First().TryGetText(out sourceText);
-            }
-
-            if (sourceText == null)
-            {
-                sourceText = location.SourceTree.GetText();
-            }
-
-            // bounds check in case the mapping is incorrect, since user can put whatever line they want
-            if (sourceText.Lines.Count > line)
-            {
-                text = sourceText.Lines[line].ToString();
-            }
-            else
-            {
-                var fallBackLineSpan = location.GetLineSpan();
-
-                // in case we fall out of bounds, we shouldn't crash, fallback to text from the unmapped span and the current file
-                text = location.SourceTree.GetText().Lines[fallBackLineSpan.StartLinePosition.Line].ToString();
-            }
+            var documents = workspace.GetDocuments(lineSpan.Path);
+            var sourceText = GetSourceText(location, documents, lineSpan.HasMappedPath);
+            var text = GetText(location, sourceText, lineSpan.StartLinePosition.Line);
 
             return new QuickFix
             {
                 Text = text,
-                FileName = path,
+                FileName = lineSpan.Path,
                 Line = lineSpan.StartLinePosition.Line,
                 Column = lineSpan.HasMappedPath ? 0 : lineSpan.StartLinePosition.Character, // when a #line directive maps into a separate file, assume columns (0,0)
                 EndLine = lineSpan.EndLinePosition.Line,
                 EndColumn = lineSpan.HasMappedPath ? 0 : lineSpan.EndLinePosition.Character,
                 Projects = documents.Select(document => document.Project.Name).ToArray()
             };
+
+            static SourceText GetSourceText(Location location, IEnumerable<Document> documents, bool hasMappedPath)
+            {
+                SourceText sourceText = null;
+
+                // if we have a mapped linespan and we found a corresponding document, pick that one
+                // otherwise use the SourceText of current location
+                if (hasMappedPath && documents != null && documents.Any())
+                {
+                    documents.First().TryGetText(out sourceText);
+                }
+
+                if (sourceText == null)
+                {
+                    sourceText = location.SourceTree.GetText();
+                }
+
+                return sourceText;
+            }
+
+            static string GetText(Location location, SourceText sourceText, int startLine)
+            {
+                string text;
+                // bounds check in case the mapping is incorrect, since user can put whatever line they want
+                if (sourceText.Lines.Count > startLine)
+                {
+                    text = sourceText.Lines[startLine].ToString();
+                }
+                else
+                {
+                    var fallBackLineSpan = location.GetLineSpan();
+
+                    // in case we fall out of bounds, we shouldn't crash, fallback to text from the unmapped span and the current file
+                    text = location.SourceTree.GetText().Lines[fallBackLineSpan.StartLinePosition.Line].ToString();
+                }
+
+                return text;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/3485
Also added more comprehensive tests.

Here is the summary of the logic:
 - correct mapping within a file - then we return the mapped line and mapped text
 - incorrect mapping within a file - then we return the mapped line (even though it's incorrect) and the original (unmapped) text since there is no way to fetch the mapped text as it's out of bounds
 - correct mapping into a file that exists in a workspace - then we return the mapped line and mapped text from that file
 - incorrect mapping into a file that exists in a workspace - then we return the mapped line and the original (unmapped) text since there is no way to fetch the mapped text as it's out of bounds
 - mapping into a file that does not exist in a workspace - then we return the mapped line and the original (unmapped) text since there is no way to fetch the mapped text as we don't have access to it (Razor case). The editor still ignores it anyway and shows the correct file in this case. 

cc @NTaylorMullen as this bug affected Razor 🙈