### PR TITLE
Include Region blocks in code folding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All changes to the project will be documented in this file.
 
 ## [1.34.16] - not yet released
 * Support for `<RunAnalyzers />` and `<RunAnalyzersDuringLiveAnalysis />` (PR: [#1739](https://github.com/OmniSharp/omnisharp-roslyn/pull/1739))
+* Add `typeparam` documentation comments to text description ([omnisharp-vscode#3516](https://github.com/OmniSharp/omnisharp-vscode/issues/3516), PR: [#1749](https://github.com/OmniSharp/omnisharp-roslyn/pull/1749))
+* Tag `#region` blocks appropriately in the block structure service ([omnisharp-vscode#2621](https://github.com/OmniSharp/omnisharp-vscode/issues/2621), PR: [#1748](https://github.com/OmniSharp/omnisharp-roslyn/pull/1748))
 
 ## [1.34.15] - 2020-03-25
 * Support for .NET Core 3.1 in csx files (PR: [#1731](https://github.com/OmniSharp/omnisharp-roslyn/pull/1731))

--- a/src/OmniSharp.Roslyn.CSharp/Services/BlockStructureWorkspaceOptionsProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/BlockStructureWorkspaceOptionsProvider.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Composition;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Options;
+using OmniSharp.Options;
+using OmniSharp.Roslyn.Options;
+using OmniSharp.Services;
+using OmniSharp.Utilities;
+
+namespace OmniSharp.Roslyn.CSharp.Services
+{
+    [Export(typeof(IWorkspaceOptionsProvider)), Shared]
+    public class BlockStructureWorkspaceOptionsProvider : IWorkspaceOptionsProvider
+    {
+        private readonly IAssemblyLoader _assemblyLoader;
+        private readonly Lazy<Assembly> _csharpFeatureAssembly;
+        private readonly Lazy<Type> _blockStructureOptions;
+
+        [ImportingConstructor]
+        public BlockStructureWorkspaceOptionsProvider(IAssemblyLoader assemblyLoader)
+        {
+            _assemblyLoader = assemblyLoader;
+            _csharpFeatureAssembly = _assemblyLoader.LazyLoad(Configuration.RoslynFeatures);
+            _blockStructureOptions = _csharpFeatureAssembly.LazyGetType("Microsoft.CodeAnalysis.Structure.BlockStructureOptions");
+        }
+
+        public int Order => 100;
+
+        public OptionSet Process(OptionSet currentOptionSet, OmniSharpOptions omniSharpOptions, IOmniSharpEnvironment omnisharpEnvironment)
+        {
+            if (_blockStructureOptions.Value.GetField("ShowBlockStructureGuidesForCommentsAndPreprocessorRegions", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) is IOption showBlockStructureGuidesForCommentsAndPreprocessorRegionsOptionValue)
+            {
+                currentOptionSet = currentOptionSet.WithChangedOption(new OptionKey(showBlockStructureGuidesForCommentsAndPreprocessorRegionsOptionValue, LanguageNames.CSharp), true);
+            }
+
+            if (_blockStructureOptions.Value.GetField("ShowOutliningForCommentsAndPreprocessorRegions", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) is IOption showOutliningForCommentsAndPreprocessorRegionsOptionValue)
+            {
+                currentOptionSet = currentOptionSet.WithChangedOption(new OptionKey(showOutliningForCommentsAndPreprocessorRegionsOptionValue, LanguageNames.CSharp), true);
+            }
+
+            return currentOptionSet;
+        }
+    }
+}

--- a/src/OmniSharp.Roslyn.CSharp/Services/BlockStructureWorkspaceOptionsProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/BlockStructureWorkspaceOptionsProvider.cs
@@ -25,7 +25,7 @@ namespace OmniSharp.Roslyn.CSharp.Services
             _blockStructureOptions = _csharpFeatureAssembly.LazyGetType("Microsoft.CodeAnalysis.Structure.BlockStructureOptions");
         }
 
-        public int Order => 100;
+        public int Order => 140;
 
         public OptionSet Process(OptionSet currentOptionSet, OmniSharpOptions omniSharpOptions, IOmniSharpEnvironment omnisharpEnvironment)
         {

--- a/src/OmniSharp.Roslyn.CSharp/Services/Structure/BlockStructureService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Structure/BlockStructureService.cs
@@ -18,6 +18,8 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
     [OmniSharpHandler(OmniSharpEndpoints.V2.BlockStructure, LanguageNames.CSharp)]
     public class BlockStructureService : IRequestHandler<BlockStructureRequest, BlockStructureResponse>
     {
+        private const string PreprocessorRegion = nameof(PreprocessorRegion);
+
         private readonly IAssemblyLoader _loader;
         private readonly Lazy<Assembly> _featureAssembly;
         private readonly Lazy<Type> _blockStructureService;
@@ -83,11 +85,11 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
 
         private string ConvertToWellKnownBlockType(string kind)
         {
-            return kind == CodeFoldingBlockKinds.Comment ||
-                   kind == CodeFoldingBlockKinds.Imports ||
-                   kind == CodeFoldingBlockKinds.Region
+            return kind == CodeFoldingBlockKinds.Comment || kind == CodeFoldingBlockKinds.Imports
                 ? kind
-                : null;
+                : kind == PreprocessorRegion
+                    ? CodeFoldingBlockKinds.Region
+                    : null;
         }
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/BlockStructureFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/BlockStructureFacts.cs
@@ -41,6 +41,30 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             Assert.Equal(expected, lineSpans);
         }
 
+        [Fact]
+        public async Task SupportsRegionBlocks()
+        {
+            var testFile = new TestFile("foo.cs", @"
+[|#region Code Region Here
+class Foo[|
+{
+    void M()[|
+    {
+        if (false)[|
+        {
+        }|]
+    }|]
+}|]
+#endregion|]");
+
+            var regionSpan = Assert.Single((await GetResponseAsync(testFile)).Spans,
+                span => span.Kind == CodeFoldingBlockKinds.Region);
+            Assert.Equal(1, regionSpan.Range.Start.Line);
+            Assert.Equal(0, regionSpan.Range.Start.Column);
+            Assert.Equal(11, regionSpan.Range.End.Line);
+            Assert.Equal(10, regionSpan.Range.End.Column);
+        }
+
         private Task<BlockStructureResponse> GetResponseAsync(TestFile testFile)
         {
             SharedOmniSharpTestHost.AddFilesToWorkspace(testFile);


### PR DESCRIPTION
For Roslyn to tag Region blocks, options in BlockStructureOptions need to be set to true. We also need to convert from the type PreprocessorRegion to Region in the BlockStructureService.

Resolves https://github.com/OmniSharp/omnisharp-vscode/issues/2621