### PR TITLE
only select MSBuild from VS if .NET SDK Resolvers are present 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to the project will be documented in this file.
 
 ## [1.35.4] - Not yet released
 * Added LSP handler for the `workspace/symbol` request. (PR: [#1799](https://github.com/OmniSharp/omnisharp-roslyn/pull/1799))
+* Do not use Visual Studio MSBuild if it doesn't have .NET SDK resolver ([#1842](https://github.com/OmniSharp/omnisharp-roslyn/issues/1842), [#1730](https://github.com/OmniSharp/omnisharp-roslyn/issues/1730), PR: [#1845](https://github.com/OmniSharp/omnisharp-roslyn/pull/1845))
 
 ## [1.35.3] - 2020-06-11
 * Added LSP handler for `textDocument/codeAction` request. (PR: [#1795](https://github.com/OmniSharp/omnisharp-roslyn/pull/1795))

--- a/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
@@ -96,16 +96,16 @@ namespace OmniSharp.MSBuild.Discovery
             if (i.DiscoveryType == DiscoveryType.UserOverride)
                 return int.MaxValue;
 
+            if (i.IsInvalidVisualStudio())
+                return int.MinValue;
+            else
+                score++;
+
             // dotnet SDK resolvers are mandatory to use a VS instance
             if (i.HasDotNetSdksResolvers())
                 score++;
             else
                 return int.MinValue;
-
-            if (i.IsInvalidVisualStudio())
-                return int.MinValue;
-            else
-                score++;
 
             if (i.DiscoveryType == DiscoveryType.StandAlone)
                 score--;

--- a/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
@@ -16,8 +16,8 @@ namespace OmniSharp.MSBuild.Discovery
                 if (invalidVSFound && bestInstanceFound.DiscoveryType == DiscoveryType.StandAlone)
                 {
                     logger.LogWarning(
-                        @"It looks like you have Visual Studio 2019 lower than 16.3 installed.
- Try updating Visual Studio 2019 to the most recent release to enable better MSBuild support."
+                        @"It looks like you have Visual Studio lower than VS 2019 16.3 installed.
+ Try updating Visual Studio to the most recent release to enable better MSBuild support."
                     );
                 }
 

--- a/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
@@ -195,22 +195,24 @@ namespace OmniSharp.MSBuild.Tests
             msbuildLocator.DeleteFakeInstancesFolders();
         }
 
-        [Fact]
-        public void RegisterDefaultInstancePrefersStandAloneOverSupportedVSLowerVersionInstanceWithoutDotnetCore()
+        [Theory]
+        [InlineData("16.2.2.3")] // lower than standalone
+        [InlineData("16.6.2.3")] // higher than standalone
+        public void RegisterDefaultInstancePrefersStandAloneOverSupportedVSInstanceWithoutDotnetCore(string vsVersion)
         {
             var msBuildInstances = new[]
             {
                 new MSBuildInstance(
                     "Test Instance",
                     TestIO.GetRandomTempFolderPath(),
-                    Version.Parse("16.2.2.3"),
+                    Version.Parse(vsVersion),
                     DiscoveryType.VisualStudioSetup
                 ),
                 GetStandAloneMSBuildInstance()
             };
 
             var msbuildLocator = new MSFakeLocator(msBuildInstances);
-            var logger = LoggerFactory.CreateLogger(nameof(RegisterDefaultInstancePrefersStandAloneOverSupportedVSLowerVersionInstanceWithoutDotnetCore));
+            var logger = LoggerFactory.CreateLogger(nameof(RegisterDefaultInstancePrefersStandAloneOverSupportedVSInstanceWithoutDotnetCore));
 
             // test
             msbuildLocator.RegisterDefaultInstance(logger);

--- a/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
@@ -226,6 +226,7 @@ namespace OmniSharp.MSBuild.Tests
 
         [Theory]
         [InlineData("15.1.2.3")]
+        [InlineData("15.9.2.3")]
         [InlineData("16.1.2.3")]
         [InlineData("16.2.2.3")]
         public void StandAloneIsPreferredOverUnsupportedVS(string vsVersion)


### PR DESCRIPTION
This is an aggressive change, similar to when we dropped VS < 16.3 to support .NET core better, one that I believe is necessary to improve user experience.

**We will no longer select MSBuild from VS instance, if that instance doesn't have .NET SDK resolvers**. The rationale is that vast majority of users want to use new SDK based projects, and not having it along the selected MSBuild instance currently leads into a broken state without much info of what went wrong. 

If someone is negatively affected - doesn't need .NET SDK (old style projects, unity) and now gets shifted to stand alone instance, they can still use the MSBuild override feature. This is similar to what we recommended to VS 2017 users back in the day. 

Additionally, I improved the warning messages:
 - we now print a warning that you have VS version that is <16.3 and ask you to upgrade
 - we now print a warning that you have a VS version that is >= 16.3 but without .NET SDK and ask you to update that

Hopefully this will improve the ability for users to "self troubleshoot" the issues.

Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1842 
Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1730 

and several other `Microsoft.Build.Exceptions.InvalidProjectFileException: The SDK 'Microsoft.NET.Sdk' specified could not be found.` **on Windows**.
