### PR TITLE
added support for WarningsAsErrors msbuild property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All changes to the project will be documented in this file.
 
 ## [1.35.1] - not yet released
+* Added support for `WarningsAsErrors` in csproj files (PR: [#1779](https://github.com/OmniSharp/omnisharp-roslyn/pull/1779))
 * Fixed not supported exception when trying to decompile a BCL assembly on Mono. For now we do not try to resolve implementation assembly from a ref assembly (PR: [#1767](https://github.com/OmniSharp/omnisharp-roslyn/pull/1767))
 * Added support for generic classes in test runner ([omnisharp-vscode#3722](https://github.com/OmniSharp/omnisharp-vscode/issues/3722), PR: [#1768](https://github.com/OmniSharp/omnisharp-roslyn/pull/1768))
 * Improved autocompletion performance (PR: [#1761](https://github.com/OmniSharp/omnisharp-roslyn/pull/1761))

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
@@ -50,7 +50,7 @@ namespace OmniSharp.MSBuild.ProjectFile
             public ImmutableArray<string> Analyzers { get; }
             public ImmutableArray<string> AdditionalFiles { get; }
             public ImmutableArray<string> AnalyzerConfigFiles { get; }
-
+            public ImmutableArray<string> WarningsAsErrors { get; }
             public RuleSet RuleSet { get; }
             public ImmutableDictionary<string, string> ReferenceAliases { get; }
             public ImmutableDictionary<string, string> ProjectReferenceAliases { get; }
@@ -75,6 +75,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 AnalyzerConfigFiles = ImmutableArray<string>.Empty;
                 ReferenceAliases = ImmutableDictionary<string, string>.Empty;
                 ProjectReferenceAliases = ImmutableDictionary<string, string>.Empty;
+                WarningsAsErrors = ImmutableArray<string>.Empty;
             }
 
             private ProjectData(
@@ -92,6 +93,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 string documentationFile,
                 ImmutableArray<string> preprocessorSymbolNames,
                 ImmutableArray<string> suppressedDiagnosticIds,
+                ImmutableArray<string> warningsAsErrors,
                 bool signAssembly,
                 string assemblyOriginatorKeyFile,
                 bool treatWarningsAsErrors,
@@ -123,6 +125,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 DocumentationFile = documentationFile;
                 PreprocessorSymbolNames = preprocessorSymbolNames.EmptyIfDefault();
                 SuppressedDiagnosticIds = suppressedDiagnosticIds.EmptyIfDefault();
+                WarningsAsErrors = warningsAsErrors.EmptyIfDefault();
 
                 SignAssembly = signAssembly;
                 AssemblyOriginatorKeyFile = assemblyOriginatorKeyFile;
@@ -149,6 +152,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 string documentationFile,
                 ImmutableArray<string> preprocessorSymbolNames,
                 ImmutableArray<string> suppressedDiagnosticIds,
+                ImmutableArray<string> warningsAsErrors,
                 bool signAssembly,
                 string assemblyOriginatorKeyFile,
                 ImmutableArray<string> sourceFiles,
@@ -167,7 +171,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 ImmutableDictionary<string, string> projectReferenceAliases)
                 : this(guid, name, assemblyName, targetPath, outputPath, intermediateOutputPath, projectAssetsFile,
                       configuration, platform, targetFramework, targetFrameworks, outputKind, languageVersion, nullableContextOptions, allowUnsafeCode, checkForOverflowUnderflow,
-                      documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, signAssembly, assemblyOriginatorKeyFile, treatWarningsAsErrors, defaultNamespace, runAnalyzers, runAnalyzersDuringLiveAnalysis, ruleset)
+                      documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, warningsAsErrors, signAssembly, assemblyOriginatorKeyFile, treatWarningsAsErrors, defaultNamespace, runAnalyzers, runAnalyzersDuringLiveAnalysis, ruleset)
             {
                 SourceFiles = sourceFiles.EmptyIfDefault();
                 ProjectReferences = projectReferences.EmptyIfDefault();
@@ -211,6 +215,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 var documentationFile = project.GetPropertyValue(PropertyNames.DocumentationFile);
                 var preprocessorSymbolNames = PropertyConverter.ToPreprocessorSymbolNames(project.GetPropertyValue(PropertyNames.DefineConstants));
                 var suppressedDiagnosticIds = PropertyConverter.ToSuppressedDiagnosticIds(project.GetPropertyValue(PropertyNames.NoWarn));
+                var warningsAsErrors = PropertyConverter.SplitList(project.GetPropertyValue(PropertyNames.WarningsAsErrors), ',');
                 var signAssembly = PropertyConverter.ToBoolean(project.GetPropertyValue(PropertyNames.SignAssembly), defaultValue: false);
                 var assemblyOriginatorKeyFile = project.GetPropertyValue(PropertyNames.AssemblyOriginatorKeyFile);
                 var treatWarningsAsErrors = PropertyConverter.ToBoolean(project.GetPropertyValue(PropertyNames.TreatWarningsAsErrors), defaultValue: false);
@@ -220,7 +225,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 return new ProjectData(
                     guid, name, assemblyName, targetPath, outputPath, intermediateOutputPath, projectAssetsFile,
                     configuration, platform, targetFramework, targetFrameworks, outputKind, languageVersion, nullableContextOptions, allowUnsafeCode, checkForOverflowUnderflow,
-                    documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, signAssembly, assemblyOriginatorKeyFile, treatWarningsAsErrors, defaultNamespace, runAnalyzers, runAnalyzersDuringLiveAnalysis, ruleset: null);
+                    documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, warningsAsErrors, signAssembly, assemblyOriginatorKeyFile, treatWarningsAsErrors, defaultNamespace, runAnalyzers, runAnalyzersDuringLiveAnalysis, ruleset: null);
             }
 
             public static ProjectData Create(MSB.Execution.ProjectInstance projectInstance)
@@ -254,6 +259,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 var documentationFile = projectInstance.GetPropertyValue(PropertyNames.DocumentationFile);
                 var preprocessorSymbolNames = PropertyConverter.ToPreprocessorSymbolNames(projectInstance.GetPropertyValue(PropertyNames.DefineConstants));
                 var suppressedDiagnosticIds = PropertyConverter.ToSuppressedDiagnosticIds(projectInstance.GetPropertyValue(PropertyNames.NoWarn));
+                var warningsAsErrors = PropertyConverter.SplitList(projectInstance.GetPropertyValue(PropertyNames.WarningsAsErrors), ',');
                 var signAssembly = PropertyConverter.ToBoolean(projectInstance.GetPropertyValue(PropertyNames.SignAssembly), defaultValue: false);
                 var treatWarningsAsErrors = PropertyConverter.ToBoolean(projectInstance.GetPropertyValue(PropertyNames.TreatWarningsAsErrors), defaultValue: false);
                 var runAnalyzers = PropertyConverter.ToBoolean(projectInstance.GetPropertyValue(PropertyNames.RunAnalyzers), defaultValue: true);
@@ -327,7 +333,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 return new ProjectData(guid, name,
                     assemblyName, targetPath, outputPath, intermediateOutputPath, projectAssetsFile,
                     configuration, platform, targetFramework, targetFrameworks,
-                    outputKind, languageVersion, nullableContextOptions, allowUnsafeCode, checkForOverflowUnderflow, documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds,
+                    outputKind, languageVersion, nullableContextOptions, allowUnsafeCode, checkForOverflowUnderflow, documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, warningsAsErrors,
                     signAssembly, assemblyOriginatorKeyFile,
                     sourceFiles, projectReferences.ToImmutable(), references.ToImmutable(), packageReferences, analyzers, additionalFiles, editorConfigFiles, treatWarningsAsErrors, defaultNamespace, runAnalyzers, runAnalyzersDuringLiveAnalysis, ruleset,
                     referenceAliases.ToImmutableDictionary(), projectReferenceAliases.ToImmutable());

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -41,6 +41,7 @@ namespace OmniSharp.MSBuild.ProjectFile
         public string DocumentationFile => _data.DocumentationFile;
         public ImmutableArray<string> PreprocessorSymbolNames => _data.PreprocessorSymbolNames;
         public ImmutableArray<string> SuppressedDiagnosticIds => _data.SuppressedDiagnosticIds;
+        public ImmutableArray<string> WarningsAsErrors => _data.WarningsAsErrors;
 
         public bool SignAssembly => _data.SignAssembly;
         public string AssemblyOriginatorKeyFile => _data.AssemblyOriginatorKeyFile;

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
@@ -52,14 +52,14 @@ namespace OmniSharp.MSBuild.ProjectFile
 
         public static ImmutableDictionary<string, ReportDiagnostic> GetDiagnosticOptions(this ProjectFileInfo projectFileInfo)
         {
-            var defaultSuppressions = CompilationOptionsHelper.GetDefaultSuppressedDiagnosticOptions(projectFileInfo.SuppressedDiagnosticIds);
+            var suppressions = CompilationOptionsHelper.GetDefaultSuppressedDiagnosticOptions(projectFileInfo.SuppressedDiagnosticIds);
             var specificRules = projectFileInfo.RuleSet?.SpecificDiagnosticOptions ?? ImmutableDictionary<string, ReportDiagnostic>.Empty;
 
-            var combinedRules = specificRules.Concat(defaultSuppressions.Where(x => !specificRules.Keys.Contains(x.Key))).ToDictionary(x => x.Key, x => x.Value);
+            var combinedRules = specificRules.Concat(suppressions.Where(x => !specificRules.Keys.Contains(x.Key))).ToDictionary(x => x.Key, x => x.Value);
 
             foreach (var warningAsError in projectFileInfo.WarningsAsErrors)
             {
-                if (!combinedRules.ContainsKey(warningAsError))
+                if (!suppressions.ContainsKey(warningAsError))
                 {
                     combinedRules[warningAsError] = ReportDiagnostic.Error;
                 }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
@@ -59,7 +59,10 @@ namespace OmniSharp.MSBuild.ProjectFile
 
             foreach (var warningAsError in projectFileInfo.WarningsAsErrors)
             {
-                combinedRules[warningAsError] = ReportDiagnostic.Error;
+                if (!combinedRules.ContainsKey(warningAsError))
+                {
+                    combinedRules[warningAsError] = ReportDiagnostic.Error;
+                }
             }
 
             return combinedRules.ToImmutableDictionary();

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
@@ -55,7 +55,14 @@ namespace OmniSharp.MSBuild.ProjectFile
             var defaultSuppressions = CompilationOptionsHelper.GetDefaultSuppressedDiagnosticOptions(projectFileInfo.SuppressedDiagnosticIds);
             var specificRules = projectFileInfo.RuleSet?.SpecificDiagnosticOptions ?? ImmutableDictionary<string, ReportDiagnostic>.Empty;
 
-            return specificRules.Concat(defaultSuppressions.Where(x => !specificRules.Keys.Contains(x.Key))).ToImmutableDictionary();
+            var combinedRules = specificRules.Concat(defaultSuppressions.Where(x => !specificRules.Keys.Contains(x.Key))).ToDictionary(x => x.Key, x => x.Value);
+
+            foreach (var warningAsError in projectFileInfo.WarningsAsErrors)
+            {
+                combinedRules[warningAsError] = ReportDiagnostic.Error;
+            }
+
+            return combinedRules.ToImmutableDictionary();
         }
 
         public static ProjectInfo CreateProjectInfo(this ProjectFileInfo projectFileInfo, IAnalyzerAssemblyLoader analyzerAssemblyLoader)

--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyConverter.cs
@@ -42,7 +42,7 @@ namespace OmniSharp.MSBuild.ProjectFile
             }
 
             var builder = ImmutableArray.CreateBuilder<string>();
-            var values = propertyValue.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            var values = propertyValue.Split(new[] { separator }, StringSplitOptions.RemoveEmptyEntries);
 
             foreach (var value in values)
             {

--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
@@ -45,5 +45,6 @@
         public const string TreatWarningsAsErrors = nameof(TreatWarningsAsErrors);
         public const string VisualStudioVersion = nameof(VisualStudioVersion);
         public const string VsInstallRoot = nameof(VsInstallRoot);
+        public const string WarningsAsErrors = nameof(WarningsAsErrors);
     }
 }

--- a/test-assets/test-projects/WarningsAsErrors/Program.cs
+++ b/test-assets/test-projects/WarningsAsErrors/Program.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/test-assets/test-projects/WarningsAsErrors/WarningsAsErrors.csproj
+++ b/test-assets/test-projects/WarningsAsErrors/WarningsAsErrors.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <WarningsAsErrors>CS1998,CS7080</WarningsAsErrors>
+    <WarningsAsErrors>CS1998,CS7080,CS7081</WarningsAsErrors>
+    <NoWarn>CS7081</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/test-assets/test-projects/WarningsAsErrors/WarningsAsErrors.csproj
+++ b/test-assets/test-projects/WarningsAsErrors/WarningsAsErrors.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <WarningsAsErrors>CS1998,CS7080</WarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -208,12 +208,15 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.NotEmpty(projectFileInfo.WarningsAsErrors);
                 Assert.Contains("CS1998", projectFileInfo.WarningsAsErrors);
                 Assert.Contains("CS7080", projectFileInfo.WarningsAsErrors);
+                Assert.Contains("CS7081", projectFileInfo.WarningsAsErrors);
 
                 var compilationOptions = projectFileInfo.CreateCompilationOptions();
-                Assert.True(compilationOptions.SpecificDiagnosticOptions.ContainsKey("CS1998"), "Specific diagnostic option fo CS1998 not found");
-                Assert.True(compilationOptions.SpecificDiagnosticOptions.ContainsKey("CS7080"), "Specific diagnostic option fo CS7080 not found");
+                Assert.True(compilationOptions.SpecificDiagnosticOptions.ContainsKey("CS1998"), "Specific diagnostic option for CS1998 not found");
+                Assert.True(compilationOptions.SpecificDiagnosticOptions.ContainsKey("CS7080"), "Specific diagnostic option for CS7080 not found");
+                Assert.True(compilationOptions.SpecificDiagnosticOptions.ContainsKey("CS7081"), "Specific diagnostic option for CS7081 not found");
                 Assert.Equal(ReportDiagnostic.Error, compilationOptions.SpecificDiagnosticOptions["CS1998"]);
                 Assert.Equal(ReportDiagnostic.Error, compilationOptions.SpecificDiagnosticOptions["CS7080"]);
+                Assert.Equal(ReportDiagnostic.Suppress, compilationOptions.SpecificDiagnosticOptions["CS7081"]); // NoWarn should be given priority over WarningsAsErrors
             }
         }
     }

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -196,5 +196,25 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.Equal(ReportDiagnostic.Default, compilationOptions.GeneralDiagnosticOption);
             }
         }
+
+        [Fact]
+        public async Task WarningsAsErrors()
+        {
+            using (var host = CreateOmniSharpHost())
+            using (var testProject = await _testAssets.GetTestProjectAsync("WarningsAsErrors"))
+            {
+                var projectFilePath = Path.Combine(testProject.Directory, "WarningsAsErrors.csproj");
+                var projectFileInfo = CreateProjectFileInfo(host, testProject, projectFilePath);
+                Assert.NotEmpty(projectFileInfo.WarningsAsErrors);
+                Assert.Contains("CS1998", projectFileInfo.WarningsAsErrors);
+                Assert.Contains("CS7080", projectFileInfo.WarningsAsErrors);
+
+                var compilationOptions = projectFileInfo.CreateCompilationOptions();
+                Assert.True(compilationOptions.SpecificDiagnosticOptions.ContainsKey("CS1998"), "Specific diagnostic option fo CS1998 not found");
+                Assert.True(compilationOptions.SpecificDiagnosticOptions.ContainsKey("CS7080"), "Specific diagnostic option fo CS7080 not found");
+                Assert.Equal(ReportDiagnostic.Error, compilationOptions.SpecificDiagnosticOptions["CS1998"]);
+                Assert.Equal(ReportDiagnostic.Error, compilationOptions.SpecificDiagnosticOptions["CS7080"]);
+            }
+        }
     }
 }


### PR DESCRIPTION
> WarningsAsErrors is a list of warnings that should be treated as errors.
> TreatWarningsAsErrors is the boolean that lifts all warnings to errors.

We never supported `WarningsAsErrors`, only `TreatWarningsAsErrors`