### PR TITLE
Exclude additive classifications from "/highlight" requests

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Highlighting/HighlightingService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Highlighting/HighlightingService.cs
@@ -82,9 +82,26 @@ namespace OmniSharp.Roslyn.CSharp.Services.Highlighting
             {
                 Highlights = results
                     .GroupBy(result => result.Span.TextSpan.ToString())
-                    .Select(grouping => CreateHighlightSpan(grouping.First().Span, grouping.First().Lines, grouping.Select(z => z.Project)))
+                    .Select(CreateHighlightSpan)
+                    .Where(span => span != null)
                     .ToArray()
             };
+        }
+
+        private static HighlightSpan CreateHighlightSpan(IEnumerable<ClassifiedResult> results)
+        {
+            var validResults = results
+                .Where(result => !ClassificationTypeNames.AdditiveTypeNames.Contains(result.Span.ClassificationType))
+                .ToArray();
+
+            if (validResults.Length == 0)
+            {
+                return null;
+            }
+
+            var first = validResults.First();
+
+            return CreateHighlightSpan(first.Span, first.Lines, validResults.Select(x => x.Project));
         }
 
         public static HighlightSpan CreateHighlightSpan(ClassifiedSpan span, TextLineCollection lines, IEnumerable<string> projects)

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/HighlightFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/HighlightFacts.cs
@@ -175,6 +175,30 @@ namespace N1
             Assert.DoesNotContain(highlights, x => x.Kind.EndsWith("name"));
         }
 
+        [Fact]
+        public async Task HighlightDoesNotContainAdditiveKinds()
+        {
+            var testFile = new TestFile("a.cs", @"
+namespace N1
+{
+    class C1
+    {
+        static void M1()
+        {
+
+        }
+    }
+}   
+");
+
+            var highlights = await GetHighlightsAsync(testFile);
+
+            foreach (var additiveName in Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.AdditiveTypeNames)
+            {
+                Assert.DoesNotContain(highlights, x => x.Kind == additiveName);
+            }
+        }
+
         private async Task<HighlightSpan[]> GetHighlightsAsync(TestFile testFile, int? line = null, HighlightClassification? exclude = null)
         {
             SharedOmniSharpTestHost.AddFilesToWorkspace(testFile);


### PR DESCRIPTION
Currently the behavior of the "/highlight" request is not deterministic for static symbols. This is because the Classifier class returns two ClassifiedSpans for static symbols (one with the actual kind and one with kind "static symbol"). And depending on which of the two spans is returned first in the result we get a different highlight span.

I propose a change where we remove these "additive" kinds from the result, only returning the actual kind of the span.

Fixes #1576