### PR TITLE
Only request dotnet info once for the solution or directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All changes to the project will be documented in this file.
 * Added LSP handler for the `workspace/symbol` request. (PR: [#1799](https://github.com/OmniSharp/omnisharp-roslyn/pull/1799))
 * Use global MSBuild property when resetting target framework ([#1738](https://github.com/OmniSharp/omnisharp-roslyn/issues/1738), PR: [#1846](https://github.com/OmniSharp/omnisharp-roslyn/pull/1846))
 * Do not use Visual Studio MSBuild if it doesn't have .NET SDK resolver ([#1842](https://github.com/OmniSharp/omnisharp-roslyn/issues/1842), [#1730](https://github.com/OmniSharp/omnisharp-roslyn/issues/1730), PR: [#1845](https://github.com/OmniSharp/omnisharp-roslyn/pull/1845))
+* Only request dotnet info once for the solution or directory ([#1844](https://github.com/OmniSharp/omnisharp-roslyn/issues/1844), PR: [#1857](https://github.com/OmniSharp/omnisharp-roslyn/pull/1857))
 
 ## [1.35.3] - 2020-06-11
 * Added LSP handler for `textDocument/codeAction` request. (PR: [#1795](https://github.com/OmniSharp/omnisharp-roslyn/pull/1795))

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -90,12 +90,11 @@ namespace OmniSharp.MSBuild.ProjectFile
             return new ProjectFileInfo(new ProjectIdInfo(id, isDefinedInSolution: false), filePath, data: null, sessionId: Guid.NewGuid(), DotNetInfo.Empty);
         }
 
-        internal static ProjectFileInfo CreateNoBuild(string filePath, ProjectLoader loader, IDotNetCliService dotNetCli)
+        internal static ProjectFileInfo CreateNoBuild(string filePath, ProjectLoader loader, DotNetInfo dotNetInfo)
         {
             var id = ProjectId.CreateNewId(debugName: filePath);
             var project = loader.EvaluateProjectFile(filePath);
 
-            var dotNetInfo = dotNetCli.GetInfo(Path.GetDirectoryName(project.FullPath));
             var data = ProjectData.Create(project);
             //we are not reading the solution here
             var projectIdInfo = new ProjectIdInfo(id, isDefinedInSolution: false);
@@ -103,7 +102,7 @@ namespace OmniSharp.MSBuild.ProjectFile
             return new ProjectFileInfo(projectIdInfo, filePath, data, sessionId: Guid.NewGuid(), dotNetInfo);
         }
 
-        public static (ProjectFileInfo, ImmutableArray<MSBuildDiagnostic>, ProjectLoadedEventArgs) Load(string filePath, ProjectIdInfo projectIdInfo, ProjectLoader loader, Guid sessionId, IDotNetCliService dotNetCli)
+        public static (ProjectFileInfo, ImmutableArray<MSBuildDiagnostic>, ProjectLoadedEventArgs) Load(string filePath, ProjectIdInfo projectIdInfo, ProjectLoader loader, Guid sessionId, DotNetInfo dotNetInfo)
         {
             if (!File.Exists(filePath))
             {
@@ -115,8 +114,6 @@ namespace OmniSharp.MSBuild.ProjectFile
             {
                 return (null, diagnostics, null);
             }
-
-            var dotNetInfo = dotNetCli.GetInfo(Path.GetDirectoryName(projectInstance.FullPath));
 
             var data = ProjectData.Create(projectInstance);
             var projectFileInfo = new ProjectFileInfo(projectIdInfo, filePath, data, sessionId, dotNetInfo);

--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -64,7 +64,7 @@ namespace OmniSharp.MSBuild
         private readonly CancellationTokenSource _processLoopCancellation;
         private readonly Task _processLoopTask;
         private readonly IAnalyzerAssemblyLoader _analyzerAssemblyLoader;
-        private readonly IDotNetCliService _dotNetCli;
+        private readonly DotNetInfo _dotNetInfo;
         private bool _processingQueue;
         private readonly Guid _sessionId = Guid.NewGuid();
 
@@ -81,7 +81,7 @@ namespace OmniSharp.MSBuild
             OmniSharpWorkspace workspace,
             IAnalyzerAssemblyLoader analyzerAssemblyLoader,
             ImmutableArray<IMSBuildEventSink> eventSinks,
-            IDotNetCliService dotNetCliService)
+            DotNetInfo dotNetInfo)
         {
             _logger = loggerFactory.CreateLogger<ProjectManager>();
             _options = options ?? new MSBuildOptions();
@@ -95,7 +95,7 @@ namespace OmniSharp.MSBuild
             _projectLoader = projectLoader;
             _workspace = workspace;
             _eventSinks = eventSinks;
-            _dotNetCli = dotNetCliService;
+            _dotNetInfo = dotNetInfo;
             _queue = new BufferBlock<ProjectToUpdate>();
             _processLoopCancellation = new CancellationTokenSource();
             _processLoopTask = Task.Run(() => ProcessLoopAsync(_processLoopCancellation.Token));
@@ -299,7 +299,7 @@ namespace OmniSharp.MSBuild
         }
 
         private (ProjectFileInfo, ProjectLoadedEventArgs) LoadProject(string projectFilePath, ProjectIdInfo idInfo)
-            => LoadOrReloadProject(projectFilePath, () => ProjectFileInfo.Load(projectFilePath, idInfo, _projectLoader, _sessionId, _dotNetCli));
+            => LoadOrReloadProject(projectFilePath, () => ProjectFileInfo.Load(projectFilePath, idInfo, _projectLoader, _sessionId, _dotNetInfo));
 
         private (ProjectFileInfo, ProjectLoadedEventArgs) ReloadProject(ProjectFileInfo projectFileInfo)
             => LoadOrReloadProject(projectFileInfo.FilePath, () => projectFileInfo.Reload(_projectLoader));
@@ -649,7 +649,7 @@ namespace OmniSharp.MSBuild
 
                         // We've found a project reference that we didn't know about already, but it exists on disk.
                         // This is likely a project that is outside of OmniSharp's TargetDirectory.
-                        referencedProject = ProjectFileInfo.CreateNoBuild(projectReferencePath, _projectLoader, _dotNetCli);
+                        referencedProject = ProjectFileInfo.CreateNoBuild(projectReferencePath, _projectLoader, _dotNetInfo);
                         AddProject(referencedProject);
 
                         QueueProjectUpdate(projectReferencePath, allowAutoRestore: true, referencedProject.ProjectIdInfo);

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -102,7 +102,8 @@ namespace OmniSharp.MSBuild
             _packageDependencyChecker = new PackageDependencyChecker(_loggerFactory, _eventEmitter, _dotNetCli, _options);
             _loader = new ProjectLoader(_options, _environment.TargetDirectory, _propertyOverrides, _loggerFactory, _sdksPathResolver);
 
-            _manager = new ProjectManager(_loggerFactory, _options, _eventEmitter, _fileSystemWatcher, _metadataFileReferenceCache, _packageDependencyChecker, _loader, _workspace, _assemblyLoader, _eventSinks, _dotNetCli);
+            var dotNetInfo = GetDotNetInfo();
+            _manager = new ProjectManager(_loggerFactory, _options, _eventEmitter, _fileSystemWatcher, _metadataFileReferenceCache, _packageDependencyChecker, _loader, _workspace, _assemblyLoader, _eventSinks, dotNetInfo);
             Initialized = true;
 
             if (_options.LoadProjectsOnDemand)
@@ -123,6 +124,15 @@ namespace OmniSharp.MSBuild
 
                 _manager.QueueProjectUpdate(projectFilePath, allowAutoRestore: true, projectIdInfo);
             }
+        }
+
+        private DotNetInfo GetDotNetInfo()
+        {
+            var workingDirectory = string.IsNullOrEmpty(_environment.SolutionFilePath)
+                ? _environment.TargetDirectory
+                : Path.GetDirectoryName(_environment.SolutionFilePath);
+
+            return _dotNetCli.GetInfo(workingDirectory);
         }
 
         private IEnumerable<(string, ProjectIdInfo)> GetInitialProjectPathsAndIds()

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -28,7 +28,6 @@ namespace OmniSharp.MSBuild.Tests
         {
             var msbuildLocator = host.GetExport<IMSBuildLocator>();
             var sdksPathResolver = host.GetExport<SdksPathResolver>();
-            var dotNetCli = host.GetExport<IDotNetCliService>();
 
             var loader = new ProjectLoader(
                 options: new MSBuildOptions(),
@@ -38,7 +37,7 @@ namespace OmniSharp.MSBuild.Tests
                 sdksPathResolver: sdksPathResolver);
 
             var projectIdInfo = new ProjectIdInfo(ProjectId.CreateNewId(), false);
-            var (projectFileInfo, _, _) = ProjectFileInfo.Load(projectFilePath, projectIdInfo, loader, sessionId: Guid.NewGuid(), dotNetCli);
+            var (projectFileInfo, _, _) = ProjectFileInfo.Load(projectFilePath, projectIdInfo, loader, sessionId: Guid.NewGuid(), DotNetInfo.Empty);
 
             return projectFileInfo;
         }


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1844

Although each project *could* define their own global.json with differing sdks, in practice there is no need to request dotnet info for each loaded project. 