### PR TITLE
The buildscript configuration parameter default value is is Debug

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -34,7 +34,7 @@ Note: The arguments below should prefixed with a single hyphen on Windows (Power
     Defaults to `Default`.
 
   `-configuration (Release|Debug)`: The configuration to build.
-    Defaults to `Release`.
+    Defaults to `Debug`.
 
   `-test-configuration (Release|Debug)`: The configuration to use for the unit tests.
     Defaults to `Debug`.


### PR DESCRIPTION
The Build-Readme still had Release as default.