### PR TITLE
Optional telemetry gathering

### DIFF
--- a/src/OmniSharp.Abstractions/IOmniSharpEnvironment.cs
+++ b/src/OmniSharp.Abstractions/IOmniSharpEnvironment.cs
@@ -10,6 +10,6 @@ namespace OmniSharp
         string SolutionFilePath { get; }
         string SharedDirectory { get; }
         string[] AdditionalArguments { get; }
-        bool NoTelemetryInfo { get; }
+        bool WantTelemetryInfo { get; }
     }
 }

--- a/src/OmniSharp.Abstractions/IOmniSharpEnvironment.cs
+++ b/src/OmniSharp.Abstractions/IOmniSharpEnvironment.cs
@@ -10,5 +10,6 @@ namespace OmniSharp
         string SolutionFilePath { get; }
         string SharedDirectory { get; }
         string[] AdditionalArguments { get; }
+        bool NoTelemetryInfo { get; }
     }
 }

--- a/src/OmniSharp.Host/CommandLineApplication.cs
+++ b/src/OmniSharp.Host/CommandLineApplication.cs
@@ -21,6 +21,7 @@ namespace OmniSharp
         private readonly CommandOption _logLevel;
         private readonly CommandOption _applicationRoot;
         private readonly CommandOption _debug;
+        private readonly CommandOption _noTelemetryInfo;
 
         public CommandLineApplication()
         {
@@ -34,6 +35,7 @@ namespace OmniSharp
             _zeroBasedIndices = Application.Option("-z | --zero-based-indices", "Use zero based indices in request/responses (defaults to 'false').", CommandOptionType.NoValue);
             _plugin = Application.Option("-pl | --plugin", "Plugin name(s).", CommandOptionType.MultipleValue);
             _debug = Application.Option("-d | --debug", "Wait for debugger to attach", CommandOptionType.NoValue);
+            _noTelemetryInfo = Application.Option("-nt | --no-telemetry-info", "Do not gather extra telemetry information", CommandOptionType.NoValue);
         }
 
         public int Execute(string[] args)
@@ -105,5 +107,7 @@ namespace OmniSharp
                 }
             }
         }
+
+        public bool NoTelemetryInfo => _noTelemetryInfo.HasValue();
     }
 }

--- a/src/OmniSharp.Host/CommandLineApplication.cs
+++ b/src/OmniSharp.Host/CommandLineApplication.cs
@@ -21,7 +21,7 @@ namespace OmniSharp
         private readonly CommandOption _logLevel;
         private readonly CommandOption _applicationRoot;
         private readonly CommandOption _debug;
-        private readonly CommandOption _noTelemetryInfo;
+        private readonly CommandOption _wantTelemetryInfo;
 
         public CommandLineApplication()
         {
@@ -35,7 +35,7 @@ namespace OmniSharp
             _zeroBasedIndices = Application.Option("-z | --zero-based-indices", "Use zero based indices in request/responses (defaults to 'false').", CommandOptionType.NoValue);
             _plugin = Application.Option("-pl | --plugin", "Plugin name(s).", CommandOptionType.MultipleValue);
             _debug = Application.Option("-d | --debug", "Wait for debugger to attach", CommandOptionType.NoValue);
-            _noTelemetryInfo = Application.Option("-nt | --no-telemetry-info", "Do not gather extra telemetry information", CommandOptionType.NoValue);
+            _wantTelemetryInfo = Application.Option("-wt | --want-telemetry-info", "Gather extra telemetry information", CommandOptionType.NoValue);
         }
 
         public int Execute(string[] args)
@@ -108,6 +108,6 @@ namespace OmniSharp
             }
         }
 
-        public bool NoTelemetryInfo => _noTelemetryInfo.HasValue();
+        public bool WantTelemetryInfo => _wantTelemetryInfo.HasValue();
     }
 }

--- a/src/OmniSharp.Host/CommandLineApplicationExtensions.cs
+++ b/src/OmniSharp.Host/CommandLineApplicationExtensions.cs
@@ -13,7 +13,8 @@ namespace OmniSharp
                 application.ApplicationRoot,
                 application.HostPid,
                 application.LogLevel,
-                application.OtherArgs.ToArray<string>());
+                application.OtherArgs.ToArray<string>(),
+                application.NoTelemetryInfo);
         }
 
         public static PluginAssemblies CreatePluginAssemblies(this CommandLineApplication application,

--- a/src/OmniSharp.Host/CommandLineApplicationExtensions.cs
+++ b/src/OmniSharp.Host/CommandLineApplicationExtensions.cs
@@ -14,7 +14,7 @@ namespace OmniSharp
                 application.HostPid,
                 application.LogLevel,
                 application.OtherArgs.ToArray<string>(),
-                application.NoTelemetryInfo);
+                application.WantTelemetryInfo);
         }
 
         public static PluginAssemblies CreatePluginAssemblies(this CommandLineApplication application,

--- a/src/OmniSharp.Host/Services/OmniSharpEnvironment.cs
+++ b/src/OmniSharp.Host/Services/OmniSharpEnvironment.cs
@@ -12,12 +12,14 @@ namespace OmniSharp.Services
         public int HostProcessId { get; }
         public LogLevel LogLevel { get; }
         public string[] AdditionalArguments { get; }
+        public bool NoTelemetryInfo { get; }
 
         public OmniSharpEnvironment(
             string path = null,
             int hostPid = -1,
             LogLevel logLevel = LogLevel.None,
-            string[] additionalArguments = null)
+            string[] additionalArguments = null,
+            bool noTelemetryInfo = false)
         {
             if (string.IsNullOrEmpty(path))
             {
@@ -40,6 +42,7 @@ namespace OmniSharp.Services
 
             HostProcessId = hostPid;
             LogLevel = logLevel;
+            NoTelemetryInfo = noTelemetryInfo;
             AdditionalArguments = additionalArguments;
 
             // First look at OMNISHARPHOME to allow users to set custom location, then

--- a/src/OmniSharp.Host/Services/OmniSharpEnvironment.cs
+++ b/src/OmniSharp.Host/Services/OmniSharpEnvironment.cs
@@ -12,14 +12,14 @@ namespace OmniSharp.Services
         public int HostProcessId { get; }
         public LogLevel LogLevel { get; }
         public string[] AdditionalArguments { get; }
-        public bool NoTelemetryInfo { get; }
+        public bool WantTelemetryInfo { get; }
 
         public OmniSharpEnvironment(
             string path = null,
             int hostPid = -1,
             LogLevel logLevel = LogLevel.None,
             string[] additionalArguments = null,
-            bool noTelemetryInfo = false)
+            bool wantTelemetryInfo = false)
         {
             if (string.IsNullOrEmpty(path))
             {
@@ -42,7 +42,7 @@ namespace OmniSharp.Services
 
             HostProcessId = hostPid;
             LogLevel = logLevel;
-            NoTelemetryInfo = noTelemetryInfo;
+            WantTelemetryInfo = wantTelemetryInfo;
             AdditionalArguments = additionalArguments;
 
             // First look at OMNISHARPHOME to allow users to set custom location, then

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -95,7 +95,7 @@ namespace OmniSharp.MSBuild.ProjectFile
             var id = ProjectId.CreateNewId(debugName: filePath);
             var project = loader.EvaluateProjectFile(filePath);
 
-            var dotNetInfo = dotNetCli.GetInfo(Path.GetDirectoryName(project.FullPath));
+            var dotNetInfo = dotNetCli?.GetInfo(Path.GetDirectoryName(project.FullPath)) ?? DotNetInfo.Empty;
             var data = ProjectData.Create(project);
             //we are not reading the solution here
             var projectIdInfo = new ProjectIdInfo(id, isDefinedInSolution: false);
@@ -116,7 +116,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 return (null, diagnostics, null);
             }
 
-            var dotNetInfo = dotNetCli.GetInfo(Path.GetDirectoryName(projectInstance.FullPath));
+            var dotNetInfo = dotNetCli?.GetInfo(Path.GetDirectoryName(projectInstance.FullPath)) ?? DotNetInfo.Empty;
 
             var data = ProjectData.Create(projectInstance);
             var projectFileInfo = new ProjectFileInfo(projectIdInfo, filePath, data, sessionId, dotNetInfo);

--- a/src/OmniSharp.MSBuild/ProjectLoadListener.cs
+++ b/src/OmniSharp.MSBuild/ProjectLoadListener.cs
@@ -87,7 +87,7 @@ namespace OmniSharp.MSBuild
 
         private static HashedString GetSdkVersion(ProjectLoadedEventArgs args)
         {
-            return _tfmAndFileHashingAlgorithm.HashInput(args.SdkVersion.ToString());
+            return _tfmAndFileHashingAlgorithm.HashInput(args.SdkVersion?.ToString() ?? "");
         }
 
         private static HashedString GetSessionId(ProjectLoadedEventArgs args)

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -102,7 +102,8 @@ namespace OmniSharp.MSBuild
             _packageDependencyChecker = new PackageDependencyChecker(_loggerFactory, _eventEmitter, _dotNetCli, _options);
             _loader = new ProjectLoader(_options, _environment.TargetDirectory, _propertyOverrides, _loggerFactory, _sdksPathResolver);
 
-            _manager = new ProjectManager(_loggerFactory, _options, _eventEmitter, _fileSystemWatcher, _metadataFileReferenceCache, _packageDependencyChecker, _loader, _workspace, _assemblyLoader, _eventSinks, _dotNetCli);
+            var dotNetCli = !_environment.NoTelemetryInfo ? _dotNetCli : null;
+            _manager = new ProjectManager(_loggerFactory, _options, _eventEmitter, _fileSystemWatcher, _metadataFileReferenceCache, _packageDependencyChecker, _loader, _workspace, _assemblyLoader, _eventSinks, dotNetCli);
             Initialized = true;
 
             if (_options.LoadProjectsOnDemand)

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -102,7 +102,7 @@ namespace OmniSharp.MSBuild
             _packageDependencyChecker = new PackageDependencyChecker(_loggerFactory, _eventEmitter, _dotNetCli, _options);
             _loader = new ProjectLoader(_options, _environment.TargetDirectory, _propertyOverrides, _loggerFactory, _sdksPathResolver);
 
-            var dotNetCli = !_environment.NoTelemetryInfo ? _dotNetCli : null;
+            var dotNetCli = _environment.WantTelemetryInfo ? _dotNetCli : null;
             _manager = new ProjectManager(_loggerFactory, _options, _eventEmitter, _fileSystemWatcher, _metadataFileReferenceCache, _packageDependencyChecker, _loader, _workspace, _assemblyLoader, _eventSinks, dotNetCli);
             Initialized = true;
 

--- a/tests/OmniSharp.MSBuild.Tests/AbstractMSBuildTestFixture.cs
+++ b/tests/OmniSharp.MSBuild.Tests/AbstractMSBuildTestFixture.cs
@@ -37,7 +37,7 @@ namespace OmniSharp.MSBuild.Tests
         protected OmniSharpTestHost CreateMSBuildTestHost(string path, IEnumerable<ExportDescriptorProvider> additionalExports = null,
             IEnumerable<KeyValuePair<string, string>> configurationData = null)
         {
-            var environment = new OmniSharpEnvironment(path, logLevel: LogLevel.Trace);
+            var environment = new OmniSharpEnvironment(path, logLevel: LogLevel.Trace, wantTelemetryInfo: true);
             var serviceProvider = TestServiceProvider.Create(this.TestOutput, environment, this.LoggerFactory, _assemblyLoader, _analyzerAssemblyLoader, _msbuildLocator,
                 configurationData);
 


### PR DESCRIPTION
This PR adds command-line flag `-wt`/`--want-telemetry-info` to request calling `dotnet --info` for telemetry purposes, and to otherwise _not_ gather this information. Fetching this data slows OmniSharp-roslyn startup, and fails in certain circumstances (see #1844).

The essence of the PR is that the `--want-telemetry-info` flag is included in `OmniSharpEnvironment`, and when it is not set, the `_dotNetCli` service is not passed in to [ProjectManager](https://github.com/OmniSharp/omnisharp-roslyn/compare/master...nickspoons:optional-telemetry-gathering?expand=1#diff-63fe9836b6472be5b5ab510254cf5bb5R105-R106). This essentially undoes the effects of PR #1820, which is where the `_dotNetCli` service began being passed in to `ProjectManager`.

cc @filipw (commenter on #1844) and @JoeRobich (author of #1820) - does this look like the right fix? Would you rather we look at doing it a different way?

~~Note that this new flag is to opt-**out** of extra info being collected. We discussed opting-**in** in #1844 but that is more complicated as it involves changes on the VScode side, which I'm not familiar with. (This PR requires changes on the Vim side, (which I can make) - as well as any other editors which choose to opt out).~~

**Edit**: the `-nt`/`--no-telemetry-info`  opt-out flags have now been changed to opt-in flags, `-wt`/`--want-telemetry-info`

Fixes #1844 