### PR TITLE
Add ability to use custom runsettings for tests

### DIFF
--- a/src/OmniSharp.DotNetTest/DebugSessionManager.cs
+++ b/src/OmniSharp.DotNetTest/DebugSessionManager.cs
@@ -77,14 +77,14 @@ namespace OmniSharp.DotNetTest
             }
         }
 
-        public Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken)
-            => DebugGetStartInfoAsync(new string[] { methodName }, testFrameworkName, targetFrameworkVersion, cancellationToken);
+        public Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string runSettings, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken)
+            => DebugGetStartInfoAsync(new string[] { methodName }, runSettings, testFrameworkName, targetFrameworkVersion, cancellationToken);
         
-        public Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string[] methodNames, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken)
+        public Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string[] methodNames, string runSettings, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken)
         {
             VerifySession(isStarted: true);
 
-            return _testManager.DebugGetStartInfoAsync(methodNames, testFrameworkName, targetFrameworkVersion, cancellationToken);
+            return _testManager.DebugGetStartInfoAsync(methodNames, runSettings, testFrameworkName, targetFrameworkVersion, cancellationToken);
         }
 
         public async Task<DebugTestLaunchResponse> DebugLaunchAsync(int targetProcessId)

--- a/src/OmniSharp.DotNetTest/Models/BaseTestClassRequest.cs
+++ b/src/OmniSharp.DotNetTest/Models/BaseTestClassRequest.cs
@@ -5,6 +5,7 @@ namespace OmniSharp.DotNetTest.Models
     public class BaseTestClassRequest : Request
     {
         public string[] MethodNames { get; set; }
+        public string RunSettings { get; set; }
         public string TestFrameworkName { get; set; }
         
         /// <summary>

--- a/src/OmniSharp.DotNetTest/Models/DebugTestGetStartInfoRequest.cs
+++ b/src/OmniSharp.DotNetTest/Models/DebugTestGetStartInfoRequest.cs
@@ -7,6 +7,7 @@ namespace OmniSharp.DotNetTest.Models
     public class DebugTestGetStartInfoRequest : Request
     {
         public string MethodName { get; set; }
+        public string RunSettings { get; set; }
         public string TestFrameworkName { get; set; }
         /// <summary>
         /// e.g. .NETCoreApp, Version=2.0

--- a/src/OmniSharp.DotNetTest/Models/GetTestStartInfoRequest.cs
+++ b/src/OmniSharp.DotNetTest/Models/GetTestStartInfoRequest.cs
@@ -7,6 +7,7 @@ namespace OmniSharp.DotNetTest.Models
     public class GetTestStartInfoRequest : Request
     {
         public string MethodName { get; set; }
+        public string RunSettings { get; set; }
         public string TestFrameworkName { get; set; }
         /// <summary>
         /// e.g. .NETCoreApp, Version=2.0

--- a/src/OmniSharp.DotNetTest/Models/RunTestRequest.cs
+++ b/src/OmniSharp.DotNetTest/Models/RunTestRequest.cs
@@ -7,6 +7,7 @@ namespace OmniSharp.DotNetTest.Models
     public class RunTestRequest : Request
     {
         public string MethodName { get; set; }
+        public string RunSettings { get; set; }
         public string TestFrameworkName { get; set; }
         /// <summary>
         /// e.g. .NETCoreApp, Version=2.0

--- a/src/OmniSharp.DotNetTest/Services/DebugTestClassService.cs
+++ b/src/OmniSharp.DotNetTest/Services/DebugTestClassService.cs
@@ -28,7 +28,7 @@ namespace OmniSharp.DotNetTest.Services
             var testManager = CreateTestManager(request.FileName);
             _debugSessionManager.StartSession(testManager);
 
-            return await _debugSessionManager.DebugGetStartInfoAsync(request.MethodNames, request.TestFrameworkName, request.TargetFrameworkVersion, CancellationToken.None);
+            return await _debugSessionManager.DebugGetStartInfoAsync(request.MethodNames, request.RunSettings, request.TestFrameworkName, request.TargetFrameworkVersion, CancellationToken.None);
         }
     }
 }

--- a/src/OmniSharp.DotNetTest/Services/DebugTestService.cs
+++ b/src/OmniSharp.DotNetTest/Services/DebugTestService.cs
@@ -36,7 +36,7 @@ namespace OmniSharp.DotNetTest.Services
             {
                 //only if the test manager connected successfully, shall we proceed with the request
                 _debugSessionManager.StartSession(testManager);
-                return _debugSessionManager.DebugGetStartInfoAsync(request.MethodName, request.TestFrameworkName, request.TargetFrameworkVersion, CancellationToken.None);
+                return _debugSessionManager.DebugGetStartInfoAsync(request.MethodName, request.RunSettings, request.TestFrameworkName, request.TargetFrameworkVersion, CancellationToken.None);
             }
 
             throw new InvalidOperationException("The debugger could not be started");

--- a/src/OmniSharp.DotNetTest/Services/GetTestStartInfoService.cs
+++ b/src/OmniSharp.DotNetTest/Services/GetTestStartInfoService.cs
@@ -19,7 +19,7 @@ namespace OmniSharp.DotNetTest.Services
 
         protected override GetTestStartInfoResponse HandleRequest(GetTestStartInfoRequest request, TestManager testManager)
         {
-            return testManager.GetTestStartInfo(request.MethodName, request.TestFrameworkName, request.TargetFrameworkVersion);
+            return testManager.GetTestStartInfo(request.MethodName, request.RunSettings, request.TestFrameworkName, request.TargetFrameworkVersion);
         }
     }
 }

--- a/src/OmniSharp.DotNetTest/Services/RunTestService.cs
+++ b/src/OmniSharp.DotNetTest/Services/RunTestService.cs
@@ -21,7 +21,7 @@ namespace OmniSharp.DotNetTest.Services
         {
             if (testManager.IsConnected)
             {
-                return testManager.RunTest(request.MethodName, request.TestFrameworkName, request.TargetFrameworkVersion);
+                return testManager.RunTest(request.MethodName, request.RunSettings, request.TestFrameworkName, request.TargetFrameworkVersion);
             }
 
             var response = new RunTestResponse

--- a/src/OmniSharp.DotNetTest/Services/RunTestsInClassService.cs
+++ b/src/OmniSharp.DotNetTest/Services/RunTestsInClassService.cs
@@ -21,7 +21,7 @@ namespace OmniSharp.DotNetTest.Services
         {
             if (testManager.IsConnected)
             {
-                return testManager.RunTest(request.MethodNames, request.TestFrameworkName, request.TargetFrameworkVersion);
+                return testManager.RunTest(request.MethodNames, request.RunSettings, request.TestFrameworkName, request.TargetFrameworkVersion);
             }
 
             var response = new RunTestResponse

--- a/src/OmniSharp.DotNetTest/TestManager.cs
+++ b/src/OmniSharp.DotNetTest/TestManager.cs
@@ -74,18 +74,18 @@ namespace OmniSharp.DotNetTest
         protected abstract string GetCliTestArguments(int port, int parentProcessId);
         protected abstract void VersionCheck();
 
-        public abstract RunTestResponse RunTest(string methodName, string testFrameworkName, string targetFrameworkVersion);
+        public abstract RunTestResponse RunTest(string methodName, string runSettings, string testFrameworkName, string targetFrameworkVersion);
 
-        public virtual RunTestResponse RunTest(string[] methodNames, string testFrameworkName, string targetFrameworkVersion)
+        public virtual RunTestResponse RunTest(string[] methodNames, string runSettings, string testFrameworkName, string targetFrameworkVersion)
         { 
             throw new NotImplementedException();
         }
 
-        public abstract GetTestStartInfoResponse GetTestStartInfo(string methodName, string testFrameworkName, string targetFrameworkVersion);
+        public abstract GetTestStartInfoResponse GetTestStartInfo(string methodName, string runSettings, string testFrameworkName, string targetFrameworkVersion);
 
-        public abstract Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken);
+        public abstract Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string runSettings, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken);
 
-        public virtual Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string[] methodNames, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken)
+        public virtual Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string[] methodNames, string runSettings, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -30,7 +30,18 @@ namespace OmniSharp.DotNetTest
         {
             if (runSettingsPath != null)
             {
-                return File.ReadAllText(runSettingsPath);
+                try
+                {
+                    return File.ReadAllText(runSettingsPath);
+                }
+                catch (FileNotFoundException)
+                {
+                    EmitTestMessage(TestMessageLevel.Warning, $"RunSettings file {runSettingsPath} not found. Continuing with default settings...");
+                }
+                catch (Exception e)
+                {
+                    EmitTestMessage(TestMessageLevel.Warning, $"There was an error loading runsettings at {runSettingsPath}: {e}. Continuing with default settings...");
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(targetFrameworkVersion))

--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -26,8 +26,13 @@ namespace OmniSharp.DotNetTest
         {
         }
 
-        private object GetDefaultRunSettings(string targetFrameworkVersion)
+        private object LoadRunSettingsOrDefault(string runSettingsPath, string targetFrameworkVersion)
         {
+            if (runSettingsPath != null)
+            {
+                return File.ReadAllText(runSettingsPath);
+            }
+
             if (!string.IsNullOrWhiteSpace(targetFrameworkVersion))
             {
                 return $@"
@@ -101,18 +106,18 @@ namespace OmniSharp.DotNetTest
             }
         }
 
-        public override GetTestStartInfoResponse GetTestStartInfo(string methodName, string testFrameworkName, string targetFrameworkVersion)
+        public override GetTestStartInfoResponse GetTestStartInfo(string methodName, string runSettings, string testFrameworkName, string targetFrameworkVersion)
         {
             VerifyTestFramework(testFrameworkName);
 
-            var testCases = DiscoverTests(new string[] { methodName }, targetFrameworkVersion);
+            var testCases = DiscoverTests(new string[] { methodName }, runSettings, targetFrameworkVersion);
 
             SendMessage(MessageType.GetTestRunnerProcessStartInfoForRunSelected,
                 new
                 {
                     TestCases = testCases,
                     DebuggingEnabled = true,
-                    RunSettings = GetDefaultRunSettings(targetFrameworkVersion)
+                    RunSettings = LoadRunSettingsOrDefault(runSettings, targetFrameworkVersion)
                 });
 
             var message = ReadMessage();
@@ -126,21 +131,21 @@ namespace OmniSharp.DotNetTest
             };
         }
 
-        public override async Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken)
-         => await DebugGetStartInfoAsync(new string[] { methodName }, testFrameworkName, targetFrameworkVersion, cancellationToken);
+        public override async Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string runSettings, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken)
+         => await DebugGetStartInfoAsync(new string[] { methodName }, runSettings, testFrameworkName, targetFrameworkVersion, cancellationToken);
 
-        public override async Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string[] methodNames, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken)
+        public override async Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string[] methodNames, string runSettings, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken)
         {
             VerifyTestFramework(testFrameworkName);
 
-            var testCases = await DiscoverTestsAsync(methodNames, targetFrameworkVersion, cancellationToken);
+            var testCases = await DiscoverTestsAsync(methodNames, runSettings, targetFrameworkVersion, cancellationToken);
 
             SendMessage(MessageType.GetTestRunnerProcessStartInfoForRunSelected,
                 new
                 {
                     TestCases = testCases,
                     DebuggingEnabled = true,
-                    RunSettings = GetDefaultRunSettings(targetFrameworkVersion)
+                    RunSettings = LoadRunSettingsOrDefault(runSettings, targetFrameworkVersion)
                 });
 
             var message = await ReadMessageAsync(cancellationToken);
@@ -186,14 +191,14 @@ namespace OmniSharp.DotNetTest
             }
         }
 
-        public override RunTestResponse RunTest(string methodName, string testFrameworkName, string targetFrameworkVersion)
-            => RunTest(new string[] { methodName }, testFrameworkName, targetFrameworkVersion);
+        public override RunTestResponse RunTest(string methodName, string runSettings, string testFrameworkName, string targetFrameworkVersion)
+            => RunTest(new string[] { methodName }, runSettings, testFrameworkName, targetFrameworkVersion);
 
-        public override RunTestResponse RunTest(string[] methodNames, string testFrameworkName, string targetFrameworkVersion)
+        public override RunTestResponse RunTest(string[] methodNames, string runSettings, string testFrameworkName, string targetFrameworkVersion)
         {
             VerifyTestFramework(testFrameworkName);
 
-            var testCases = DiscoverTests(methodNames, targetFrameworkVersion);
+            var testCases = DiscoverTests(methodNames, runSettings, targetFrameworkVersion);
 
             var testResults = new List<TestResult>();
 
@@ -204,7 +209,7 @@ namespace OmniSharp.DotNetTest
                     new
                     {
                         TestCases = testCases,
-                        RunSettings = GetDefaultRunSettings(targetFrameworkVersion)
+                        RunSettings = LoadRunSettingsOrDefault(runSettings, targetFrameworkVersion)
                     });
 
                 var done = false;
@@ -244,10 +249,10 @@ namespace OmniSharp.DotNetTest
                     ErrorMessage = testResult.ErrorMessage,
                     ErrorStackTrace = testResult.ErrorStackTrace,
                     StandardOutput = testResult.Messages
-                                    .Where(message => message.Category == TestResultMessage.StandardOutCategory)
-                                    .Select(message => message.Text).ToArray(),
+                        .Where(message => message.Category == TestResultMessage.StandardOutCategory)
+                        .Select(message => message.Text).ToArray(),
                     StandardError = testResult.Messages.Where(message => message.Category == TestResultMessage.StandardErrorCategory)
-                    .Select(message => message.Text).ToArray()
+                        .Select(message => message.Text).ToArray()
                 });
 
             return new RunTestResponse
@@ -257,7 +262,7 @@ namespace OmniSharp.DotNetTest
             };
         }
 
-        private async Task<TestCase[]> DiscoverTestsAsync(string[] methodNames, string targetFrameworkVersion, CancellationToken cancellationToken)
+        private async Task<TestCase[]> DiscoverTestsAsync(string[] methodNames, string runSettings, string targetFrameworkVersion, CancellationToken cancellationToken)
         {
             SendMessage(MessageType.StartDiscovery,
                 new
@@ -266,7 +271,7 @@ namespace OmniSharp.DotNetTest
                     {
                         Project.OutputFilePath
                     },
-                    RunSettings = GetDefaultRunSettings(targetFrameworkVersion)
+                    RunSettings = LoadRunSettingsOrDefault(runSettings, targetFrameworkVersion)
                 });
 
             var testCases = new List<TestCase>();
@@ -322,9 +327,9 @@ namespace OmniSharp.DotNetTest
             };
         }
 
-        private TestCase[] DiscoverTests(string[] methodNames, string targetFrameworkVersion)
+        private TestCase[] DiscoverTests(string[] methodNames, string runSettings, string targetFrameworkVersion)
         {
-            return DiscoverTestsAsync(methodNames, targetFrameworkVersion, CancellationToken.None).Result;
+            return DiscoverTestsAsync(methodNames, runSettings, targetFrameworkVersion, CancellationToken.None).Result;
         }
     }
 }

--- a/test-assets/test-projects/MSTestProject/TestProgram.cs
+++ b/test-assets/test-projects/MSTestProject/TestProgram.cs
@@ -6,6 +6,8 @@ namespace Main.Test
     [TestClass]
     public class MainTest
     {
+        public TestContext TestContext { get; set; }
+
         [TestMethod]
         public void Test()
         {
@@ -40,6 +42,12 @@ namespace Main.Test
             int a = 1, b = 1;
             Console.WriteLine($"a = {a}, b = {b}");
             Assert.AreEqual(a,b);
+        }
+
+        [TestMethod]
+        public void CheckRunSettings()
+        {
+            Assert.AreEqual(TestContext.Properties["TestRunSetting"].ToString(), "CorrectValue");
         }
 
         private void UtilityFunction()

--- a/test-assets/test-projects/MSTestProject/TestRunSettings.runsettings
+++ b/test-assets/test-projects/MSTestProject/TestRunSettings.runsettings
@@ -1,0 +1,5 @@
+<RunSettings>
+    <TestRunParameters>
+        <Parameter name="TestRunSetting" value="CorrectValue" />
+    </TestRunParameters>
+</RunSettings>

--- a/tests/OmniSharp.DotNetTest.Tests/AbstractRunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/AbstractRunTestFacts.cs
@@ -20,7 +20,7 @@ namespace OmniSharp.DotNetTest.Tests
             return host.GetRequestHandler<RunTestService>(OmniSharpEndpoints.V2.RunTest);
         }
 
-        protected async Task<RunTestResponse> RunDotNetTestAsync(string projectName, string methodName, string testFramework, bool shouldPass, string targetFrameworkVersion = null, bool expectResults = true)
+        protected async Task<RunTestResponse> RunDotNetTestAsync(string projectName, string methodName, string testFramework, bool shouldPass, string targetFrameworkVersion = null, bool expectResults = true, bool useRunSettings = false)
         {
             using (var testProject = await TestAssets.Instance.GetTestProjectAsync(projectName))
             using (var host = CreateOmniSharpHost(testProject.Directory, null, DotNetCliVersion))
@@ -34,6 +34,11 @@ namespace OmniSharp.DotNetTest.Tests
                     TestFrameworkName = testFramework,
                     TargetFrameworkVersion = targetFrameworkVersion
                 };
+
+                if (useRunSettings)
+                {
+                    request.RunSettings = Path.Combine(testProject.Directory, "TestRunSettings.runsettings");
+                }
 
                 var response = await service.Handle(request);
 

--- a/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
@@ -223,5 +223,27 @@ namespace OmniSharp.DotNetTest.Tests
             Assert.Single(response.Results);
             Assert.NotEmpty(response.Results[0].StandardOutput);
         }
+
+        [Fact]
+        public async Task RunMSTestWithRunSettings()
+        {
+            await RunDotNetTestAsync(
+                MSTestProject,
+                methodName: "Main.Test.MainTest.CheckRunSettings",
+                testFramework: "mstest",
+                shouldPass: true,
+                useRunSettings: true);
+        }
+
+        [Fact]
+        public async Task RunMSTestWithoutRunSettings()
+        {
+            await RunDotNetTestAsync(
+                MSTestProject,
+                methodName: "Main.Test.MainTest.CheckRunSettings",
+                testFramework: "mstest",
+                shouldPass: false,
+                useRunSettings: false);
+        }
     }
 }

--- a/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
+++ b/tests/OmniSharp.DotNetTest.Tests/RunTestFacts.cs
@@ -238,12 +238,16 @@ namespace OmniSharp.DotNetTest.Tests
         [Fact]
         public async Task RunMSTestWithoutRunSettings()
         {
-            await RunDotNetTestAsync(
+            var response = await RunDotNetTestAsync(
                 MSTestProject,
                 methodName: "Main.Test.MainTest.CheckRunSettings",
                 testFramework: "mstest",
                 shouldPass: false,
                 useRunSettings: false);
+
+            Assert.Single(response.Results);
+            Assert.NotEmpty(response.Results[0].ErrorMessage);
+            Assert.NotEmpty(response.Results[0].ErrorStackTrace);
         }
     }
 }


### PR DESCRIPTION
Currently, the RunSettings are sent to Omnisharp as a a path, and then loaded. Alternatively, we could load the runsettings in the extension, and then send XML with the request.

Related PR to omnisharp-vscode: https://github.com/OmniSharp/omnisharp-vscode/pull/3573