### PR TITLE
Check for MSBuild version is higher than required by the .NET SDK

### DIFF
--- a/src/OmniSharp.Host/CompositionHostBuilder.cs
+++ b/src/OmniSharp.Host/CompositionHostBuilder.cs
@@ -40,7 +40,7 @@ namespace OmniSharp
             _exportDescriptorProviders = exportDescriptorProviders ?? Array.Empty<ExportDescriptorProvider>();
         }
 
-        public CompositionHost Build()
+        public CompositionHost Build(string workingDirectory)
         {
             var options = _serviceProvider.GetRequiredService<IOptionsMonitor<OmniSharpOptions>>();
             var memoryCache = _serviceProvider.GetRequiredService<IMemoryCache>();
@@ -64,7 +64,8 @@ namespace OmniSharp
             // This is for tests, where the MSBuild instance may be registered early.
             if (msbuildLocator.RegisteredInstance == null)
             {
-                msbuildLocator.RegisterDefaultInstance(logger);
+                var dotNetInfo = dotNetCliService.GetInfo(workingDirectory);
+                msbuildLocator.RegisterDefaultInstance(logger, dotNetInfo);
             }
 
             config = config

--- a/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
@@ -1,13 +1,20 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Microsoft.Extensions.Logging;
+using OmniSharp.Services;
 
 namespace OmniSharp.MSBuild.Discovery
 {
     internal static class Extensions
     {
-        public static void RegisterDefaultInstance(this IMSBuildLocator msbuildLocator, ILogger logger)
+        private static readonly Version s_minimumMSBuildVersion = new Version(16, 3);
+
+        public static void RegisterDefaultInstance(this IMSBuildLocator msbuildLocator, ILogger logger, DotNetInfo dotNetInfo = null)
         {
-            var bestInstanceFound = GetBestInstance(msbuildLocator, logger, out var invalidVSFound, out var vsWithoutSdkResolver);
+            var minimumMSBuildVersion = GetSdkMinimumMSBuildVersion(dotNetInfo, logger);
+            logger.LogDebug($".NET SDK requires MSBuild instances version {minimumMSBuildVersion} or higher");
+
+            var bestInstanceFound = GetBestInstance(msbuildLocator, minimumMSBuildVersion, logger, out var invalidVSFound, out var vsWithoutSdkResolver);
 
             if (bestInstanceFound != null)
             {
@@ -16,7 +23,7 @@ namespace OmniSharp.MSBuild.Discovery
                 if (invalidVSFound && bestInstanceFound.DiscoveryType == DiscoveryType.StandAlone)
                 {
                     logger.LogWarning(
-                        @"It looks like you have Visual Studio lower than VS 2019 16.3 installed.
+                        $@"It looks like you have Visual Studio lower than VS 2019 {s_minimumMSBuildVersion} installed.
  Try updating Visual Studio to the most recent release to enable better MSBuild support."
                     );
                 }
@@ -27,6 +34,31 @@ namespace OmniSharp.MSBuild.Discovery
                         @"It looks like you have Visual Studio 2019 installed without .NET Core SDK support which is required by OmniSharp.
  Try updating Visual Studio 2019 installation with .NET Core SDK to enable better MSBuild support."
                     );
+                }
+
+                if (bestInstanceFound.Version < minimumMSBuildVersion)
+                {
+                    if (bestInstanceFound.DiscoveryType == DiscoveryType.Mono)
+                    {
+                        logger.LogWarning(
+                            $@"It looks like you have Mono installed which contains a MSBuild lower than {minimumMSBuildVersion} which is the minimum supported by the configured .NET Core Sdk.
+ Try updating Mono to the latest stable or preview version to enable better .NET Core Sdk support."
+                        );
+                    }
+                    else if (bestInstanceFound.DiscoveryType == DiscoveryType.StandAlone)
+                    {
+                        logger.LogWarning(
+                            $@"It looks like you have Visual Studio 2019 installed which contains a MSBuild lower than {minimumMSBuildVersion} which is the minimum supported by the configured .NET Core Sdk.
+ Try updating Visual Studio to version {minimumMSBuildVersion} or higher to enable better .NET Core Sdk support."
+                        );
+                    }
+                    else if (bestInstanceFound.DiscoveryType == DiscoveryType.UserOverride)
+                    {
+                        logger.LogWarning(
+                            $@"It looks like you have overridden the version of MSBuild with a version lower than {minimumMSBuildVersion} which is the minimum supported by the configured .NET Core Sdk.
+ Try updating your MSBuild to version {minimumMSBuildVersion} or higher to enable better .NET Core Sdk support."
+                        );
+                    }
                 }
 
                 msbuildLocator.RegisterInstance(bestInstanceFound);
@@ -55,12 +87,12 @@ namespace OmniSharp.MSBuild.Discovery
         /// Checks if it is MSBuild from Visual Studio 2017 RTM that cannot be used.
         /// </summary>
         public static bool IsInvalidVisualStudio(this MSBuildInstance instance)
-            => (instance.Version.Major < 16 ||
-                (instance.Version.Major == 16 && instance.Version.Minor < 3))
+            => (instance.Version.Major < s_minimumMSBuildVersion.Major ||
+                (instance.Version.Major == s_minimumMSBuildVersion.Major && instance.Version.Minor < s_minimumMSBuildVersion.Minor))
                 && (instance.DiscoveryType == DiscoveryType.DeveloperConsole
                     || instance.DiscoveryType == DiscoveryType.VisualStudioSetup);
 
-        public static MSBuildInstance GetBestInstance(this IMSBuildLocator msbuildLocator, ILogger logger, out bool invalidVSFound, out bool vsWithoutSdkResolver)
+        public static MSBuildInstance GetBestInstance(this IMSBuildLocator msbuildLocator, Version minimumMSBuildVersion, ILogger logger, out bool invalidVSFound, out bool vsWithoutSdkResolver)
         {
             invalidVSFound = false;
             vsWithoutSdkResolver = false;
@@ -69,7 +101,7 @@ namespace OmniSharp.MSBuild.Discovery
 
             foreach (var instance in msbuildLocator.GetInstances())
             {
-                var score = GetInstanceFeatureScore(instance);
+                var score = GetInstanceFeatureScore(instance, minimumMSBuildVersion);
 
                 logger.LogDebug($"MSBuild instance {instance.Name} {instance.Version} scored at {score}");
 
@@ -88,7 +120,7 @@ namespace OmniSharp.MSBuild.Discovery
             return bestMatchInstance;
         }
 
-        private static int GetInstanceFeatureScore(MSBuildInstance i)
+        private static int GetInstanceFeatureScore(MSBuildInstance i, Version minimumMSBuildVersion)
         {
             var score = 0;
 
@@ -111,6 +143,29 @@ namespace OmniSharp.MSBuild.Discovery
                 score--;
 
             return score;
+        }
+
+        public static Version GetSdkMinimumMSBuildVersion(DotNetInfo dotNetInfo, ILogger logger)
+        {
+            if (dotNetInfo is null
+                || string.IsNullOrWhiteSpace(dotNetInfo.SdksPath)
+                || dotNetInfo.SdkVersion is null)
+            {
+                return s_minimumMSBuildVersion;
+            }
+
+            var version = dotNetInfo.SdkVersion;
+            var sdksPath = dotNetInfo.SdksPath;
+            var minimumVersionPath = Path.Combine(sdksPath, version.ToNormalizedString(), "minimumMSBuildVersion");
+
+            if (!File.Exists(minimumVersionPath))
+            {
+                logger.LogDebug($"Unable to locate minimumMSBuildVersion file at '{minimumVersionPath}'");
+                return s_minimumMSBuildVersion;
+            }
+
+            var minimumVersionText = File.ReadAllText(minimumVersionPath);
+            return Version.Parse(minimumVersionText);
         }
     }
 }

--- a/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
@@ -20,7 +20,7 @@ namespace OmniSharp.MSBuild.Discovery
             {
                 // Did we end up choosing the standalone MSBuild because there was an invalid Visual Studio?
                 // If so, provide a helpful message to the user.
-                if (invalidVSFound && bestInstanceFound.DiscoveryType == DiscoveryType.VisualStudioSetup)
+                if (invalidVSFound && bestInstanceFound.DiscoveryType == DiscoveryType.StandAlone)
                 {
                     logger.LogWarning(
                         $@"It looks like you have Visual Studio lower than VS 2019 {s_minimumMSBuildVersion} installed.
@@ -28,7 +28,7 @@ namespace OmniSharp.MSBuild.Discovery
                     );
                 }
 
-                if (vsWithoutSdkResolver && bestInstanceFound.DiscoveryType == DiscoveryType.VisualStudioSetup)
+                if (vsWithoutSdkResolver && bestInstanceFound.DiscoveryType == DiscoveryType.StandAlone)
                 {
                     logger.LogWarning(
                         @"It looks like you have Visual Studio 2019 installed without .NET Core SDK support which is required by OmniSharp.

--- a/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
@@ -20,7 +20,7 @@ namespace OmniSharp.MSBuild.Discovery
             {
                 // Did we end up choosing the standalone MSBuild because there was an invalid Visual Studio?
                 // If so, provide a helpful message to the user.
-                if (invalidVSFound && bestInstanceFound.DiscoveryType == DiscoveryType.StandAlone)
+                if (invalidVSFound && bestInstanceFound.DiscoveryType == DiscoveryType.VisualStudioSetup)
                 {
                     logger.LogWarning(
                         $@"It looks like you have Visual Studio lower than VS 2019 {s_minimumMSBuildVersion} installed.
@@ -28,7 +28,7 @@ namespace OmniSharp.MSBuild.Discovery
                     );
                 }
 
-                if (vsWithoutSdkResolver && bestInstanceFound.DiscoveryType == DiscoveryType.StandAlone)
+                if (vsWithoutSdkResolver && bestInstanceFound.DiscoveryType == DiscoveryType.VisualStudioSetup)
                 {
                     logger.LogWarning(
                         @"It looks like you have Visual Studio 2019 installed without .NET Core SDK support which is required by OmniSharp.
@@ -38,14 +38,21 @@ namespace OmniSharp.MSBuild.Discovery
 
                 if (bestInstanceFound.Version < minimumMSBuildVersion)
                 {
-                    if (bestInstanceFound.DiscoveryType == DiscoveryType.Mono)
+                    if (bestInstanceFound.DiscoveryType == DiscoveryType.StandAlone)
+                    {
+                        logger.LogWarning(
+                            $@"It looks like the included version of MSBuild is lower than {minimumMSBuildVersion} which is the minimum supported by the configured .NET Core Sdk.
+ Try installing MSBuild version {minimumMSBuildVersion} or higher to enable better .NET Core Sdk support."
+                        );
+                    }
+                    else if (bestInstanceFound.DiscoveryType == DiscoveryType.Mono)
                     {
                         logger.LogWarning(
                             $@"It looks like you have Mono installed which contains a MSBuild lower than {minimumMSBuildVersion} which is the minimum supported by the configured .NET Core Sdk.
  Try updating Mono to the latest stable or preview version to enable better .NET Core Sdk support."
                         );
                     }
-                    else if (bestInstanceFound.DiscoveryType == DiscoveryType.StandAlone)
+                    else if (bestInstanceFound.DiscoveryType == DiscoveryType.VisualStudioSetup)
                     {
                         logger.LogWarning(
                             $@"It looks like you have Visual Studio 2019 installed which contains a MSBuild lower than {minimumMSBuildVersion} which is the minimum supported by the configured .NET Core Sdk.
@@ -84,7 +91,7 @@ namespace OmniSharp.MSBuild.Discovery
         }
 
         /// <summary>
-        /// Checks if it is MSBuild from Visual Studio 2017 RTM that cannot be used.
+        /// Checks if the discovered Visual Studio instance includes a version of MSBuild lower than our minimum supported version.
         /// </summary>
         public static bool IsInvalidVisualStudio(this MSBuildInstance instance)
             => (instance.Version.Major < s_minimumMSBuildVersion.Major ||

--- a/src/OmniSharp.Http/Startup.cs
+++ b/src/OmniSharp.Http/Startup.cs
@@ -60,7 +60,7 @@ namespace OmniSharp.Http
             _compositionHost = new CompositionHostBuilder(serviceProvider)
                 .WithOmniSharpAssemblies()
                 .WithAssemblies(assemblyLoader.LoadByAssemblyNameOrPath(logger, plugins).ToArray())
-                .Build();
+                .Build(_environment.TargetDirectory);
 
             return serviceProvider;
         }

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -56,7 +56,7 @@ namespace OmniSharp.LanguageServerProtocol
                 .WithOutput(output)
                 .ConfigureLogging(x => x
                         .AddLanguageProtocolLogging()
-                    // .SetMinimumLevel(application.LogLevel)
+                // .SetMinimumLevel(application.LogLevel)
                 )
                 .OnInitialize(Initialize)
                 .WithServices(ConfigureServices);
@@ -202,7 +202,7 @@ namespace OmniSharp.LanguageServerProtocol
                 .WithAssemblies(typeof(LanguageServerHost).Assembly)
                 .WithAssemblies(assemblyLoader.LoadByAssemblyNameOrPath(logger, plugins.AssemblyNames).ToArray());
 
-            return (serviceProvider, compositionHostBuilder.Build());
+            return (serviceProvider, compositionHostBuilder.Build(environment.TargetDirectory));
         }
 
         internal static RequestHandlers ConfigureCompositionHost(ILanguageServer server,
@@ -241,7 +241,7 @@ namespace OmniSharp.LanguageServerProtocol
 
             logger.LogTrace(
                 "Configured Document Selectors {@DocumentSelectors}",
-                documentSelectors.Select(x => new {x.language, x.selector})
+                documentSelectors.Select(x => new { x.language, x.selector })
             );
 
             var omnisharpRequestHandlers =
@@ -365,7 +365,7 @@ namespace OmniSharp.LanguageServerProtocol
 
             IDictionary<string, Lazy<LanguageProtocolInteropHandler>> endpointHandlers = null;
             var updateBufferEndpointHandler = new Lazy<LanguageProtocolInteropHandler<UpdateBufferRequest, object>>(
-                () => (LanguageProtocolInteropHandler<UpdateBufferRequest, object>) endpointHandlers[
+                () => (LanguageProtocolInteropHandler<UpdateBufferRequest, object>)endpointHandlers[
                     OmniSharpEndpoints.UpdateBuffer].Value);
             var languagePredicateHandler = new LanguagePredicateHandler(projectSystems);
             var projectSystemPredicateHandler = new StaticLanguagePredicateHandler("Projects");

--- a/src/OmniSharp.Stdio/Host.cs
+++ b/src/OmniSharp.Stdio/Host.cs
@@ -44,7 +44,7 @@ namespace OmniSharp.Stdio
 
             _logger.LogInformation($"Starting OmniSharp on {Platform.Current}");
 
-            _compositionHost = compositionHostBuilder.Build();
+            _compositionHost = compositionHostBuilder.Build(_environment.TargetDirectory);
             _cachedStringBuilder = new CachedStringBuilder();
 
             var handlers = Initialize();

--- a/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
+++ b/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
@@ -121,7 +121,7 @@ namespace OmniSharp.Http.Tests
             var serviceProvider = TestServiceProvider.Create(this.TestOutput, new OmniSharpEnvironment());
             var compositionHost = new CompositionHostBuilder(serviceProvider)
                 .WithAssemblies(assemblies)
-                .Build();
+                .Build(workingDirectory: null);
 
             return new PlugInHost(serviceProvider, compositionHost);
         }

--- a/tests/OmniSharp.MSBuild.Tests/AbstractMSBuildTestFixture.cs
+++ b/tests/OmniSharp.MSBuild.Tests/AbstractMSBuildTestFixture.cs
@@ -27,7 +27,7 @@ namespace OmniSharp.MSBuild.Tests
 
             // Some tests require MSBuild to be discovered early
             // to ensure that the Microsoft.Build.* assemblies can be located
-            _msbuildLocator.RegisterDefaultInstance(this.LoggerFactory.CreateLogger("MSBuildTests"));
+            _msbuildLocator.RegisterDefaultInstance(this.LoggerFactory.CreateLogger("MSBuildTests"), dotNetInfo: null);
         }
 
         public void Dispose()

--- a/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
@@ -33,7 +33,7 @@ namespace OmniSharp.MSBuild.Tests
             var logger = LoggerFactory.CreateLogger(nameof(RegisterDefaultInstanceFindsTheBestInstanceAvailable));
 
             // test
-            msbuildLocator.RegisterDefaultInstance(logger);
+            msbuildLocator.RegisterDefaultInstance(logger, dotNetInfo: null);
 
             Assert.NotNull(msbuildLocator.RegisteredInstance);
             Assert.Same(msBuildInstances[1], msbuildLocator.RegisteredInstance);
@@ -72,7 +72,7 @@ namespace OmniSharp.MSBuild.Tests
             );
 
             // test
-            msbuildLocator.RegisterDefaultInstance(logger);
+            msbuildLocator.RegisterDefaultInstance(logger, dotNetInfo: null);
 
             Assert.NotNull(msbuildLocator.RegisteredInstance);
             Assert.Same(msBuildInstances[2], msbuildLocator.RegisteredInstance);
@@ -112,7 +112,7 @@ namespace OmniSharp.MSBuild.Tests
             );
 
             // test
-            msbuildLocator.RegisterDefaultInstance(logger);
+            msbuildLocator.RegisterDefaultInstance(logger, dotNetInfo: null);
 
             Assert.NotNull(msbuildLocator.RegisteredInstance);
             Assert.Same(msBuildInstances[2], msbuildLocator.RegisteredInstance);
@@ -159,7 +159,7 @@ namespace OmniSharp.MSBuild.Tests
             );
 
             // test
-            msbuildLocator.RegisterDefaultInstance(logger);
+            msbuildLocator.RegisterDefaultInstance(logger, dotNetInfo: null);
 
             Assert.NotNull(msbuildLocator.RegisteredInstance);
             Assert.Same(msBuildInstances[4], msbuildLocator.RegisteredInstance);
@@ -186,7 +186,7 @@ namespace OmniSharp.MSBuild.Tests
             var logger = LoggerFactory.CreateLogger(nameof(RegisterDefaultInstancePrefersSupportedVSLowerVersionInstanceOverStandAlone));
 
             // test
-            msbuildLocator.RegisterDefaultInstance(logger);
+            msbuildLocator.RegisterDefaultInstance(logger, dotNetInfo: null);
 
             Assert.NotNull(msbuildLocator.RegisteredInstance);
             Assert.Same(msBuildInstances[0], msbuildLocator.RegisteredInstance);
@@ -215,7 +215,7 @@ namespace OmniSharp.MSBuild.Tests
             var logger = LoggerFactory.CreateLogger(nameof(RegisterDefaultInstancePrefersStandAloneOverSupportedVSInstanceWithoutDotnetCore));
 
             // test
-            msbuildLocator.RegisterDefaultInstance(logger);
+            msbuildLocator.RegisterDefaultInstance(logger, dotNetInfo: null);
 
             Assert.NotNull(msbuildLocator.RegisteredInstance);
             Assert.Same(msBuildInstances[1], msbuildLocator.RegisteredInstance);
@@ -246,7 +246,7 @@ namespace OmniSharp.MSBuild.Tests
             var logger = LoggerFactory.CreateLogger(nameof(StandAloneIsPreferredOverUnsupportedVS));
 
             // test
-            msbuildLocator.RegisterDefaultInstance(logger);
+            msbuildLocator.RegisterDefaultInstance(logger, dotNetInfo: null);
 
             Assert.NotNull(msbuildLocator.RegisteredInstance);
             Assert.Same(msBuildInstances[1], msbuildLocator.RegisteredInstance);

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -88,7 +88,7 @@ namespace TestUtility
             [CallerMemberName] string callerName = "")
         {
             var compositionHost = new CompositionHostBuilder(serviceProvider, s_lazyAssemblies.Value, additionalExports)
-                .Build();
+                .Build(workingDirectory: null);
 
             WorkspaceInitializer.Initialize(serviceProvider, compositionHost);
 


### PR DESCRIPTION
Provide a warning when the discovered MSBuild version is lower than the minimumMSBuildVersion supported by the configured SDK.