### PR TITLE
Use the real MSBuild version during discovery

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -210,7 +210,22 @@ Task("CreateMSBuildFolder")
         "Microsoft.Build.Tasks.v4.0",
         "Microsoft.Build.Tasks.v12.0",
         "Microsoft.Build.Utilities.v4.0",
-        "Microsoft.Build.Utilities.v12.0"
+        "Microsoft.Build.Utilities.v12.0",
+    };
+
+    var msBuildDependencies = new []
+    {
+        "Microsoft.Bcl.AsyncInterfaces",
+        "System.Buffers",
+        "System.Collections.Immutable",
+        "System.Memory",
+        "System.Numerics.Vectors",
+        "System.Resources.Extensions",
+        "System.Runtime.CompilerServices.Unsafe",
+        "System.Text.Encodings.Web",
+        "System.Text.Json",
+        "System.Threading.Tasks.Dataflow",
+        "System.Threading.Tasks.Extensions",
     };
 
     var msbuildRuntimeFiles = new []
@@ -244,15 +259,8 @@ Task("CreateMSBuildFolder")
         "Microsoft.Xaml.targets",
         "MSBuild.dll",
         "MSBuild.dll.config",
-        "System.Buffers.dll",
-        "System.Collections.Immutable.dll",
-        "System.Memory.dll",
-        "System.Numerics.Vectors.dll",
-        "System.Reflection.Metadata.dll",
-        "System.Resources.Extensions.dll",
-        "System.Threading.Tasks.Dataflow.dll",
         "Workflow.VisualBasic.targets",
-        "Workflow.targets"
+        "Workflow.targets",
     };
 
     string sdkResolverTFM;
@@ -277,6 +285,19 @@ Task("CreateMSBuildFolder")
             if (FileHelper.Exists(librarySourcePath))
             {
                 FileHelper.Copy(librarySourcePath, libraryTargetPath);
+            }
+        }
+
+        Information("Copying MSBuild dependencies...");
+
+        foreach (var dependency in msBuildDependencies)
+        {
+            var dependencyFileName = dependency + ".dll";
+            var dependencySourcePath = CombinePaths(env.Folders.Tools, dependency, "lib", "netstandard2.0", dependencyFileName);
+            var dependencyTargetPath = CombinePaths(msbuildCurrentBinTargetFolder, dependencyFileName);
+            if (FileHelper.Exists(dependencySourcePath))
+            {
+                FileHelper.Copy(dependencySourcePath, dependencyTargetPath);
             }
         }
 
@@ -312,12 +333,27 @@ Task("CreateMSBuildFolder")
         {
             var libraryFileName = library + ".dll";
 
-            // copy MSBuild from current Mono (should be 6.4.0+)
+            // copy MSBuild from current Mono
             var librarySourcePath = CombinePaths(monoMSBuildPath, libraryFileName);
             var libraryTargetPath = CombinePaths(msbuildCurrentBinTargetFolder, libraryFileName);
             if (FileHelper.Exists(librarySourcePath))
             {
                 FileHelper.Copy(librarySourcePath, libraryTargetPath);
+            }
+        }
+
+        Information("Copying MSBuild depednencies...");
+
+        foreach (var dependency in msBuildDependencies)
+        {
+            var dependencyFileName = dependency + ".dll";
+
+            // copy MSBuild from current Mono
+            var dependencySourcePath = CombinePaths(monoMSBuildPath, dependencyFileName);
+            var dependencyTargetPath = CombinePaths(msbuildCurrentBinTargetFolder, dependencyFileName);
+            if (FileHelper.Exists(dependencySourcePath))
+            {
+                FileHelper.Copy(dependencySourcePath, dependencyTargetPath);
             }
         }
 

--- a/src/OmniSharp.Host/MSBuild/Discovery/MSBuildInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/MSBuildInstanceProvider.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using NuGet.Versioning;
 
 namespace OmniSharp.MSBuild.Discovery
 {
@@ -95,6 +97,17 @@ namespace OmniSharp.MSBuild.Discovery
             return Directory.Exists(result)
                 ? result
                 : null;
+        }
+
+        protected static Version GetMSBuildVersion(string microsoftBuildPath)
+        {
+            var msbuildVersionInfo = FileVersionInfo.GetVersionInfo(microsoftBuildPath);
+            var semanticVersion = SemanticVersion.Parse(msbuildVersionInfo.ProductVersion);
+            return new Version(
+                semanticVersion.Major,
+                semanticVersion.Minor,
+                semanticVersion.Patch
+            );
         }
     }
 }

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/MonoInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/MonoInstanceProvider.cs
@@ -103,16 +103,21 @@ Try installing MSBuild into Mono (e.g. 'sudo apt-get install msbuild') to enable
             var localMSBuildPath = FindLocalMSBuildDirectory();
             if (localMSBuildPath != null)
             {
+                microsoftBuildPath = Path.Combine(localMSBuildPath, "Current", "Bin", "Microsoft.Build.dll");
+
                 var localRoslynPath = Path.Combine(localMSBuildPath, "Current", "Bin", "Roslyn");
                 propertyOverrides.Add("CscToolPath", localRoslynPath);
                 propertyOverrides.Add("CscToolExe", "csc.exe");
             }
 
+            var msbuildVersionInfo = FileVersionInfo.GetVersionInfo(microsoftBuildPath);
+            var version = Version.Parse(msbuildVersionInfo.ProductVersion);
+
             return ImmutableArray.Create(
                 new MSBuildInstance(
                     nameof(DiscoveryType.Mono),
                     toolsPath,
-                    new Version(16, 4),
+                    version,
                     DiscoveryType.Mono,
                     propertyOverrides.ToImmutable()));
         }

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/MonoInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/MonoInstanceProvider.cs
@@ -110,8 +110,7 @@ Try installing MSBuild into Mono (e.g. 'sudo apt-get install msbuild') to enable
                 propertyOverrides.Add("CscToolExe", "csc.exe");
             }
 
-            var msbuildVersionInfo = FileVersionInfo.GetVersionInfo(microsoftBuildPath);
-            var version = Version.Parse(msbuildVersionInfo.ProductVersion);
+            var version = GetMSBuildVersion(microsoftBuildPath);
 
             return ImmutableArray.Create(
                 new MSBuildInstance(

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Utilities;
@@ -25,6 +26,10 @@ namespace OmniSharp.MSBuild.Discovery.Providers
             var toolsPath = Path.Combine(extensionsPath, "Current", "Bin");
             var roslynPath = Path.Combine(toolsPath, "Roslyn");
 
+            var microsoftBuildPath = Path.Combine(toolsPath, "Microsoft.Build.dll");
+            var msbuildVersionInfo = FileVersionInfo.GetVersionInfo(microsoftBuildPath);
+            var version = Version.Parse(msbuildVersionInfo.ProductVersion);
+
             var propertyOverrides = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
 
             if (PlatformHelper.IsMono)
@@ -46,7 +51,7 @@ namespace OmniSharp.MSBuild.Discovery.Providers
                 new MSBuildInstance(
                     nameof(DiscoveryType.StandAlone),
                     toolsPath,
-                    new Version(16, 4), // we now ship with embedded MsBuild 16.4
+                    version,
                     DiscoveryType.StandAlone,
                     propertyOverrides.ToImmutable(),
                     setMSBuildExePathVariable: true));

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using Microsoft.Extensions.Logging;
+using NuGet.Versioning;
 using OmniSharp.Utilities;
 
 namespace OmniSharp.MSBuild.Discovery.Providers
@@ -26,9 +27,7 @@ namespace OmniSharp.MSBuild.Discovery.Providers
             var toolsPath = Path.Combine(extensionsPath, "Current", "Bin");
             var roslynPath = Path.Combine(toolsPath, "Roslyn");
 
-            var microsoftBuildPath = Path.Combine(toolsPath, "Microsoft.Build.dll");
-            var msbuildVersionInfo = FileVersionInfo.GetVersionInfo(microsoftBuildPath);
-            var version = Version.Parse(msbuildVersionInfo.ProductVersion);
+            var version = GetMSBuildVersion(Path.Combine(toolsPath, "Microsoft.Build.dll"));
 
             var propertyOverrides = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/UserOverrideInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/UserOverrideInstanceProvider.cs
@@ -2,6 +2,8 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
 
 namespace OmniSharp.MSBuild.Discovery.Providers
 {
@@ -22,12 +24,16 @@ namespace OmniSharp.MSBuild.Discovery.Providers
                 return ImmutableArray<MSBuildInstance>.Empty;
             }
 
+            var microsoftBuildPath = Path.Combine(_options.MSBuildPath, "Microsoft.Build.dll");
+            var msbuildVersionInfo = FileVersionInfo.GetVersionInfo(microsoftBuildPath);
+            var version = Version.Parse(msbuildVersionInfo.ProductVersion);
+
             var builder = ImmutableArray.CreateBuilder<MSBuildInstance>();
             builder.Add(
                 new MSBuildInstance(
                     _options.Name ?? $"Overridden MSBuild from {_options.MSBuildPath}",
                     _options.MSBuildPath,
-                    new Version(99, 0),
+                    version,
                     DiscoveryType.UserOverride,
                     _options.PropertyOverrides?.ToImmutableDictionary()));
             return builder.ToImmutable();

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/UserOverrideInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/UserOverrideInstanceProvider.cs
@@ -24,9 +24,7 @@ namespace OmniSharp.MSBuild.Discovery.Providers
                 return ImmutableArray<MSBuildInstance>.Empty;
             }
 
-            var microsoftBuildPath = Path.Combine(_options.MSBuildPath, "Microsoft.Build.dll");
-            var msbuildVersionInfo = FileVersionInfo.GetVersionInfo(microsoftBuildPath);
-            var version = Version.Parse(msbuildVersionInfo.ProductVersion);
+            var version = GetMSBuildVersion(Path.Combine(_options.MSBuildPath, "Microsoft.Build.dll"));
 
             var builder = ImmutableArray.CreateBuilder<MSBuildInstance>();
             builder.Add(

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Cake" version="0.37.0" />
+    <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.1" />
     <package id="Microsoft.Build" version="16.8.0-preview-20371-01" />
     <package id="Microsoft.Build.Framework" version="16.8.0-preview-20371-01" />
     <package id="Microsoft.Build.Runtime" version="16.8.0-preview-20371-01" />
@@ -29,5 +30,15 @@
     <package id="SQLitePCLRaw.bundle_green" version="1.1.2" />
     <package id="SQLitePCLRaw.core" version="1.1.2" />
     <package id="SQLitePCLRaw.provider.e_sqlite3.net45" version="1.1.2" />
+    <package id="System.Buffers" version="4.5.1" />
+    <package id="System.Collections.Immutable" version="1.7.1" />
+    <package id="System.Memory" version="4.5.4" />
+    <package id="System.Numerics.Vectors" version="4.5.0" />
+    <package id="System.Resources.Extensions" version="4.7.1" />
+    <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" />
+    <package id="System.Text.Encodings.Web" version="4.7.1" />
+    <package id="System.Text.Json" version="4.7.1" />
+    <package id="System.Threading.Tasks.Dataflow" version="4.11.1" />
+    <package id="System.Threading.Tasks.Extensions" version="4.5.4" />
     <package id="xunit.runner.console" version="2.4.0" />
 </packages>


### PR DESCRIPTION
Read the product version for the MSBuild that is discovered.

Makes https://github.com/OmniSharp/omnisharp-roslyn/pull/1875 more useful.