### PR TITLE
Allow client to specify symbol filter for FindSymbols Endpoint.

### DIFF
--- a/src/OmniSharp.Abstractions/Models/v1/FindSymbols/FindSymbolsRequest.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/FindSymbols/FindSymbolsRequest.cs
@@ -9,5 +9,6 @@ namespace OmniSharp.Models.FindSymbols
         public string Filter { get; set; }
         public int? MinFilterLength { get; set; }
         public int? MaxItemsToReturn { get; set; }
+        public OmniSharpSymbolFilter? SymbolFilter { get; set; }
     }
 }

--- a/src/OmniSharp.Abstractions/Models/v1/FindSymbols/OmniSharpSymbolFilter.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/FindSymbols/OmniSharpSymbolFilter.cs
@@ -9,7 +9,7 @@ namespace OmniSharp.Models.FindSymbols
         Namespace = 1,
         Type = 2,
         Member = 4,
-        TypeAndMember = 6,
-        All = 7,
+        TypeAndMember = Type | Member,
+        All = Type | Member | Namespace,
     }
 }

--- a/src/OmniSharp.Abstractions/Models/v1/FindSymbols/OmniSharpSymbolFilter.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/FindSymbols/OmniSharpSymbolFilter.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace OmniSharp.Models.FindSymbols
+{
+    [Flags]
+    public enum OmniSharpSymbolFilter
+    {
+        None = 0,
+        Namespace = 1,
+        Type = 2,
+        Member = 4,
+        TypeAndMember = 6,
+        All = 7,
+    }
+}

--- a/src/OmniSharp.Cake/Services/RequestHandlers/Navigation/FindSymbolsHandler.cs
+++ b/src/OmniSharp.Cake/Services/RequestHandlers/Navigation/FindSymbolsHandler.cs
@@ -26,8 +26,9 @@ namespace OmniSharp.Cake.Services.RequestHandlers.Navigation
                 return Task.FromResult(new QuickFixResponse { QuickFixes = Array.Empty<QuickFix>() });
             }
 
+            var symbolFilter = (Microsoft.CodeAnalysis.SymbolFilter)(request?.SymbolFilter ?? OmniSharpSymbolFilter.TypeAndMember);
             int maxItemsToReturn = (request?.MaxItemsToReturn).GetValueOrDefault();
-            return Workspace.CurrentSolution.FindSymbols(request?.Filter, LanguageNames.Cake, maxItemsToReturn);
+            return Workspace.CurrentSolution.FindSymbols(request?.Filter, LanguageNames.Cake, maxItemsToReturn, symbolFilter);
         }
 
         protected override Task<QuickFixResponse> TranslateResponse(QuickFixResponse response, FindSymbolsRequest request)

--- a/src/OmniSharp.Cake/Services/RequestHandlers/Navigation/FindSymbolsHandler.cs
+++ b/src/OmniSharp.Cake/Services/RequestHandlers/Navigation/FindSymbolsHandler.cs
@@ -7,6 +7,7 @@ using OmniSharp.Mef;
 using OmniSharp.Models;
 using OmniSharp.Models.FindSymbols;
 using static OmniSharp.Cake.Constants;
+using SymbolFilter = Microsoft.CodeAnalysis.SymbolFilter;
 
 namespace OmniSharp.Cake.Services.RequestHandlers.Navigation
 {
@@ -26,7 +27,7 @@ namespace OmniSharp.Cake.Services.RequestHandlers.Navigation
                 return Task.FromResult(new QuickFixResponse { QuickFixes = Array.Empty<QuickFix>() });
             }
 
-            var symbolFilter = (Microsoft.CodeAnalysis.SymbolFilter)(request?.SymbolFilter ?? OmniSharpSymbolFilter.TypeAndMember);
+            var symbolFilter = (SymbolFilter)(request?.SymbolFilter ?? OmniSharpSymbolFilter.TypeAndMember);
             int maxItemsToReturn = (request?.MaxItemsToReturn).GetValueOrDefault();
             return Workspace.CurrentSolution.FindSymbols(request?.Filter, LanguageNames.Cake, maxItemsToReturn, symbolFilter);
         }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindSymbolsService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindSymbolsService.cs
@@ -28,9 +28,10 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                 return new QuickFixResponse { QuickFixes = Array.Empty<QuickFix>() };
             }
 
+            var symbolFilter = (SymbolFilter)(request?.SymbolFilter ?? OmniSharpSymbolFilter.TypeAndMember);
             int maxItemsToReturn = (request?.MaxItemsToReturn).GetValueOrDefault();
-            var csprojSymbols = await _workspace.CurrentSolution.FindSymbols(request?.Filter, ".csproj", maxItemsToReturn);
-            var csxSymbols = await _workspace.CurrentSolution.FindSymbols(request?.Filter, ".csx", maxItemsToReturn);
+            var csprojSymbols = await _workspace.CurrentSolution.FindSymbols(request?.Filter, ".csproj", maxItemsToReturn, symbolFilter);
+            var csxSymbols = await _workspace.CurrentSolution.FindSymbols(request?.Filter, ".csx", maxItemsToReturn, symbolFilter);
             return new QuickFixResponse()
             {
                 QuickFixes = csprojSymbols.QuickFixes.Concat(csxSymbols.QuickFixes)

--- a/src/OmniSharp.Roslyn/Extensions/SolutionExtensions.cs
+++ b/src/OmniSharp.Roslyn/Extensions/SolutionExtensions.cs
@@ -13,7 +13,8 @@ namespace OmniSharp.Extensions
         public static async Task<QuickFixResponse> FindSymbols(this Solution solution,
             string pattern,
             string projectFileExtension,
-            int maxItemsToReturn)
+            int maxItemsToReturn,
+            SymbolFilter symbolFilter = SymbolFilter.TypeAndMember)
         {
             var projects = solution.Projects.Where(p =>
                 (p.FilePath?.EndsWith(projectFileExtension, StringComparison.OrdinalIgnoreCase) ?? false) ||
@@ -24,8 +25,8 @@ namespace OmniSharp.Extensions
             foreach (var project in projects)
             {
                 var symbols = !string.IsNullOrEmpty(pattern) ?
-                    await SymbolFinder.FindSourceDeclarationsWithPatternAsync(project, pattern, SymbolFilter.TypeAndMember) :
-                    await SymbolFinder.FindSourceDeclarationsAsync(project, candidate => true, SymbolFilter.TypeAndMember);
+                    await SymbolFinder.FindSourceDeclarationsWithPatternAsync(project, pattern, symbolFilter) :
+                    await SymbolFinder.FindSourceDeclarationsAsync(project, candidate => true, symbolFilter);
 
                 foreach (var symbol in symbols)
                 {


### PR DESCRIPTION
FindSymbols Endpoint now exposes a `SymbolFilter` Property. This enables the Client to specify what Symbols he is interested in. Previously `SymbolFilter.TypeAndMember` was used by default. Especially in larger projects this results in poor performance.