### PR TITLE
LSP: expose omnisharp/client/findReferences custom command for code lenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to the project will be documented in this file.
 
 ## [1.35.3] - not yet released
 * Added LSP handler for `textDocument/codeAction` request. (PR: [#1795](https://github.com/OmniSharp/omnisharp-roslyn/pull/1795))
+* Expose a custom LSP `omnisharp/client/findReferences` command via code lens (meant to be handled by LSP client). (PR: [#1807](https://github.com/OmniSharp/omnisharp-roslyn/pull/1807))
 
 ## [1.35.2] - 2020-05-20
 * Added support for `WarningsAsErrors` in csproj files (PR: [#1779](https://github.com/OmniSharp/omnisharp-roslyn/pull/1779))

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpExecuteCommandHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpExecuteCommandHandler.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+
+namespace OmniSharp.LanguageServerProtocol.Handlers
+{
+    class OmniSharpExecuteCommandHandler : ExecuteCommandHandler
+    {
+        public static IEnumerable<IJsonRpcHandler> Enumerate(RequestHandlers handlers)
+        {
+            yield return new OmniSharpExecuteCommandHandler();
+        }
+
+        public OmniSharpExecuteCommandHandler()
+            : base (new ExecuteCommandRegistrationOptions() {
+                Commands = new Container<string>(),
+            })
+        {
+        }
+
+        public override Task<Unit>
+        Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Unit.Value);
+        }
+    }
+}

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -169,6 +169,7 @@ namespace OmniSharp.LanguageServerProtocol
                 .Concat(OmniSharpCodeActionHandler.Enumerate(_handlers))
                 .Concat(OmniSharpDocumentFormattingHandler.Enumerate(_handlers))
                 .Concat(OmniSharpDocumentFormatRangeHandler.Enumerate(_handlers))
+                .Concat(OmniSharpExecuteCommandHandler.Enumerate(_handlers))
                 .Concat(OmniSharpDocumentOnTypeFormatHandler.Enumerate(_handlers)))
             {
                 server.AddHandlers(handler);


### PR DESCRIPTION
This exposes a custom `omnisharp/client/findReferences` command that is meant to be handled by LSP client to display references at given `Location`.

Since this is a custom command there needs to be changes made per-LSP client to handle this command, issue a `textDocument/references` request at given `Location` and display that on UI.