### PR TITLE
Update OmniSharp.Extensions.LanguageServer to "0.14.2" to fix synchronisation

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -62,7 +62,7 @@
     <PackageReference Update="Nuget.ProjectModel" Version="$(NuGetPackageVersion)" />
     <PackageReference Update="Nuget.Versioning" Version="$(NuGetPackageVersion)" />
 
-    <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.13.1" />
+    <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.14.2" />
 
     <PackageReference Update="SQLitePCLRaw.bundle_green" Version="1.1.2" />
     <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpTextDocumentSyncHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpTextDocumentSyncHandler.cs
@@ -4,7 +4,7 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -16,7 +16,6 @@ using OmniSharp.Extensions.LanguageServer.Server;
 using OmniSharp.LanguageServerProtocol.Eventing;
 using OmniSharp.LanguageServerProtocol.Handlers;
 using OmniSharp.Mef;
-using OmniSharp.Models.Diagnostics;
 using OmniSharp.Options;
 using OmniSharp.Roslyn;
 using OmniSharp.Services;
@@ -28,7 +27,6 @@ namespace OmniSharp.LanguageServerProtocol
     {
         private readonly LanguageServerOptions _options;
         private IServiceCollection _services;
-        private readonly LoggerFactory _loggerFactory;
         private readonly CommandLineApplication _application;
         private readonly CancellationTokenSource _cancellationTokenSource;
         private CompositionHost _compositionHost;
@@ -44,16 +42,17 @@ namespace OmniSharp.LanguageServerProtocol
             CommandLineApplication application,
             CancellationTokenSource cancellationTokenSource)
         {
-            _loggerFactory = new LoggerFactory();
-            _logger = _loggerFactory.CreateLogger<LanguageServerHost>();
             _options = new LanguageServerOptions()
                 .WithInput(input)
                 .WithOutput(output)
-                .WithLoggerFactory(_loggerFactory)
-                .AddDefaultLoggingProvider()
+                .ConfigureLogging(x => x
+                    .AddLanguageServer()
+                    .SetMinimumLevel(application.LogLevel))
                 .OnInitialize(Initialize)
-                .WithMinimumLogLevel(application.LogLevel)
-                .WithServices(services => _services = services);
+                .WithServices(services => {
+                        _services = services;
+                    });
+
             _application = application;
             _cancellationTokenSource = cancellationTokenSource;
         }
@@ -61,7 +60,6 @@ namespace OmniSharp.LanguageServerProtocol
         public void Dispose()
         {
             _compositionHost?.Dispose();
-            _loggerFactory?.Dispose();
             _cancellationTokenSource?.Dispose();
         }
 
@@ -92,6 +90,9 @@ namespace OmniSharp.LanguageServerProtocol
             var configurationRoot = new ConfigurationBuilder(_environment).Build();
             _eventEmitter = new LanguageServerEventEmitter();
             _serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_environment, configurationRoot, _eventEmitter, _services);
+
+            var loggerFactory = _serviceProvider.GetService<ILoggerFactory>();
+            _logger = loggerFactory.CreateLogger<LanguageServerHost>();
 
             var options = _serviceProvider.GetRequiredService<IOptionsMonitor<OmniSharpOptions>>();
             var plugins = _application.CreatePluginAssemblies(options.CurrentValue, _environment);


### PR DESCRIPTION
See https://github.com/OmniSharp/csharp-language-server-protocol/pull/199

This is a more conservative version of my previous PR to fix LSP synchronisation issues:
 - https://github.com/OmniSharp/omnisharp-roslyn/pull/1754

I'd consider this one for merge, as it does not require introducing ProgressManager as the PR for upgrade to 0.16.0 does.