### PR TITLE
upgraded build agent to ubuntu 18.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
 
   - job: Linux
     pool:
-      vmImage: "Ubuntu-16.04"
+      vmImage: "Ubuntu-18.04"
     dependsOn: GitVersion
     variables:
       MONO_VERSION: 6.8.0


### PR DESCRIPTION
Last month Azure DevOps finally got Ubuntu 18.04 images - we should upgrade as we should be testing on this most popular version of Ubuntu.