### PR TITLE
Quote the path to mono in run script

### DIFF
--- a/mono-packaging/run
+++ b/mono-packaging/run
@@ -9,7 +9,7 @@ mono_cmd=${bin_dir}/mono
 omnisharp_cmd=${omnisharp_dir}/OmniSharp.exe
 config_file=${etc_dir}/config
 
-chmod 755 ${mono_cmd}
+chmod 755 "${mono_cmd}"
 
 no_omnisharp=false
 


### PR DESCRIPTION
Reported in https://github.com/OmniSharp/omnisharp-vscode/issues/3608

Other use of `{mono_cmd}` were already quoted just looks like this one was missed.