### PR TITLE
added support for EmbeddedLanguageCompletionProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All changes to the project will be documented in this file.
 * Introduced a new `/quickinfo` endpoint to provide a richer set of information compared to `/typeinfo`. Consumers are encouraged to use it as their hover provider ([#1808](https://github.com/OmniSharp/omnisharp-roslyn/issues/1808), PR: [#1860](https://github.com/OmniSharp/omnisharp-roslyn/pull/1860))
 * Fixed return type in LSP completion handler ([#1864](https://github.com/OmniSharp/omnisharp-roslyn/issues/1864), PR: [#1869](https://github.com/OmniSharp/omnisharp-roslyn/pull/1869))
 * Upgraded to the latest version of the csharp-language-server-protocol [#1815](https://github.com/OmniSharp/omnisharp-roslyn/pull/1815)
+* Added support for Roslyn `EmbeddedLanguageCompletionProvider` which enables completions for string literals for `DateTime` and `Regex` ([#1871](https://github.com/OmniSharp/omnisharp-roslyn/pull/1871))
 
 ## [1.35.4] - 2020-07-22
 * Update to Roslyn `3.8.0-1.20357.3` (PR: [#1849](https://github.com/OmniSharp/omnisharp-roslyn/pull/1849))

--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/IntellisenseService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/IntellisenseService.cs
@@ -99,19 +99,8 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
                                 continue;
                             }
 
-                            // for other completions, i.e. keywords, create a simple AutoCompleteResponse
-                            // we'll just assume that the completion text is the same
-                            // as the display text.
-                            var response = new AutoCompleteResponse()
-                            {
-                                CompletionText = item.DisplayText,
-                                DisplayText = item.DisplayText,
-                                Snippet = item.DisplayText,
-                                Kind = request.WantKind ? item.Tags.First() : null,
-                                IsSuggestionMode = isSuggestionMode,
-                                Preselect = preselect
-                            };
-
+                            // for other completions, i.e. keywords or em, create a simple AutoCompleteResponse
+                            var response = item.ToAutoCompleteResponse(request.WantKind, isSuggestionMode, preselect);
                             completions.Add(response);
                         }
                     }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -451,7 +451,7 @@ class C
 
         [Theory]
         [InlineData("dummy.cs")]
-        //[InlineData("dummy.csx")]
+        [InlineData("dummy.csx")]
         public async Task Embedded_language_completion_provider_for_datetime_format(string filename)
         {
             const string source = @"
@@ -460,17 +460,19 @@ class C
 {
     void M()
     {
-        var d = DateTime.Now.ToString(""$$
+        var d = DateTime.Now.ToString(""$$""
     }
 }
 ";
 
             var completions = await FindCompletionsAsync(filename, source);
 
-            var completion = completions.First();
-            Assert.Equal("G", completion.CompletionText);
-            Assert.Equal("general long date/time", completion.DisplayText);
-            Assert.Contains(@"The ""G"" standard format specifier", completion.Description);
+            Assert.NotEmpty(completions);
+
+            var gStandardCompletion = completions.FirstOrDefault(x => x.CompletionText == "G");
+            Assert.NotNull(gStandardCompletion);
+            Assert.Equal("general long date/time", gStandardCompletion.DisplayText);
+            Assert.Contains(@"The ""G"" standard format specifier", gStandardCompletion.Description);
         }
 
         [Fact]

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -475,33 +475,6 @@ class C
             Assert.Contains(@"The ""G"" standard format specifier", gStandardCompletion.Description);
         }
 
-        [Theory]
-        [InlineData("dummy.cs")]
-        [InlineData("dummy.csx")]
-        public async Task Embedded_language_completion_provider_for_regex(string filename)
-        {
-            const string source = @"
-using System;
-using System.Text.RegularExpressions;
-class C
-{
-    void M()
-    {
-        var r = Regex.Match(""foo"", ""$$""
-    }
-}
-";
-
-            var completions = await FindCompletionsAsync(filename, source);
-
-            Assert.NotEmpty(completions);
-
-            var wCompletion = completions.FirstOrDefault(x => x.CompletionText == @"\w");
-            Assert.NotNull(wCompletion);
-            Assert.Equal("word character", wCompletion.DisplayText);
-            Assert.Contains(@"matches any word character", wCompletion.Description);
-        }
-
         [Fact]
         public async Task Scripting_by_default_returns_completions_for_CSharp7_1()
         {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -496,10 +496,10 @@ class C
 
             Assert.NotEmpty(completions);
 
-            var gStandardCompletion = completions.FirstOrDefault(x => x.CompletionText == @"\w");
-            Assert.NotNull(gStandardCompletion);
-            Assert.Equal("word character", gStandardCompletion.DisplayText);
-            Assert.Contains(@"matches any word character", gStandardCompletion.Description);
+            var wCompletion = completions.FirstOrDefault(x => x.CompletionText == @"\w");
+            Assert.NotNull(wCompletion);
+            Assert.Equal("word character", wCompletion.DisplayText);
+            Assert.Contains(@"matches any word character", wCompletion.Description);
         }
 
         [Fact]

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -475,6 +475,33 @@ class C
             Assert.Contains(@"The ""G"" standard format specifier", gStandardCompletion.Description);
         }
 
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Embedded_language_completion_provider_for_regex(string filename)
+        {
+            const string source = @"
+using System;
+using System.Text.RegularExpressions;
+class C
+{
+    void M()
+    {
+        var r = Regex.Match(""foo"", ""$$""
+    }
+}
+";
+
+            var completions = await FindCompletionsAsync(filename, source);
+
+            Assert.NotEmpty(completions);
+
+            var gStandardCompletion = completions.FirstOrDefault(x => x.CompletionText == @"\w");
+            Assert.NotNull(gStandardCompletion);
+            Assert.Equal("word character", gStandardCompletion.DisplayText);
+            Assert.Contains(@"matches any word character", gStandardCompletion.Description);
+        }
+
         [Fact]
         public async Task Scripting_by_default_returns_completions_for_CSharp7_1()
         {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -449,6 +449,30 @@ class C
             Assert.True(completions.All(c => !c.IsSuggestionMode));
         }
 
+        [Theory]
+        [InlineData("dummy.cs")]
+        //[InlineData("dummy.csx")]
+        public async Task Embedded_language_completion_provider_for_datetime_format(string filename)
+        {
+            const string source = @"
+using System;
+class C
+{
+    void M()
+    {
+        var d = DateTime.Now.ToString(""$$
+    }
+}
+";
+
+            var completions = await FindCompletionsAsync(filename, source);
+
+            var completion = completions.First();
+            Assert.Equal("G", completion.CompletionText);
+            Assert.Equal("general long date/time", completion.DisplayText);
+            Assert.Contains(@"The ""G"" standard format specifier", completion.Description);
+        }
+
         [Fact]
         public async Task Scripting_by_default_returns_completions_for_CSharp7_1()
         {


### PR DESCRIPTION
This is quite new in Roslyn. It gives completion results for e.g. datetime string literals and regex patterns

<img width="1127" alt="Bildschirmfoto 2020-07-30 um 21 29 06" src="https://user-images.githubusercontent.com/1710369/88970138-30070700-d2b2-11ea-9e25-4e77bc616d5d.png">
<img width="984" alt="Bildschirmfoto 2020-07-30 um 21 41 02" src="https://user-images.githubusercontent.com/1710369/88970141-31383400-d2b2-11ea-8b96-5fa539cd3721.png">
