### PR TITLE
Fixed a bug where organizing usings clashed with other formatting settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.34.13] - not yet released
+* Fixed a bug where organizing usings clashed with other formatting settings (PR: [#1715](https://github.com/OmniSharp/omnisharp-roslyn/pull/1713))
+
 ## [1.34.12] - 2020-02-18
 * Fixed out of bounds exception in line mapping ([omnisharp-vscode#3485](https://github.com/OmniSharp/omnisharp-vscode/issues/3485), PR: [#1707](https://github.com/OmniSharp/omnisharp-roslyn/pull/1707))
 * Added support for aliases in project references ([#1685](https://github.com/OmniSharp/omnisharp-roslyn/issues/1685), PR: [#1701](https://github.com/OmniSharp/omnisharp-roslyn/pull/1701))
-* Raised the lowest discovered VS2019 version to 16.3 ((#1700)[https://github.com/OmniSharp/omnisharp-roslyn/issues/1700], PR: (#1713)(https://github.com/OmniSharp/omnisharp-roslyn/pull/1713))
+* Raised the lowest discovered VS2019 version to 16.3 ([#1700](https://github.com/OmniSharp/omnisharp-roslyn/issues/1700), PR: [#1713](https://github.com/OmniSharp/omnisharp-roslyn/pull/1713))
 
 ## [1.34.11] - 2020-02-05
 * Updated the bundled to Mono 6.8.0 and MSBuild to be copied from Mono 6.8.0 ([#1693](https://github.com/OmniSharp/omnisharp-roslyn/issues/1693), PR: [#1697](https://github.com/OmniSharp/omnisharp-roslyn/pull/1697))

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Formatting/FormattingWorker.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Formatting/FormattingWorker.cs
@@ -110,7 +110,7 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Formatting
             var newDocument = textSpan != null ? await Formatter.FormatAsync(document, textSpan.Value, optionSet) : await Formatter.FormatAsync(document, optionSet);
             if (omnisharpOptions.FormattingOptions.OrganizeImports)
             {
-                newDocument = await Formatter.OrganizeImportsAsync(document);
+                newDocument = await Formatter.OrganizeImportsAsync(newDocument);
             }
 
             return newDocument;


### PR DESCRIPTION
when organize usings was enabled, it prevented the regular formatting from working since it passed in the original document... 🙈

@JoeRobich after this is merged, let's release again so that you don't ship the buggy version in VS Code