### PR TITLE
Do not crash when plugin assembly cannot be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to the project will be documented in this file.
 * Added LSP handler for `textDocument/codeAction` request. (PR: [#1795](https://github.com/OmniSharp/omnisharp-roslyn/pull/1795))
 * Expose a custom LSP `omnisharp/client/findReferences` command via code lens (meant to be handled by LSP client). (PR: [#1807](https://github.com/OmniSharp/omnisharp-roslyn/pull/1807))
 * Added `DirectoryDelete` option to `FileChangeType` allowing clients to report deleted directories that need to be removed (along all the files) from the workspace (PR: [#1821](https://github.com/OmniSharp/omnisharp-roslyn/pull/1821))
+* Do not crash when plugin assembly cannot be loaded ([#1307](https://github.com/OmniSharp/omnisharp-roslyn/issues/1307), PR: [#1827](https://github.com/OmniSharp/omnisharp-roslyn/pull/1827))
 
 ## [1.35.2] - 2020-05-20
 * Added support for `WarningsAsErrors` in csproj files (PR: [#1779](https://github.com/OmniSharp/omnisharp-roslyn/pull/1779))

--- a/src/OmniSharp.Abstractions/Plugins/PluginAssemblies.cs
+++ b/src/OmniSharp.Abstractions/Plugins/PluginAssemblies.cs
@@ -4,13 +4,11 @@ namespace OmniSharp.Plugins
 {
     public class PluginAssemblies
     {
-        private readonly IEnumerable<string> _assemblyNames;
-
         public PluginAssemblies(IEnumerable<string> assemblyNames)
         {
-            _assemblyNames = assemblyNames;
+            AssemblyNames = assemblyNames;
         }
 
-        public IEnumerable<string> AssemblyNames { get { return _assemblyNames; } }
+        public IEnumerable<string> AssemblyNames { get; }
     }
 }

--- a/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
+++ b/src/OmniSharp.Abstractions/Services/IAssemblyLoader.cs
@@ -55,7 +55,7 @@ namespace OmniSharp.Services
             }
         }
 
-        public static IEnumerable<Assembly> LoadByAssemblyNameOrPath(this IAssemblyLoader loader, ILogger logger, IEnumerable<string>  assemblyNames)
+        public static IEnumerable<Assembly> LoadByAssemblyNameOrPath(this IAssemblyLoader loader, ILogger logger, IEnumerable<string> assemblyNames)
         {
             foreach (var assemblyName in assemblyNames)
             {

--- a/src/OmniSharp.Host/CompositionHostBuilder.cs
+++ b/src/OmniSharp.Host/CompositionHostBuilder.cs
@@ -86,6 +86,7 @@ namespace OmniSharp
             }
 
             var parts = _assemblies
+                .Where(a => a != null)
                 .Concat(new[] { typeof(OmniSharpWorkspace).GetTypeInfo().Assembly, typeof(IRequest).GetTypeInfo().Assembly, typeof(FileSystemHelper).GetTypeInfo().Assembly })
                 .Distinct()
                 .SelectMany(a => SafeGetTypes(a))


### PR DESCRIPTION
Fixes #1307 

The assembly loader returns null when an assembly cannot be loaded by name, which - at the moment - would lead to a null reference exception when starting OmniSharp.