### PR TITLE
Updated .NET 5 tests to use 5.0.100-preview.7.20366.6

### DIFF
--- a/build.json
+++ b/build.json
@@ -3,7 +3,7 @@
     "DotNetChannel": "Preview",
     "DotNetVersions": [
         "3.1.201",
-        "5.0.100-preview.6.20318.15"
+        "5.0.100-preview.7.20366.6"
     ],
     "RequiredMonoVersion": "6.6.0",
     "DownloadURL": "https://roslynomnisharp.blob.core.windows.net/ext",

--- a/test-assets/test-projects/Net50Project/global.json
+++ b/test-assets/test-projects/Net50Project/global.json
@@ -1,5 +1,5 @@
 {
     "sdk": {
-        "version": "5.0.100-preview.6.20318.15"
+        "version": "5.0.100-preview.7.20366.6"
     }
 }

--- a/tests/OmniSharp.MSBuild.Tests/ProjectLoadListenerTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectLoadListenerTests.cs
@@ -238,7 +238,7 @@ namespace OmniSharp.MSBuild.Tests
             using (var host = CreateMSBuildTestHost(testProject.Directory, emitter.AsExportDescriptionProvider(LoggerFactory)))
             {
                 Assert.Equal(2, emitter.ReceivedMessages.Length);
-                Assert.Equal(GetHashedFileExtension("5.0.100-preview.6.20318.15"), emitter.ReceivedMessages[0].SdkVersion);
+                Assert.Equal(GetHashedFileExtension("5.0.100-preview.7.20366.6"), emitter.ReceivedMessages[0].SdkVersion);
             }
         }
 


### PR DESCRIPTION
It was released a couple of hours ago, we should be up to date