### PR TITLE
Improved msbuild discovery scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to the project will be documented in this file.
 ## [1.35.2] - not yet released
 * Added support for `WarningsAsErrors` in csproj files (PR: [#1779](https://github.com/OmniSharp/omnisharp-roslyn/pull/1779))
 * Added support for `WarningsNotAsErrors` in csproj files ([#1681](https://github.com/OmniSharp/omnisharp-roslyn/issues/1681), PR: [#1784](https://github.com/OmniSharp/omnisharp-roslyn/pull/1784))
+* Improved MSBuild scoring system ([#1783](https://github.com/OmniSharp/omnisharp-roslyn/issues/1783), PR: [#1795](https://github.com/OmniSharp/omnisharp-roslyn/pull/1795))
 
 ## [1.35.1] - 2020-05-04
 * Fixed not supported exception when trying to decompile a BCL assembly on Mono. For now we do not try to resolve implementation assembly from a ref assembly (PR: [#1767](https://github.com/OmniSharp/omnisharp-roslyn/pull/1767))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All changes to the project will be documented in this file.
 ## [1.35.2] - not yet released
 * Added support for `WarningsAsErrors` in csproj files (PR: [#1779](https://github.com/OmniSharp/omnisharp-roslyn/pull/1779))
 * Added support for `WarningsNotAsErrors` in csproj files ([#1681](https://github.com/OmniSharp/omnisharp-roslyn/issues/1681), PR: [#1784](https://github.com/OmniSharp/omnisharp-roslyn/pull/1784))
-* Improved MSBuild scoring system ([#1783](https://github.com/OmniSharp/omnisharp-roslyn/issues/1783), PR: [#1795](https://github.com/OmniSharp/omnisharp-roslyn/pull/1795))
+* Improved MSBuild scoring system ([#1783](https://github.com/OmniSharp/omnisharp-roslyn/issues/1783), PR: [#1797](https://github.com/OmniSharp/omnisharp-roslyn/pull/1797))
 
 ## [1.35.1] - 2020-05-04
 * Fixed not supported exception when trying to decompile a BCL assembly on Mono. For now we do not try to resolve implementation assembly from a ref assembly (PR: [#1767](https://github.com/OmniSharp/omnisharp-roslyn/pull/1767))

--- a/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
@@ -7,7 +7,7 @@ namespace OmniSharp.MSBuild.Discovery
     {
         public static void RegisterDefaultInstance(this IMSBuildLocator msbuildLocator, ILogger logger)
         {
-            var bestInstanceFound = GetBestInstance(msbuildLocator, out var invalidVSFound);
+            var bestInstanceFound = GetBestInstance(msbuildLocator, logger, out var invalidVSFound);
 
             if (bestInstanceFound != null)
             {
@@ -16,8 +16,8 @@ namespace OmniSharp.MSBuild.Discovery
                 if (invalidVSFound && bestInstanceFound.DiscoveryType == DiscoveryType.StandAlone)
                 {
                     logger.LogWarning(
-                        @"It looks like you have Visual Studio 2017 RTM installed.
- Try updating Visual Studio 2017 to the most recent release to enable better MSBuild support."
+                        @"It looks like you have Visual Studio 2019 RTM installed.
+ Try updating Visual Studio 2019 to the most recent release to enable better MSBuild support."
                     );
                 }
 
@@ -52,7 +52,7 @@ namespace OmniSharp.MSBuild.Discovery
                 && (instance.DiscoveryType == DiscoveryType.DeveloperConsole
                     || instance.DiscoveryType == DiscoveryType.VisualStudioSetup);
 
-        public static MSBuildInstance GetBestInstance(this IMSBuildLocator msbuildLocator, out bool invalidVSFound)
+        public static MSBuildInstance GetBestInstance(this IMSBuildLocator msbuildLocator, ILogger logger, out bool invalidVSFound)
         {
             invalidVSFound = false;
             MSBuildInstance bestMatchInstance = null;
@@ -62,10 +62,12 @@ namespace OmniSharp.MSBuild.Discovery
             {
                 var score = GetInstanceFeatureScore(instance);
 
+                logger.LogDebug($"MSBuild instance {instance.Name} {instance.Version} scored at {score}");
+
                 invalidVSFound = invalidVSFound || instance.IsInvalidVisualStudio();
 
-                if (score > bestMatchScore
-                    || (score == bestMatchScore && instance.Version.Major > (bestMatchInstance?.Version.Major ?? 0)))
+                if (score > bestMatchScore ||
+                    score == bestMatchScore && instance.Version > bestMatchInstance?.Version)
                 {
                     bestMatchInstance = instance;
                     bestMatchScore = score;

--- a/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
@@ -66,7 +66,8 @@ namespace OmniSharp.MSBuild.Discovery
 
                 invalidVSFound = invalidVSFound || instance.IsInvalidVisualStudio();
 
-                if (score > bestMatchScore ||
+                if (bestMatchInstance == null ||
+                    score > bestMatchScore ||
                     score == bestMatchScore && instance.Version > bestMatchInstance?.Version)
                 {
                     bestMatchInstance = instance;

--- a/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
@@ -68,7 +68,7 @@ namespace OmniSharp.MSBuild.Discovery
 
                 if (bestMatchInstance == null ||
                     score > bestMatchScore ||
-                    score == bestMatchScore && instance.Version > bestMatchInstance?.Version)
+                    score == bestMatchScore && instance.Version > bestMatchInstance.Version)
                 {
                     bestMatchInstance = instance;
                     bestMatchScore = score;

--- a/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
@@ -169,7 +169,7 @@ namespace OmniSharp.MSBuild.Tests
         }
 
         [Fact]
-        public void RegisterDefaultInstanceStillPrefersTheFirstInstance()
+        public void RegisterDefaultInstancePrefersSupportedVSLowerVersionInstanceOverStandAlone()
         {
             var msBuildInstances = new[]
             {
@@ -178,18 +178,45 @@ namespace OmniSharp.MSBuild.Tests
                     TestIO.GetRandomTempFolderPath(),
                     Version.Parse("16.3.2.3"),
                     DiscoveryType.VisualStudioSetup
-                ),
+                ).AddDotNetCoreToFakeInstance(),
                 GetStandAloneMSBuildInstance()
             };
 
             var msbuildLocator = new MSFakeLocator(msBuildInstances);
-            var logger = LoggerFactory.CreateLogger(nameof(RegisterDefaultInstanceStillPrefersTheFirstInstance));
+            var logger = LoggerFactory.CreateLogger(nameof(RegisterDefaultInstancePrefersSupportedVSLowerVersionInstanceOverStandAlone));
 
             // test
             msbuildLocator.RegisterDefaultInstance(logger);
 
             Assert.NotNull(msbuildLocator.RegisteredInstance);
             Assert.Same(msBuildInstances[0], msbuildLocator.RegisteredInstance);
+
+            // clean up
+            msbuildLocator.DeleteFakeInstancesFolders();
+        }
+
+        [Fact]
+        public void RegisterDefaultInstancePrefersStandAloneOverSupportedVSLowerVersionInstanceWithoutDotnetCore()
+        {
+            var msBuildInstances = new[]
+            {
+                new MSBuildInstance(
+                    "Test Instance",
+                    TestIO.GetRandomTempFolderPath(),
+                    Version.Parse("16.2.2.3"),
+                    DiscoveryType.VisualStudioSetup
+                ),
+                GetStandAloneMSBuildInstance()
+            };
+
+            var msbuildLocator = new MSFakeLocator(msBuildInstances);
+            var logger = LoggerFactory.CreateLogger(nameof(RegisterDefaultInstancePrefersStandAloneOverSupportedVSLowerVersionInstanceWithoutDotnetCore));
+
+            // test
+            msbuildLocator.RegisterDefaultInstance(logger);
+
+            Assert.NotNull(msbuildLocator.RegisteredInstance);
+            Assert.Same(msBuildInstances[1], msbuildLocator.RegisteredInstance);
 
             // clean up
             msbuildLocator.DeleteFakeInstancesFolders();

--- a/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
@@ -81,6 +81,46 @@ namespace OmniSharp.MSBuild.Tests
             msbuildLocator.DeleteFakeInstancesFolders();
         }
 
+
+        [Fact]
+        public void RegisterDefaultInstanceFindsTheNewestInstanceAvailableEvenWithOtherValidInstances()
+        {
+            var msBuildInstances = new[]
+            {
+                new MSBuildInstance(
+                    "Valid Test Instance",
+                    TestIO.GetRandomTempFolderPath(),
+                    Version.Parse("16.5.1.0"),
+                    DiscoveryType.VisualStudioSetup
+                ).AddDotNetCoreToFakeInstance(),
+                GetInvalidMsBuildInstance(),
+
+                // same but newer minor version
+                new MSBuildInstance(
+                    "Another Valid Test Instance",
+                    TestIO.GetRandomTempFolderPath(),
+                    Version.Parse("16.6.1.0"),
+                    DiscoveryType.VisualStudioSetup
+                ).AddDotNetCoreToFakeInstance(),
+                GetStandAloneMSBuildInstance()
+            };
+
+            var msbuildLocator = new MSFakeLocator(msBuildInstances);
+
+            var logger = LoggerFactory.CreateLogger(
+                nameof(RegisterDefaultInstanceFindsTheBestInstanceAvailableEvenWithOtherValidInstances)
+            );
+
+            // test
+            msbuildLocator.RegisterDefaultInstance(logger);
+
+            Assert.NotNull(msbuildLocator.RegisteredInstance);
+            Assert.Same(msBuildInstances[2], msbuildLocator.RegisteredInstance);
+
+            // clean up
+            msbuildLocator.DeleteFakeInstancesFolders();
+        }
+
         [Fact]
         public void RegisterDefaultInstanceFindsUserOverrideAvailableEvenWithOtherValidInstances()
         {


### PR DESCRIPTION
Fixes #1783 
We should compare full versions rather than just major. Otherwise the selection is non deterministic, for example if 16.4 is discovered before 16.6, 16.4 would be used.