### PR TITLE
removed any attempt to handle ref assemblies via GAC when decompiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.35.1] - not yet released
+* Fixed not supported exception when trying to decompile a BCL assembly on Mono (PR: [#1767](https://github.com/OmniSharp/omnisharp-roslyn/pull/1767))
+
 ## [1.35.0] - 2020-04-10
 * Support for `<RunAnalyzers />` and `<RunAnalyzersDuringLiveAnalysis />` (PR: [#1739](https://github.com/OmniSharp/omnisharp-roslyn/pull/1739))
 * Add `typeparam` documentation comments to text description ([omnisharp-vscode#3516](https://github.com/OmniSharp/omnisharp-vscode/issues/3516), PR: [#1749](https://github.com/OmniSharp/omnisharp-roslyn/pull/1749))

--- a/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
+++ b/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj
@@ -18,7 +18,6 @@
         <PackageReference Include="System.Reactive" />
         <PackageReference Include="ICSharpCode.Decompiler" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
         <PackageReference Include="Microsoft.VisualStudio.CodingConventions" />

--- a/src/OmniSharp.Roslyn.CSharp/Services/Decompilation/DecompilationExternalSourceService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Decompilation/DecompilationExternalSourceService.cs
@@ -26,10 +26,10 @@ namespace OmniSharp.Roslyn.CSharp.Services.Decompilation
         private readonly Lazy<OmniSharpCSharpDecompiledSourceService> _service;
 
         [ImportingConstructor]
-        public DecompilationExternalSourceService(IAssemblyLoader loader, ILoggerFactory loggerFactory, OmniSharpWorkspace omniSharpWorkspace) : base(loader)
+        public DecompilationExternalSourceService(IAssemblyLoader loader, ILoggerFactory loggerFactory) : base(loader)
         {
             _loggerFactory = loggerFactory;
-            _service = new Lazy<OmniSharpCSharpDecompiledSourceService>(() => new OmniSharpCSharpDecompiledSourceService(omniSharpWorkspace.Services.GetLanguageServices(LanguageNames.CSharp), _loader, _loggerFactory));
+            _service = new Lazy<OmniSharpCSharpDecompiledSourceService>(() => new OmniSharpCSharpDecompiledSourceService(_loader, _loggerFactory));
         }
 
         public async Task<(Document document, string documentPath)> GetAndAddExternalSymbolDocument(Project project, ISymbol symbol, CancellationToken cancellationToken)


### PR DESCRIPTION
See the discussion here https://github.com/icsharpcode/ilspy-vscode/issues/45#issuecomment-613473929

Long story short, searching for ref assemblies in GAC results in no-definition found - Not Supported exception on Mono. This means that we can't decompile into BCL types on Mono. On Windows it "works" - as in, it doesn't crash, but it doesn't find implementation assemblies anyway.

This PR removes any attempt to handle ref assemblies; this means things should always decompile fine, but we won't find implementation assemblies. This is consistent with VS experience where ref assemblies are decompiled instead of implementation assemblies.

It's a super complex topic, and we can improve on that gradually in the future (or maybe VS implementation will improve).