### PR TITLE
Move the Hover LSP provider to use the new quickinfo service

### DIFF
--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpHoverHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpHoverHandler.cs
@@ -3,11 +3,9 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using OmniSharp.Models.TypeLookup;
+using OmniSharp.Models;
 
 namespace OmniSharp.LanguageServerProtocol.Handlers
 {
@@ -16,14 +14,14 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
         public static IEnumerable<IJsonRpcHandler> Enumerate(RequestHandlers handlers)
         {
             foreach (var (selector, handler) in handlers
-                .OfType<Mef.IRequestHandler<TypeLookupRequest, TypeLookupResponse>>())
+                .OfType<Mef.IRequestHandler<QuickInfoRequest, QuickInfoResponse>>())
                 if (handler != null)
                     yield return new OmniSharpHoverHandler(handler, selector);
         }
 
-        private readonly Mef.IRequestHandler<TypeLookupRequest, TypeLookupResponse> _definitionHandler;
+        private readonly Mef.IRequestHandler<QuickInfoRequest, QuickInfoResponse> _definitionHandler;
 
-        public OmniSharpHoverHandler(Mef.IRequestHandler<TypeLookupRequest, TypeLookupResponse> definitionHandler, DocumentSelector documentSelector)
+        public OmniSharpHoverHandler(Mef.IRequestHandler<QuickInfoRequest, QuickInfoResponse> definitionHandler, DocumentSelector documentSelector)
             : base(new HoverRegistrationOptions()
             {
                 DocumentSelector = documentSelector
@@ -34,12 +32,11 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
 
         public async override Task<Hover> Handle(HoverParams request, CancellationToken token)
         {
-            var omnisharpRequest = new TypeLookupRequest()
+            var omnisharpRequest = new QuickInfoRequest()
             {
                 FileName = Helpers.FromUri(request.TextDocument.Uri),
                 Column = Convert.ToInt32(request.Position.Character),
                 Line = Convert.ToInt32(request.Position.Line),
-                IncludeDocumentation = true
             };
 
             var omnisharpResponse = await _definitionHandler.Handle(omnisharpRequest);
@@ -48,7 +45,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
             {
                 // TODO: Range?  We don't currently have that!
                 // Range =
-                Contents = new MarkedStringsOrMarkupContent(new Container<MarkedString>(Helpers.EscapeMarkdown(omnisharpResponse.Type), Helpers.EscapeMarkdown(omnisharpResponse.Documentation)))
+                Contents = new MarkedStringsOrMarkupContent(new MarkupContent() { Value = omnisharpResponse.Markdown })
             };
         }
     }

--- a/src/OmniSharp.LanguageServerProtocol/Helpers.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Helpers.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Models;
@@ -120,13 +119,6 @@ namespace OmniSharp.LanguageServerProtocol
                 Start = ToPosition(range.Start),
                 End = ToPosition(range.End)
             };
-        }
-
-        public static string EscapeMarkdown(string markdown)
-        {
-            if (markdown == null)
-                return null;
-            return Regex.Replace(markdown, @"([\\`\*_\{\}\[\]\(\)#+\-\.!])", @"\$1");
         }
 
         private static readonly IDictionary<string, SymbolKind> Kinds = new Dictionary<string, SymbolKind>

--- a/src/OmniSharp.Roslyn.CSharp/Services/QuickInfoProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/QuickInfoProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using OmniSharp.Mef;
 using OmniSharp.Models;
 using OmniSharp.Options;
+using OmniSharp.Utilities;
 
 #nullable enable
 
@@ -186,12 +187,12 @@ namespace OmniSharp.Roslyn.CSharp.Services
                     switch (current.Tag)
                     {
                         case TextTags.Text when !isInCodeBlock:
-                            stringBuilder.Append(current.Text);
+                            addText(current.Text);
                             break;
 
                         case TextTags.Text:
                             endBlock();
-                            stringBuilder.Append(current.Text);
+                            addText(current.Text);
                             break;
 
                         case TextTags.Space when isInCodeBlock:
@@ -200,7 +201,7 @@ namespace OmniSharp.Roslyn.CSharp.Services
                                 endBlock();
                             }
 
-                            stringBuilder.Append(current.Text);
+                            addText(current.Text);
                             break;
 
                         case TextTags.Space:
@@ -234,7 +235,7 @@ namespace OmniSharp.Roslyn.CSharp.Services
                                 isInCodeBlock = true;
                                 stringBuilder.Append('`');
                             }
-                            stringBuilder.Append(current.Text);
+                            addText(current.Text);
                             break;
                     }
                 }
@@ -245,6 +246,11 @@ namespace OmniSharp.Roslyn.CSharp.Services
                 }
 
                 return;
+
+                void addText(string text)
+                {
+                    stringBuilder.Append(MarkdownHelpers.Escape(text));
+                }
 
                 void addNewline()
                 {

--- a/src/OmniSharp.Roslyn.CSharp/Services/QuickInfoProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/QuickInfoProvider.cs
@@ -201,7 +201,11 @@ namespace OmniSharp.Roslyn.CSharp.Services
                                 endBlock();
                             }
 
-                            addText(current.Text);
+                            stringBuilder.Append(current.Text);
+                            break;
+
+                        case TextTags.Punctuation when isInCodeBlock && current.Text != "`":
+                            stringBuilder.Append(current.Text);
                             break;
 
                         case TextTags.Space:
@@ -211,7 +215,7 @@ namespace OmniSharp.Roslyn.CSharp.Services
 
                         case ContainerStart:
                             addNewline();
-                            stringBuilder.Append(current.Text);
+                            addText(current.Text);
                             break;
 
                         case ContainerEnd:
@@ -235,7 +239,7 @@ namespace OmniSharp.Roslyn.CSharp.Services
                                 isInCodeBlock = true;
                                 stringBuilder.Append('`');
                             }
-                            addText(current.Text);
+                            stringBuilder.Append(current.Text);
                             break;
                     }
                 }

--- a/src/OmniSharp.Shared/Utilities/MarkdownHelpers.cs
+++ b/src/OmniSharp.Shared/Utilities/MarkdownHelpers.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.RegularExpressions;
+
+namespace OmniSharp.Utilities
+{
+    public static class MarkdownHelpers
+    {
+        private static Regex EscapeRegex = new Regex(@"([\\`\*_\{\}\[\]\(\)#+\-\.!])", RegexOptions.Compiled);
+
+        public static string Escape(string markdown)
+        {
+            if (markdown == null)
+                return null;
+            return EscapeRegex.Replace(markdown, @"\$1");
+        }
+    }
+}

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/QuickInfoProviderFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/QuickInfoProviderFacts.cs
@@ -692,6 +692,25 @@ class Program
             Assert.Equal("```csharp\nvoid Program.B()\n```\n\nHello World", response.Markdown);
         }
 
+        [Fact]
+        public async Task MarkdownInComment()
+        {
+            string content = @"
+class Program
+{
+	/// <summary>*This should be escaped*</summary>
+	public static void B() { }
+
+    public static void A()
+    {
+        B$$();
+    }
+
+}";
+            var response = await GetTypeLookUpResponse(content);
+            Assert.Equal("```csharp\nvoid Program.B()\n```\n\n\\*This should be escaped\\*", response.Markdown);
+        }
+
         private async Task<QuickInfoResponse> GetTypeLookUpResponse(string content)
         {
             TestFile testFile = new TestFile("dummy.cs", content);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/QuickInfoProviderFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/QuickInfoProviderFacts.cs
@@ -77,7 +77,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             var controller = new QuickInfoProvider(workspace, new FormattingOptions(), null);
             var response = await controller.Handle(new QuickInfoRequest { FileName = testFile.FileName, Line = position.Line, Column = position.Offset });
 
-            Assert.Equal("```csharp\nclass ClassLibraryWithDocumentation.DocumentedClass\n```\n\nThis class performs an important function.", response.Markdown);
+            Assert.Equal("```csharp\nclass ClassLibraryWithDocumentation.DocumentedClass\n```\n\nThis class performs an important function\\.", response.Markdown);
         }
 
         [Fact]
@@ -310,7 +310,7 @@ class testissue
     }
 }";
             var response = await GetTypeLookUpResponse(content);
-            Assert.Equal("```csharp\nbool testissue.Compare(int gameObject, string tagName)\n```\n\nYou may have some additional information about this class here.", response.Markdown);
+            Assert.Equal("```csharp\nbool testissue.Compare(int gameObject, string tagName)\n```\n\nYou may have some additional information about this class here\\.", response.Markdown);
         }
 
         [Fact]
@@ -325,7 +325,7 @@ class testissue
     }
 }";
             var response = await GetTypeLookUpResponse(content);
-            Assert.Equal("```csharp\nbool testissue.Compare(int gameObject, string tagName)\n```\n\nChecks if object is tagged with the tag.", response.Markdown);
+            Assert.Equal("```csharp\nbool testissue.Compare(int gameObject, string tagName)\n```\n\nChecks if object is tagged with the tag\\.", response.Markdown);
         }
 
         [Fact]
@@ -340,7 +340,7 @@ class testissue
     }
 }";
             var response = await GetTypeLookUpResponse(content);
-            Assert.Equal("```csharp\nbool testissue.Compare(int gameObject, string tagName)\n```\n\nReturns:\n\n  Returns true if object is tagged with tag.", response.Markdown);
+            Assert.Equal("```csharp\nbool testissue.Compare(int gameObject, string tagName)\n```\n\nReturns:\n\n  Returns true if object is tagged with tag\\.", response.Markdown);
         }
 
         [Fact]
@@ -466,7 +466,7 @@ public class TestClass
 }
 ";
             var response = await GetTypeLookUpResponse(content);
-            Assert.Equal("```csharp\nstring Employee.Name { }\n```\n\nThe Name property represents the employee's name.\n\nValue:\n\n  The Name property gets/sets the value of the string field, _name.", response.Markdown);
+            Assert.Equal("```csharp\nstring Employee.Name { }\n```\n\nThe Name property represents the employee's name\\.\n\nValue:\n\n  The Name property gets/sets the value of the string field, \\_name\\.", response.Markdown);
         }
 
         [Fact]
@@ -481,7 +481,7 @@ public class TestClass
     }
 }";
             var response = await GetTypeLookUpResponse(content);
-            Assert.Equal("```csharp\nvoid TestClass.DoWork(int Int1)\n```\n\nDoWork is a method in the TestClass class. `System.Console.WriteLine(string)` for information about output statements.", response.Markdown);
+            Assert.Equal("```csharp\nvoid TestClass.DoWork(int Int1)\n```\n\nDoWork is a method in the TestClass class\\. `System.Console.WriteLine(string)` for information about output statements\\.", response.Markdown);
         }
 
         [Fact]
@@ -542,7 +542,7 @@ public class TestClass
 }
             ";
             var response = await GetTypeLookUpResponse(content);
-            Assert.Equal("```csharp\nvoid TestClass.DoWork(int Int1)\n```\n\nDoWork is a method in the TestClass class.\n\n\n\nHere's how you could make a second paragraph in a description.", response.Markdown);
+            Assert.Equal("```csharp\nvoid TestClass.DoWork(int Int1)\n```\n\nDoWork is a method in the TestClass class\\.\n\n\n\nHere's how you could make a second paragraph in a description\\.", response.Markdown);
         }
 
         [Fact]
@@ -563,7 +563,7 @@ public class TestClass
             }
 }";
             var response = await GetTypeLookUpResponse(content);
-            Assert.Equal("```csharp\nvoid TestClass.DoWork(int Int1)\n```\n\nDoWork is a method in the TestClass class. `TestClass.Main()`", response.Markdown);
+            Assert.Equal("```csharp\nvoid TestClass.DoWork(int Int1)\n```\n\nDoWork is a method in the TestClass class\\. `TestClass.Main()`", response.Markdown);
         }
 
         [Fact]
@@ -580,7 +580,7 @@ class testissue
     }
 }";
             var response = await GetTypeLookUpResponse(content);
-            Assert.Equal("```csharp\nbool testissue.Compare(int gameObject, string tagName)\n```\n\nChecks if object is tagged with the tag.", response.Markdown);
+            Assert.Equal("```csharp\nbool testissue.Compare(int gameObject, string tagName)\n```\n\nChecks if object is tagged with the tag\\.", response.Markdown);
         }
 
         [Fact]
@@ -602,7 +602,7 @@ class testissue
 }";
             var response = await GetTypeLookUpResponse(content);
             Assert.Equal(
-                "```csharp\nT[] testissue.Compare(int gameObject)\n```\n\nChecks if object is tagged with the tag.\n\nYou may have some additional information about this class here.\n\nReturns:\n\n  Returns an array of type `T`.\n\n\n\nExceptions:\n\n  `System.Exception`",
+                "```csharp\nT[] testissue.Compare(int gameObject)\n```\n\nChecks if object is tagged with the tag\\.\n\nYou may have some additional information about this class here\\.\n\nReturns:\n\n  Returns an array of type `T`\\.\n\n\n\nExceptions:\n\n  `System.Exception`",
                 response.Markdown);
         }
 
@@ -618,7 +618,7 @@ public class TestClass
     }
 }";
             var response = await GetTypeLookUpResponse(content);
-            Assert.Equal("```csharp\nvoid TestClass.DoWork(int Int1)\n```\n\nDoWork is a method in the TestClass class.", response.Markdown);
+            Assert.Equal("```csharp\nvoid TestClass.DoWork(int Int1)\n```\n\nDoWork is a method in the TestClass class\\.", response.Markdown);
         }
 
         [Fact]
@@ -634,7 +634,7 @@ class testissue
     }
 }";
             var response = await GetTypeLookUpResponse(content);
-            Assert.Equal("```csharp\n(parameter) int gameObject\n```\n\nThe game object.", response.Markdown);
+            Assert.Equal("```csharp\n(parameter) int gameObject\n```\n\nThe game object\\.", response.Markdown);
         }
 
         [Fact]
@@ -650,7 +650,7 @@ class testissue
     }
 }";
             var response = await GetTypeLookUpResponse(content);
-            Assert.Equal("```csharp\n(parameter) string tagName\n```\n\nName of the tag.", response.Markdown);
+            Assert.Equal("```csharp\n(parameter) string tagName\n```\n\nName of the tag\\.", response.Markdown);
         }
 
         [Fact]


### PR DESCRIPTION
@david-driscoll this does what it says on the tin. Hopefully this will be another thing that we can get working in vscode. I'm unsure what the `Range` in LSP represents here, though: is it supposed to be full range of the thing being hovered over? If so, I'm not sure if we actually _want_ to implement that: I'm used to highlighting either getting every instance of a thing, or not highlighting it at all. If we do want to implement that, though, it would be very straightforward to add, as QuickInfo already has the info.

Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1806.