### PR TITLE
Update Roslyn version and tools to match .NET 5 Preview8

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,8 +5,8 @@
         <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
         <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
         <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+        <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+        <add key="dotnet5-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json" />
         <add key="OmniSharp" value="https://www.myget.org/F/omnisharp/api/v3/index.json" />
-        <add key="roslyn-myget" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
-        <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
     </packageSources>
 </configuration>

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>16.6.0</MSBuildPackageVersion>
     <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.8.0-1.20357.3</RoslynPackageVersion>
+    <RoslynPackageVersion>3.8.0-1.20373.6</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <MSBuildPackageVersion>16.6.0</MSBuildPackageVersion>
     <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.8.0-1.20373.6</RoslynPackageVersion>
+    <RoslynPackageVersion>3.8.0-1.20363.1</RoslynPackageVersion>
     <XunitPackageVersion>2.4.0</XunitPackageVersion>
   </PropertyGroup>
 

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Cake" version="0.37.0" />
-    <package id="Microsoft.Build" version="16.6.0" />
-    <package id="Microsoft.Build.Framework" version="16.6.0" />
-    <package id="Microsoft.Build.Runtime" version="16.6.0" />
-    <package id="Microsoft.Build.Tasks.Core" version="16.6.0" />
-    <package id="Microsoft.Build.Utilities.Core" version="16.6.0" />
-    <package id="Microsoft.Net.Compilers" version="3.5.0" />
-    <package id="Microsoft.DotNet.MSBuildSdkResolver" version="3.1.200-preview.20126.2" />
-    <package id="Microsoft.Build.NuGetSdkResolver" version="5.6.0-preview.2.6508" />
-    <package id="Newtonsoft.Json" version="11.0.1" />
-    <package id="NuGet.Build.Tasks" version="5.6.0-preview.2.6508" />
-    <package id="NuGet.Commands" version="5.6.0-preview.2.6508" />
-    <package id="NuGet.Common" version="5.6.0-preview.2.6508" />
-    <package id="NuGet.Configuration" version="5.6.0-preview.2.6508" />
-    <package id="NuGet.Credentials" version="5.6.0-preview.2.6508" />
-    <package id="NuGet.DependencyResolver.Core" version="5.6.0-preview.2.6508" />
-    <package id="NuGet.Frameworks" version="5.6.0-preview.2.6508" />
-    <package id="NuGet.LibraryModel" version="5.6.0-preview.2.6508" />
-    <package id="NuGet.Packaging" version="5.6.0-preview.2.6508" />
-    <package id="NuGet.ProjectModel" version="5.6.0-preview.2.6508" />
-    <package id="NuGet.Protocol" version="5.6.0-preview.2.6508" />
-    <package id="NuGet.Versioning" version="5.6.0-preview.2.6508" />
-    <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="3.1.2" />
-    <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="3.1.2" />
-    <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="3.1.2" />
-    <package id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" version="3.1.2" />
+    <package id="Microsoft.Build" version="16.8.0-preview-20371-01" />
+    <package id="Microsoft.Build.Framework" version="16.8.0-preview-20371-01" />
+    <package id="Microsoft.Build.Runtime" version="16.8.0-preview-20371-01" />
+    <package id="Microsoft.Build.Tasks.Core" version="16.8.0-preview-20371-01" />
+    <package id="Microsoft.Build.Utilities.Core" version="16.8.0-preview-20371-01" />
+    <package id="Microsoft.Net.Compilers" version="3.8.0-1.20373.6" />
+    <package id="Microsoft.DotNet.MSBuildSdkResolver" version="5.0.100-preview.8.20362.1" />
+    <package id="Microsoft.Build.NuGetSdkResolver" version="5.8.0-preview.1.6718" />
+    <package id="Newtonsoft.Json" version="12.0.2" />
+    <package id="NuGet.Build.Tasks" version="5.8.0-preview.1.6718" />
+    <package id="NuGet.Commands" version="5.8.0-preview.1.6718" />
+    <package id="NuGet.Common" version="5.8.0-preview.1.6718" />
+    <package id="NuGet.Configuration" version="5.8.0-preview.1.6718" />
+    <package id="NuGet.Credentials" version="5.8.0-preview.1.6718" />
+    <package id="NuGet.DependencyResolver.Core" version="5.8.0-preview.1.6718" />
+    <package id="NuGet.Frameworks" version="5.8.0-preview.1.6718" />
+    <package id="NuGet.LibraryModel" version="5.8.0-preview.1.6718" />
+    <package id="NuGet.Packaging" version="5.8.0-preview.1.6718" />
+    <package id="NuGet.ProjectModel" version="5.8.0-preview.1.6718" />
+    <package id="NuGet.Protocol" version="5.8.0-preview.1.6718" />
+    <package id="NuGet.Versioning" version="5.8.0-preview.1.6718" />
+    <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0-preview.8.20361.2" />
+    <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0-preview.8.20361.2" />
+    <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0-preview.8.20361.2" />
+    <package id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" version="5.0.0-preview.8.20361.2" />
     <package id="SQLitePCLRaw.bundle_green" version="1.1.2" />
     <package id="SQLitePCLRaw.core" version="1.1.2" />
     <package id="SQLitePCLRaw.provider.e_sqlite3.net45" version="1.1.2" />


### PR DESCRIPTION
Not sure whether we would want the included build tools to match the .NET SDK tools or the latest VS preview tools.