### PR TITLE
Upgrade Omnisharp.Extensions.LanguageServer to 0.16.0

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -62,7 +62,7 @@
     <PackageReference Update="Nuget.ProjectModel" Version="$(NuGetPackageVersion)" />
     <PackageReference Update="Nuget.Versioning" Version="$(NuGetPackageVersion)" />
 
-    <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.13.1" />
+    <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.16.0" />
 
     <PackageReference Update="SQLitePCLRaw.bundle_green" Version="1.1.2" />
     <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpCodeLensHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpCodeLensHandler.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Models;
@@ -19,12 +18,12 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
     {
         public static IEnumerable<IJsonRpcHandler> Enumerate(RequestHandlers handlers)
         {
-            foreach (var (selector, membersAsTreeHandler, findUsagesHandler) in handlers
+            foreach (var (selector, pm, membersAsTreeHandler, findUsagesHandler) in handlers
                 .OfType<
                     Mef.IRequestHandler<MembersTreeRequest, FileMemberTree>,
                     Mef.IRequestHandler<FindUsagesRequest, QuickFixResponse>>())
             {
-                yield return new OmniSharpCodeLensHandler(membersAsTreeHandler, findUsagesHandler, selector);
+                yield return new OmniSharpCodeLensHandler(membersAsTreeHandler, findUsagesHandler, selector, pm);
             }
         }
 
@@ -34,12 +33,13 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
         public OmniSharpCodeLensHandler(
             Mef.IRequestHandler<MembersTreeRequest, FileMemberTree> membersAsTreeHandler,
             Mef.IRequestHandler<FindUsagesRequest, QuickFixResponse> findUsagesHandler,
-            DocumentSelector documentSelector)
+            DocumentSelector documentSelector,
+            ProgressManager progressManager)
             : base(new CodeLensRegistrationOptions()
             {
                 DocumentSelector = documentSelector,
                 ResolveProvider = true
-            })
+            }, progressManager)
         {
             _membersAsTreeHandler = membersAsTreeHandler;
             _findUsagesHandler = findUsagesHandler;

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpCompletionHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpCompletionHandler.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Models.AutoComplete;
@@ -15,10 +15,10 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
         public static IEnumerable<IJsonRpcHandler> Enumerate(RequestHandlers handlers)
         {
 
-            foreach (var (selector, handler) in handlers
+            foreach (var (selector, pm, handler) in handlers
                 .OfType<Mef.IRequestHandler<AutoCompleteRequest, IEnumerable<AutoCompleteResponse>>>())
                 if (handler != null)
-                    yield return new OmniSharpCompletionHandler(handler, selector);
+                    yield return new OmniSharpCompletionHandler(handler, selector, pm);
         }
 
         private readonly Mef.IRequestHandler<AutoCompleteRequest, IEnumerable<AutoCompleteResponse>> _autoCompleteHandler;
@@ -63,14 +63,14 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
             return CompletionItemKind.Property;
         }
 
-        public OmniSharpCompletionHandler(Mef.IRequestHandler<AutoCompleteRequest, IEnumerable<AutoCompleteResponse>> autoCompleteHandler, DocumentSelector documentSelector)
+        public OmniSharpCompletionHandler(Mef.IRequestHandler<AutoCompleteRequest, IEnumerable<AutoCompleteResponse>> autoCompleteHandler, DocumentSelector documentSelector, ProgressManager pm)
             : base(new CompletionRegistrationOptions()
             {
                 DocumentSelector = documentSelector,
                 // TODO: Come along and add a service for getting autocompletion details after the fact.
                 ResolveProvider = false,
                 TriggerCharacters = new[] { ".", },
-            })
+            }, pm)
         {
             _autoCompleteHandler = autoCompleteHandler;
         }

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpDefinitionHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpDefinitionHandler.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Models.GotoDefinition;
@@ -15,18 +15,18 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
     {
         public static IEnumerable<IJsonRpcHandler> Enumerate(RequestHandlers handlers)
         {
-            foreach (var (selector, handler) in handlers.OfType<Mef.IRequestHandler<GotoDefinitionRequest, GotoDefinitionResponse>>())
+            foreach (var (selector, pm, handler) in handlers.OfType<Mef.IRequestHandler<GotoDefinitionRequest, GotoDefinitionResponse>>())
                 if (handler != null)
-                    yield return new OmniSharpDefinitionHandler(handler, selector);
+                    yield return new OmniSharpDefinitionHandler(handler, selector, pm);
         }
 
         private readonly Mef.IRequestHandler<GotoDefinitionRequest, GotoDefinitionResponse> _definitionHandler;
 
-        public OmniSharpDefinitionHandler(Mef.IRequestHandler<GotoDefinitionRequest, GotoDefinitionResponse> definitionHandler, DocumentSelector documentSelector)
-            : base(new TextDocumentRegistrationOptions()
+        public OmniSharpDefinitionHandler(Mef.IRequestHandler<GotoDefinitionRequest, GotoDefinitionResponse> definitionHandler, DocumentSelector documentSelector, ProgressManager pm)
+            : base(new DefinitionRegistrationOptions()
             {
                 DocumentSelector = documentSelector
-            })
+            }, pm)
         {
             _definitionHandler = definitionHandler;
         }

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpDocumentFormatRangeHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpDocumentFormatRangeHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Models.Format;
@@ -14,7 +15,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
     {
         public static IEnumerable<IJsonRpcHandler> Enumerate(RequestHandlers handlers)
         {
-            foreach (var (selector, handler) in handlers
+            foreach (var (selector, pm, handler) in handlers
                 .OfType<Mef.IRequestHandler<FormatRangeRequest, FormatRangeResponse>>())
                 if (handler != null)
                     yield return new OmniSharpDocumentFormatRangeHandler(handler, selector);
@@ -22,7 +23,8 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
 
         private readonly Mef.IRequestHandler<FormatRangeRequest, FormatRangeResponse> _formatRangeHandler;
 
-        public OmniSharpDocumentFormatRangeHandler(Mef.IRequestHandler<FormatRangeRequest, FormatRangeResponse> formatRangeHandler, DocumentSelector documentSelector) : base(new TextDocumentRegistrationOptions()
+        public OmniSharpDocumentFormatRangeHandler(Mef.IRequestHandler<FormatRangeRequest, FormatRangeResponse> formatRangeHandler, DocumentSelector documentSelector)
+        : base(new DocumentRangeFormattingRegistrationOptions()
         {
             DocumentSelector = documentSelector,
         })

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpDocumentFormattingHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpDocumentFormattingHandler.cs
@@ -16,7 +16,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
     {
         public static IEnumerable<IJsonRpcHandler> Enumerate(RequestHandlers handlers)
         {
-            foreach (var (selector, handler) in handlers
+            foreach (var (selector, pm, handler) in handlers
                 .OfType<Mef.IRequestHandler<CodeFormatRequest, CodeFormatResponse>>())
                 if (handler != null)
                     yield return new OmniSharpDocumentFormattingHandler(handler, selector);
@@ -24,7 +24,8 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
 
         private readonly Mef.IRequestHandler<CodeFormatRequest, CodeFormatResponse> _codeFormatHandler;
 
-        public OmniSharpDocumentFormattingHandler(Mef.IRequestHandler<CodeFormatRequest, CodeFormatResponse> codeFormatHandler, DocumentSelector documentSelector) : base(new TextDocumentRegistrationOptions()
+        public OmniSharpDocumentFormattingHandler(Mef.IRequestHandler<CodeFormatRequest, CodeFormatResponse> codeFormatHandler, DocumentSelector documentSelector)
+        : base(new DocumentFormattingRegistrationOptions()
         {
             DocumentSelector = documentSelector,
         })

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpDocumentOnTypeFormatHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpDocumentOnTypeFormatHandler.cs
@@ -14,7 +14,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
     {
         public static IEnumerable<IJsonRpcHandler> Enumerate(RequestHandlers handlers)
         {
-            foreach (var (selector, handler) in handlers
+            foreach (var (selector, pm, handler) in handlers
                 .OfType<Mef.IRequestHandler<FormatAfterKeystrokeRequest, FormatRangeResponse>>())
                 if (handler != null)
                     yield return new OmniSharpDocumentOnTypeFormatHandler(handler, selector);

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpHoverHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpHoverHandler.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Models.TypeLookup;
@@ -14,7 +13,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
     {
         public static IEnumerable<IJsonRpcHandler> Enumerate(RequestHandlers handlers)
         {
-            foreach (var (selector, handler) in handlers
+            foreach (var (selector, pm, handler) in handlers
                 .OfType<Mef.IRequestHandler<TypeLookupRequest, TypeLookupResponse>>())
                 if (handler != null)
                     yield return new OmniSharpHoverHandler(handler, selector);
@@ -23,7 +22,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
         private readonly Mef.IRequestHandler<TypeLookupRequest, TypeLookupResponse> _definitionHandler;
 
         public OmniSharpHoverHandler(Mef.IRequestHandler<TypeLookupRequest, TypeLookupResponse> definitionHandler, DocumentSelector documentSelector)
-            : base(new TextDocumentRegistrationOptions()
+            : base(new HoverRegistrationOptions()
             {
                 DocumentSelector = documentSelector
             })
@@ -47,7 +46,10 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
             {
                 // TODO: Range?  We don't currently have that!
                 // Range =
-                Contents = new MarkedStringsOrMarkupContent(new MarkedStringContainer(Helpers.EscapeMarkdown(omnisharpResponse.Type), Helpers.EscapeMarkdown(omnisharpResponse.Documentation)))
+                Contents = new MarkedStringsOrMarkupContent(
+                    new MarkedString(
+                        Helpers.EscapeMarkdown(omnisharpResponse.Type),
+                        Helpers.EscapeMarkdown(omnisharpResponse.Documentation)))
             };
         }
     }

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpReferencesHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpReferencesHandler.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Models;
@@ -16,19 +16,19 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
     {
         public static IEnumerable<IJsonRpcHandler> Enumerate(RequestHandlers handlers)
         {
-            foreach (var (selector, handler) in handlers
+            foreach (var (selector, pm, handler) in handlers
                 .OfType<Mef.IRequestHandler<FindUsagesRequest, QuickFixResponse>>())
                 if (handler != null)
-                    yield return new OmniSharpReferencesHandler(handler, selector);
+                    yield return new OmniSharpReferencesHandler(handler, selector, pm);
         }
 
         private readonly Mef.IRequestHandler<FindUsagesRequest, QuickFixResponse> _findUsagesHandler;
 
-        public OmniSharpReferencesHandler(Mef.IRequestHandler<FindUsagesRequest, QuickFixResponse> findUsagesHandler, DocumentSelector documentSelector)
-            : base(new TextDocumentRegistrationOptions()
+        public OmniSharpReferencesHandler(Mef.IRequestHandler<FindUsagesRequest, QuickFixResponse> findUsagesHandler, DocumentSelector documentSelector, ProgressManager pm)
+            : base(new ReferenceRegistrationOptions()
             {
                 DocumentSelector = documentSelector
-            })
+            }, pm)
         {
             _findUsagesHandler = findUsagesHandler;
         }

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpRenameHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpRenameHandler.cs
@@ -27,7 +27,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
 
         public static IEnumerable<IJsonRpcHandler> Enumerate(RequestHandlers handlers)
         {
-            foreach (var (selector, handler) in handlers
+            foreach (var (selector, pm, handler) in handlers
                 .OfType<Mef.IRequestHandler<RenameRequest, RenameResponse>>())
                 if (handler != null)
                     yield return new OmniSharpRenameHandler(handler, selector);

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs
@@ -27,7 +27,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
 
         public static IEnumerable<IJsonRpcHandler> Enumerate(RequestHandlers handlers)
         {
-            foreach (var (selector, handler) in handlers
+            foreach (var (selector, pm, handler) in handlers
                 .OfType<Mef.IRequestHandler<SignatureHelpRequest, SignatureHelpResponse>>())
                 if (handler != null)
                     yield return new OmniSharpSignatureHelpHandler(handler, selector);

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpTextDocumentSyncHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpTextDocumentSyncHandler.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
@@ -24,7 +22,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
             RequestHandlers handlers,
             OmniSharpWorkspace workspace)
         {
-            foreach (var (selector, openHandler, closeHandler, bufferHandler) in handlers
+            foreach (var (selector, pm, openHandler, closeHandler, bufferHandler) in handlers
                 .OfType<
                     Mef.IRequestHandler<FileOpenRequest, FileOpenResponse>,
                     Mef.IRequestHandler<FileCloseRequest, FileCloseResponse>,

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -16,7 +16,6 @@ using OmniSharp.Extensions.LanguageServer.Server;
 using OmniSharp.LanguageServerProtocol.Eventing;
 using OmniSharp.LanguageServerProtocol.Handlers;
 using OmniSharp.Mef;
-using OmniSharp.Models.Diagnostics;
 using OmniSharp.Options;
 using OmniSharp.Roslyn;
 using OmniSharp.Services;
@@ -49,11 +48,16 @@ namespace OmniSharp.LanguageServerProtocol
             _options = new LanguageServerOptions()
                 .WithInput(input)
                 .WithOutput(output)
-                .WithLoggerFactory(_loggerFactory)
+                .ConfigureLogging(x => x
+                    .AddLanguageServer()
+                    .SetMinimumLevel(application.LogLevel))
                 .AddDefaultLoggingProvider()
                 .OnInitialize(Initialize)
-                .WithMinimumLogLevel(application.LogLevel)
-                .WithServices(services => _services = services);
+                .WithServices(services => {
+                        services.AddSingleton<ILoggerFactory>(_loggerFactory);
+                        _services = services;
+                    });
+
             _application = application;
             _cancellationTokenSource = cancellationTokenSource;
         }

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -129,7 +129,8 @@ namespace OmniSharp.LanguageServerProtocol
             // This will mean that we will have a strategy to create handlers from the interface type
             _handlers = new RequestHandlers(
                 _compositionHost.GetExports<Lazy<IRequestHandler, OmniSharpRequestHandlerMetadata>>(),
-                documentSelectors
+                documentSelectors,
+                _options.ProgressManager
             );
 
             _logger.LogTrace("--- Handler Definitions ---");

--- a/src/OmniSharp.LanguageServerProtocol/RequestHandlerCollection.cs
+++ b/src/OmniSharp.LanguageServerProtocol/RequestHandlerCollection.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Mef;
 
@@ -9,15 +10,21 @@ namespace OmniSharp.LanguageServerProtocol
     {
         private readonly IEnumerable<IRequestHandler> _handlers;
 
-        public RequestHandlerCollection(string language, IEnumerable<IRequestHandler> handlers, DocumentSelector documentSelector)
+        public RequestHandlerCollection(
+            string language,
+            IEnumerable<IRequestHandler> handlers,
+            DocumentSelector documentSelector,
+            ProgressManager progressManager)
         {
             DocumentSelector = documentSelector;
             _handlers = handlers;
             Language = language;
+            ProgressManager = progressManager;
         }
 
         public string Language { get; }
         public DocumentSelector DocumentSelector { get; }
+        public ProgressManager ProgressManager { get; }
 
         public IEnumerator<IRequestHandler> GetEnumerator()
         {

--- a/src/OmniSharp.LanguageServerProtocol/RequestHandlers.cs
+++ b/src/OmniSharp.LanguageServerProtocol/RequestHandlers.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Mef;
 
@@ -11,13 +12,16 @@ namespace OmniSharp.LanguageServerProtocol
     {
         private readonly IEnumerable<Lazy<IRequestHandler, OmniSharpRequestHandlerMetadata>> _requestHandlers;
         private readonly IEnumerable<(string language, DocumentSelector selector)> _documentSelectors;
+        private readonly ProgressManager _progressManager;
 
         public RequestHandlers(
             IEnumerable<Lazy<IRequestHandler, OmniSharpRequestHandlerMetadata>> requestHandlers,
-            IEnumerable<(string language, DocumentSelector selector)> documentSelectors)
+            IEnumerable<(string language, DocumentSelector selector)> documentSelectors,
+            ProgressManager progressManager)
         {
             _requestHandlers = requestHandlers;
             _documentSelectors = documentSelectors;
+            _progressManager = progressManager;
         }
 
         public IEnumerator<RequestHandlerCollection> GetEnumerator()
@@ -26,24 +30,26 @@ namespace OmniSharp.LanguageServerProtocol
                 .Select(documentSelector => new RequestHandlerCollection(
                     documentSelector.language,
                     _requestHandlers.Where(z => z.Metadata.Language == documentSelector.language).Select(z => z.Value),
-                    documentSelector.selector)
+                    documentSelector.selector,
+                    _progressManager)
                 )
                 .GetEnumerator();
         }
 
-        public IEnumerable<(DocumentSelector selector, T handler)> OfType<T>()
+        public IEnumerable<(DocumentSelector selector, ProgressManager pm, T handler)> OfType<T>()
             where T : IRequestHandler
         {
             foreach (var group in this)
             {
                 yield return (
                     group.DocumentSelector,
+                    group.ProgressManager,
                     group.OfType<T>().SingleOrDefault()
                 );
             }
         }
 
-        public IEnumerable<(DocumentSelector selector, T handler, T2 handler2)> OfType<T, T2>()
+        public IEnumerable<(DocumentSelector selector, ProgressManager pm, T handler, T2 handler2)> OfType<T, T2>()
             where T : IRequestHandler
             where T2 : IRequestHandler
         {
@@ -51,13 +57,14 @@ namespace OmniSharp.LanguageServerProtocol
             {
                 yield return (
                     group.DocumentSelector,
+                    group.ProgressManager,
                     group.OfType<T>().SingleOrDefault(),
                     group.OfType<T2>().SingleOrDefault()
                 );
             }
         }
 
-        public IEnumerable<(DocumentSelector selector, T handler, T2 handler2, T3 handler3)> OfType<T, T2, T3>()
+        public IEnumerable<(DocumentSelector selector, ProgressManager pm, T handler, T2 handler2, T3 handler3)> OfType<T, T2, T3>()
             where T : IRequestHandler
             where T2 : IRequestHandler
             where T3 : IRequestHandler
@@ -66,6 +73,7 @@ namespace OmniSharp.LanguageServerProtocol
             {
                 yield return (
                     group.DocumentSelector,
+                    group.ProgressManager,
                     group.OfType<T>().SingleOrDefault(),
                     group.OfType<T2>().SingleOrDefault(),
                     group.OfType<T3>().SingleOrDefault()
@@ -73,7 +81,7 @@ namespace OmniSharp.LanguageServerProtocol
             }
         }
 
-        public IEnumerable<(DocumentSelector selector, T handler, T2 handler2, T3 handler3, T4 handler4)> OfType<T, T2, T3, T4>()
+        public IEnumerable<(DocumentSelector selector, ProgressManager pm, T handler, T2 handler2, T3 handler3, T4 handler4)> OfType<T, T2, T3, T4>()
             where T : IRequestHandler
             where T2 : IRequestHandler
             where T3 : IRequestHandler
@@ -83,6 +91,7 @@ namespace OmniSharp.LanguageServerProtocol
             {
                 yield return (
                     group.DocumentSelector,
+                    group.ProgressManager,
                     group.OfType<T>().SingleOrDefault(),
                     group.OfType<T2>().SingleOrDefault(),
                     group.OfType<T3>().SingleOrDefault(),


### PR DESCRIPTION
This brings some more LSP functionality to life. The fixes work for me --, under
emacs (emacs-lsp) I now have autocompletion, go-to-definition, error list,
lenses working via lsp.

I am not really sure if this is how I should plug ProgressManager into omnisharp code (i.e. what should the lifetime of progress manager look like). When looking at code samples from csharp-language-server-protocol repo, it seems that it should be a singleton and then passed over to handlers. Maybe @david-driscoll can comment on that.

 - https://github.com/OmniSharp/csharp-language-server-protocol/tree/master/sample/SampleServer