### PR TITLE
use global property when resetting TargetFramework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to the project will be documented in this file.
 
 ## [1.35.4] - Not yet released
 * Added LSP handler for the `workspace/symbol` request. (PR: [#1799](https://github.com/OmniSharp/omnisharp-roslyn/pull/1799))
+* Use global MSBuild property when resetting target framework ([#1738](https://github.com/OmniSharp/omnisharp-roslyn/issues/1738), PR: [#1846](https://github.com/OmniSharp/omnisharp-roslyn/pull/1846))
 
 ## [1.35.3] - 2020-06-11
 * Added LSP handler for `textDocument/codeAction` request. (PR: [#1795](https://github.com/OmniSharp/omnisharp-roslyn/pull/1795))

--- a/src/OmniSharp.MSBuild/ProjectLoader.cs
+++ b/src/OmniSharp.MSBuild/ProjectLoader.cs
@@ -148,7 +148,7 @@ namespace OmniSharp.MSBuild
                 // For now, we'll just pick the first target framework. Eventually, we'll need to
                 // do better and potentially allow OmniSharp hosts to select a target framework.
                 targetFramework = targetFrameworks[0];
-                evaluatedProject.SetProperty(PropertyNames.TargetFramework, targetFramework);
+                evaluatedProject.SetGlobalProperty(PropertyNames.TargetFramework, targetFramework);
                 evaluatedProject.ReevaluateIfNecessary();
             }
         }


### PR DESCRIPTION
see: https://github.com/dotnet/runtime/issues/33427#issuecomment-597634844
fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1738