### PR TITLE
upgraded to Mono 6.10.0.105, msbuild 16.6 and added missing targets

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
       vmImage: "macOS-10.15"
     dependsOn: GitVersion
     variables:
-      MONO_VERSION: 6.8.0
+      MONO_VERSION: 6.10.0
     steps:
       - template: ./.pipelines/init.yml
         parameters:
@@ -79,7 +79,7 @@ jobs:
       vmImage: "Ubuntu-18.04"
     dependsOn: GitVersion
     variables:
-      MONO_VERSION: 6.8.0
+      MONO_VERSION: 6.10.0
     steps:
       - template: ./.pipelines/init.yml
         parameters:
@@ -90,7 +90,7 @@ jobs:
       - script: |
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           sudo apt install apt-transport-https ca-certificates
-          echo "deb https://download.mono-project.com/repo/ubuntu stable-xenial/snapshots/$MONO_VERSION.105 main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic/snapshots/$MONO_VERSION.105 main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
           sudo apt update
           sudo apt install mono-devel
           sudo apt install msbuild

--- a/build.cake
+++ b/build.cake
@@ -225,7 +225,9 @@ Task("CreateMSBuildFolder")
         "Microsoft.CSharp.Mono.targets",
         "Microsoft.CSharp.targets",
         "Microsoft.Data.Entity.targets",
+        "Microsoft.Managed.After.targets
         "Microsoft.Managed.targets",
+        "Microsoft.Managed.Before.targets",
         "Microsoft.NET.props",
         "Microsoft.NETFramework.CurrentVersion.props",
         "Microsoft.NETFramework.CurrentVersion.targets",

--- a/build.cake
+++ b/build.cake
@@ -225,7 +225,7 @@ Task("CreateMSBuildFolder")
         "Microsoft.CSharp.Mono.targets",
         "Microsoft.CSharp.targets",
         "Microsoft.Data.Entity.targets",
-        "Microsoft.Managed.After.targets
+        "Microsoft.Managed.After.targets",
         "Microsoft.Managed.targets",
         "Microsoft.Managed.Before.targets",
         "Microsoft.NET.props",

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -3,7 +3,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <MSBuildPackageVersion>16.5.0</MSBuildPackageVersion>
+    <MSBuildPackageVersion>16.6.0</MSBuildPackageVersion>
     <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
     <RoslynPackageVersion>3.8.0-1.20357.3</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Cake" version="0.37.0" />
-    <package id="Microsoft.Build" version="16.5.0" />
-    <package id="Microsoft.Build.Framework" version="16.5.0" />
-    <package id="Microsoft.Build.Runtime" version="16.5.0" />
-    <package id="Microsoft.Build.Tasks.Core" version="16.5.0" />
-    <package id="Microsoft.Build.Utilities.Core" version="16.5.0" />
+    <package id="Microsoft.Build" version="16.6.0" />
+    <package id="Microsoft.Build.Framework" version="16.6.0" />
+    <package id="Microsoft.Build.Runtime" version="16.6.0" />
+    <package id="Microsoft.Build.Tasks.Core" version="16.6.0" />
+    <package id="Microsoft.Build.Utilities.Core" version="16.6.0" />
     <package id="Microsoft.Net.Compilers" version="3.5.0" />
     <package id="Microsoft.DotNet.MSBuildSdkResolver" version="3.1.200-preview.20126.2" />
     <package id="Microsoft.Build.NuGetSdkResolver" version="5.6.0-preview.2.6508" />


### PR DESCRIPTION
Mono 6.10.0 is stable now. MsBuild 16.6 is also stable and the missing targets fix the currently broken build on Linux.
@JoeRobich after this is merged could you please also upgrade the embedded mono ZIPs that get downloaded at build time as dependencies? thanks