### PR TITLE
Removed vs-editor feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -8,6 +8,5 @@
         <add key="OmniSharp" value="https://www.myget.org/F/omnisharp/api/v3/index.json" />
         <add key="roslyn-myget" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
         <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
-        <add key="vs-editor" value="https://myget.org/F/vs-editor/api/v3/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
It is no longer needed since we removed `Microsoft.VisualStudio.CodingConventions`