### PR TITLE
Fix folder deletion with VSCode

### DIFF
--- a/src/OmniSharp.Abstractions/FileWatching/FileChangeType.cs
+++ b/src/OmniSharp.Abstractions/FileWatching/FileChangeType.cs
@@ -6,6 +6,6 @@
         Change,
         Create,
         Delete,
-        FolderDelete
+        DirectoryDelete
     }
 }

--- a/src/OmniSharp.Abstractions/FileWatching/FileChangeType.cs
+++ b/src/OmniSharp.Abstractions/FileWatching/FileChangeType.cs
@@ -5,6 +5,7 @@
         Unspecified = 0,
         Change,
         Create,
-        Delete
+        Delete,
+        FolderDelete
     }
 }

--- a/src/OmniSharp.Abstractions/FileWatching/IFileSystemWatcher.cs
+++ b/src/OmniSharp.Abstractions/FileWatching/IFileSystemWatcher.cs
@@ -12,5 +12,6 @@ namespace OmniSharp.FileWatching
         /// <param name="pathOrExtension">The file path, directory path or file extension to watch.</param>
         /// <param name="callback">The callback that will be invoked when a change occurs in the watched file or directory.</param>
         void Watch(string pathOrExtension, FileSystemNotificationCallback callback);
+        void WatchFolders(FileSystemNotificationCallback callback);
     }
 }

--- a/src/OmniSharp.Abstractions/FileWatching/IFileSystemWatcher.cs
+++ b/src/OmniSharp.Abstractions/FileWatching/IFileSystemWatcher.cs
@@ -12,6 +12,6 @@ namespace OmniSharp.FileWatching
         /// <param name="pathOrExtension">The file path, directory path or file extension to watch.</param>
         /// <param name="callback">The callback that will be invoked when a change occurs in the watched file or directory.</param>
         void Watch(string pathOrExtension, FileSystemNotificationCallback callback);
-        void WatchFolders(FileSystemNotificationCallback callback);
+        void WatchDirectories(FileSystemNotificationCallback callback);
     }
 }

--- a/src/OmniSharp.Host/FileWatching/ManualFileSystemWatcher.cs
+++ b/src/OmniSharp.Host/FileWatching/ManualFileSystemWatcher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace OmniSharp.FileWatching
 {
@@ -8,6 +9,7 @@ namespace OmniSharp.FileWatching
     {
         private readonly object _gate = new object();
         private readonly Dictionary<string, Callbacks> _callbacksMap;
+        private readonly Callbacks _folderCallbacks = new Callbacks();
 
         public ManualFileSystemWatcher()
         {
@@ -18,6 +20,16 @@ namespace OmniSharp.FileWatching
         {
             lock (_gate)
             {
+                if(changeType == FileChangeType.FolderDelete)
+                {
+                    foreach(var matchingCallback in _callbacksMap.AsEnumerable().Where(x => x.Key.StartsWith(filePath)))
+                    {
+                        matchingCallback.Value.Invoke(matchingCallback.Key, FileChangeType.Delete);
+                    }
+
+                    _folderCallbacks.Invoke(filePath, FileChangeType.FolderDelete);
+                }
+
                 if (_callbacksMap.TryGetValue(filePath, out var fileCallbacks))
                 {
                     fileCallbacks.Invoke(filePath, changeType);
@@ -36,6 +48,11 @@ namespace OmniSharp.FileWatching
                     extensionCallbacks.Invoke(filePath, changeType);
                 }
             }
+        }
+
+        public void WatchFolders(FileSystemNotificationCallback callback)
+        {
+            _folderCallbacks.Add(callback);
         }
 
         public void Watch(string pathOrExtension, FileSystemNotificationCallback callback)

--- a/src/OmniSharp.Host/FileWatching/ManualFileSystemWatcher.cs
+++ b/src/OmniSharp.Host/FileWatching/ManualFileSystemWatcher.cs
@@ -20,14 +20,14 @@ namespace OmniSharp.FileWatching
         {
             lock (_gate)
             {
-                if(changeType == FileChangeType.FolderDelete)
+                if(changeType == FileChangeType.DirectoryDelete)
                 {
                     foreach(var matchingCallback in _callbacksMap.AsEnumerable().Where(x => x.Key.StartsWith(filePath)))
                     {
                         matchingCallback.Value.Invoke(matchingCallback.Key, FileChangeType.Delete);
                     }
 
-                    _folderCallbacks.Invoke(filePath, FileChangeType.FolderDelete);
+                    _folderCallbacks.Invoke(filePath, FileChangeType.DirectoryDelete);
                 }
 
                 if (_callbacksMap.TryGetValue(filePath, out var fileCallbacks))
@@ -50,7 +50,7 @@ namespace OmniSharp.FileWatching
             }
         }
 
-        public void WatchFolders(FileSystemNotificationCallback callback)
+        public void WatchDirectories(FileSystemNotificationCallback callback)
         {
             _folderCallbacks.Add(callback);
         }

--- a/src/OmniSharp.Host/FileWatching/ManualFileSystemWatcher.cs
+++ b/src/OmniSharp.Host/FileWatching/ManualFileSystemWatcher.cs
@@ -22,11 +22,6 @@ namespace OmniSharp.FileWatching
             {
                 if(changeType == FileChangeType.DirectoryDelete)
                 {
-                    foreach(var matchingCallback in _callbacksMap.AsEnumerable().Where(x => x.Key.StartsWith(filePath + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)))
-                    {
-                        matchingCallback.Value.Invoke(matchingCallback.Key, FileChangeType.Delete);
-                    }
-
                     _folderCallbacks.Invoke(filePath, FileChangeType.DirectoryDelete);
                 }
 

--- a/src/OmniSharp.Host/FileWatching/ManualFileSystemWatcher.cs
+++ b/src/OmniSharp.Host/FileWatching/ManualFileSystemWatcher.cs
@@ -22,7 +22,7 @@ namespace OmniSharp.FileWatching
             {
                 if(changeType == FileChangeType.DirectoryDelete)
                 {
-                    foreach(var matchingCallback in _callbacksMap.AsEnumerable().Where(x => x.Key.StartsWith(filePath)))
+                    foreach(var matchingCallback in _callbacksMap.AsEnumerable().Where(x => x.Key.StartsWith(filePath + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)))
                     {
                         matchingCallback.Value.Invoke(matchingCallback.Key, FileChangeType.Delete);
                     }

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -51,15 +51,12 @@ namespace OmniSharp
         {
             if(changeType == FileChangeType.FolderDelete)
             {
-                var docs = CurrentSolution
-                    .Projects
-                    .SelectMany(x => x.Documents)
-                    .Where(x => x.FilePath.StartsWith(path, StringComparison.OrdinalIgnoreCase))
-                    .Select(x => x.Id);
+                var docs = CurrentSolution.Projects.SelectMany(x => x.Documents)
+                    .Where(x => x.FilePath.StartsWith(path, StringComparison.OrdinalIgnoreCase));
 
                 foreach(var doc in docs)
                 {
-                    OnDocumentRemoved(doc);
+                    OnDocumentRemoved(doc.Id);
                 }
             }
         }

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -52,7 +52,7 @@ namespace OmniSharp
             if(changeType == FileChangeType.DirectoryDelete)
             {
                 var docs = CurrentSolution.Projects.SelectMany(x => x.Documents)
-                    .Where(x => x.FilePath.StartsWith(path, StringComparison.OrdinalIgnoreCase));
+                    .Where(x => x.FilePath.StartsWith(path + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase));
 
                 foreach(var doc in docs)
                 {

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -41,7 +41,7 @@ namespace OmniSharp
         {
             BufferManager = new BufferManager(this, fileSystemWatcher);
             _logger = loggerFactory.CreateLogger<OmniSharpWorkspace>();
-            fileSystemWatcher.WatchFolders(OnDirectoryRemoved);
+            fileSystemWatcher.WatchDirectories(OnDirectoryRemoved);
         }
 
         public override bool CanOpenDocuments => true;
@@ -49,7 +49,7 @@ namespace OmniSharp
 
         private void OnDirectoryRemoved(string path, FileChangeType changeType)
         {
-            if(changeType == FileChangeType.FolderDelete)
+            if(changeType == FileChangeType.DirectoryDelete)
             {
                 var docs = CurrentSolution.Projects.SelectMany(x => x.Documents)
                     .Where(x => x.FilePath.StartsWith(path, StringComparison.OrdinalIgnoreCase));

--- a/tests/OmniSharp.Cake.Tests/LineIndexHelperFacts.cs
+++ b/tests/OmniSharp.Cake.Tests/LineIndexHelperFacts.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Cake.Utilities;
+using OmniSharp.FileWatching;
 using OmniSharp.Services;
 using OmniSharp.Utilities;
 using Xunit;
@@ -59,7 +60,7 @@ namespace OmniSharp.Cake.Tests
             var workspace = new OmniSharpWorkspace(
                 new HostServicesAggregator(
                     Enumerable.Empty<IHostServicesProvider>(), new LoggerFactory()),
-                new LoggerFactory(), null);
+                new LoggerFactory(), new DummyFileSystemWatcher());
 
             var projectInfo = ProjectInfo.Create(ProjectId.CreateNewId(), VersionStamp.Create(),
                 "ProjectNameVal", "AssemblyNameVal", LanguageNames.CSharp);
@@ -146,6 +147,17 @@ namespace OmniSharp.Cake.Tests
             var (actualIndex, _) = await LineIndexHelper.TranslateFromGenerated(fileName, index, workspace, true);
 
             Assert.Equal(expected, actualIndex);
+        }
+
+        private class DummyFileSystemWatcher : IFileSystemWatcher
+        {
+            public void Watch(string pathOrExtension, FileSystemNotificationCallback callback)
+            {
+            }
+
+            public void WatchDirectories(FileSystemNotificationCallback callback)
+            {
+            }
         }
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FilesChangedFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FilesChangedFacts.cs
@@ -45,6 +45,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 var watcher = host.GetExport<IFileSystemWatcher>();
 
                 var projectDirectory = Path.GetDirectoryName(host.Workspace.CurrentSolution.Projects.First().FilePath);
+
                 const string filename = "FileName.cs";
                 var filePath = Path.Combine(projectDirectory, filename);
                 File.WriteAllText(filePath, "text");
@@ -68,7 +69,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         }
 
         [Fact]
-        public void TestMultipleDirectoryWatchers()
+        public async Task TestMultipleDirectoryWatchers()
         {
             using (var host = CreateEmptyOmniSharpHost())
             {
@@ -80,7 +81,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 watcher.Watch("", (path, changeType) => { secondWatcherCalled = true; });
 
                 var handler = GetRequestHandler(host);
-                handler.Handle(new[] { new FilesChangedRequest() { FileName = "FileName.cs", ChangeType = FileChangeType.Create } });
+                await handler.Handle(new[] { new FilesChangedRequest() { FileName = "FileName.cs", ChangeType = FileChangeType.Create } });
 
                 Assert.True(firstWatcherCalled);
                 Assert.True(secondWatcherCalled);
@@ -88,7 +89,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         }
 
         [Fact]
-        public void TestFileExtensionWatchers()
+        public async Task TestFileExtensionWatchers()
         {
             using (var host = CreateEmptyOmniSharpHost())
             {
@@ -98,10 +99,38 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 watcher.Watch(".cs", (path, changeType) => { extensionWatcherCalled = true; });
 
                 var handler = GetRequestHandler(host);
-                handler.Handle(new[] { new FilesChangedRequest() { FileName = "FileName.cs", ChangeType = FileChangeType.Create } });
+                await handler.Handle(new[] { new FilesChangedRequest() { FileName = "FileName.cs", ChangeType = FileChangeType.Create } });
 
                 Assert.True(extensionWatcherCalled);
             }
+        }
+
+        [Fact]
+        // This is specifically added to workaround VScode broken file remove notifications on folder removals/moves/renames.
+        // It's by design at VsCode and will probably not get fixed any time soon if ever.
+        public async Task TestThatOnFolderRemovalFilesUnderFolderAreRemoved()
+        {
+            using (var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectAndSolution"))
+            using (var host = CreateOmniSharpHost(testProject.Directory))
+            {
+                var watcher = host.GetExport<IFileSystemWatcher>();
+
+                var filePath = await AddFile(host);
+
+                await GetRequestHandler(host).Handle(new[] { new FilesChangedRequest() { FileName = Path.GetDirectoryName(filePath), ChangeType = FileChangeType.DirectoryDelete } });
+
+                Assert.DoesNotContain(host.Workspace.CurrentSolution.Projects.First().Documents, d => d.FilePath == filePath && d.Name == Path.GetFileName(filePath));
+            }
+        }
+
+        private async Task<string> AddFile(OmniSharpTestHost host)
+        {
+            var projectDirectory = Path.GetDirectoryName(host.Workspace.CurrentSolution.Projects.First().FilePath);
+            const string filename = "FileName.cs";
+            var filePath = Path.Combine(projectDirectory, filename);
+            File.WriteAllText(filePath, "text");
+            await GetRequestHandler(host).Handle(new[] { new FilesChangedRequest() { FileName = filePath, ChangeType = FileChangeType.Create } });
+            return filePath;
         }
     }
 }


### PR DESCRIPTION
VSCode has issue (however by design at current version) where removed folders doesn't send any notifications of removed files because file watcher has some kind of performance optimizations to ignore them.

However watching folders removal is possible. This PR adds support for omnishar-roslyn side so clients can notify removed directory instead of single files if needed -> which can be impelemented properly with current VSCode file watcher.

This fixes one of most common issue that requires omnisharp restart on any directory rename/move/... operation.

Vscode side implementation: https://github.com/OmniSharp/omnisharp-vscode/pull/3829