### PR TITLE
Add typeparam to description text

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/DocumentationConverter.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/DocumentationConverter.cs
@@ -69,6 +69,12 @@ namespace OmniSharp.Roslyn.CSharp.Services.Documentation
                                     ret.Append(xml["name"]);
                                     ret.Append(" ");
                                     break;
+                                case "typeparam":
+                                    ret.Append(lineEnding);
+                                    ret.Append("<");
+                                    ret.Append(TrimMultiLineString(xml["name"], lineEnding));
+                                    ret.Append(">: ");
+                                    break;
                                 case "param":
                                     ret.Append(lineEnding);
                                     ret.Append(TrimMultiLineString(xml["name"], lineEnding));

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/DocumentationConverterFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/DocumentationConverterFacts.cs
@@ -57,5 +57,25 @@ The <paramref name=""arg""/> parameter takes a number and <paramref name=""arg2"
 The arg parameter takes a number and arg2 takes a string.";
             Assert.Equal(expected, plainText, ignoreLineEndingDifferences: true);
         }
+
+        [Fact]
+        public void Has_typeparam_and_param_in_description()
+        {
+            var documentation = @"
+<member name=""M:TestNamespace.TestClass.CreateWorkspace`1"">
+    <summary>
+    Creates a workspace.
+    </summary>
+    <typeparam name=""T"">The type of workspace being created.</typeparam>
+    <param name=""Path"">The path to the workspace.</param>
+</member>";
+            var plainText = DocumentationConverter.ConvertDocumentation(documentation, "\n");
+            var expected =
+@"Creates a workspace.
+
+<T>: The type of workspace being created.
+Path: The path to the workspace.";
+            Assert.Equal(expected, plainText, ignoreLineEndingDifferences: true);
+        }
     }
 }


### PR DESCRIPTION
Handle typeparam doc comment similar to param. Instead of `{Name}: Description` list them as `<{Name}>: Description`.

Resolves https://github.com/OmniSharp/omnisharp-vscode/issues/3516