### PR TITLE
Default UseLegacySdkResolver to true

### DIFF
--- a/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
+++ b/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
@@ -19,7 +19,7 @@ namespace OmniSharp.Options
         /// SDKs for a project by running 'dotnet --info' and retrieving the path. This is only needed
         /// for older versions of the .NET Core SDK.
         /// </summary>
-        public bool UseLegacySdkResolver { get; set; }
+        public bool UseLegacySdkResolver { get; set; } = true;
 
         public string MSBuildExtensionsPath { get; set; }
         public string TargetFrameworkRootPath { get; set; }


### PR DESCRIPTION
Since we've had issues with SDK resolution it may be useful to enable this until issues can be fully addressed.