### PR TITLE
Add flag so that all document changes are added together

### DIFF
--- a/src/OmniSharp.Abstractions/Models/Request.cs
+++ b/src/OmniSharp.Abstractions/Models/Request.cs
@@ -11,5 +11,6 @@ namespace OmniSharp.Models
         public int Column { get; set; }
         public string Buffer { get; set; }
         public IEnumerable<LinePositionSpanTextChange> Changes { get; set; }
+        public bool ApplyChangesTogether { get; set; }
     }
 }

--- a/src/OmniSharp.Roslyn/BufferManager.cs
+++ b/src/OmniSharp.Roslyn/BufferManager.cs
@@ -32,7 +32,7 @@ namespace OmniSharp.Roslyn
 
         public bool IsTransientDocument(DocumentId documentId)
         {
-            lock(_lock)
+            lock (_lock)
             {
                 return _transientDocumentIds.Contains(documentId);
             }
@@ -74,14 +74,30 @@ namespace OmniSharp.Roslyn
                         var document = solution.GetDocument(documentId);
                         var sourceText = await document.GetTextAsync();
 
-                        foreach (var change in request.Changes)
+                        if (request.ApplyChangesTogether)
                         {
-                            var startOffset = sourceText.Lines.GetPosition(new LinePosition(change.StartLine, change.StartColumn));
-                            var endOffset = sourceText.Lines.GetPosition(new LinePosition(change.EndLine, change.EndColumn));
+                            var textChanges = new List<TextChange>();
+                            foreach (var change in request.Changes)
+                            {
+                                var startOffset = sourceText.Lines.GetPosition(new LinePosition(change.StartLine, change.StartColumn));
+                                var endOffset = sourceText.Lines.GetPosition(new LinePosition(change.EndLine, change.EndColumn));
 
-                            sourceText = sourceText.WithChanges(new[] {
-                                new TextChange(new TextSpan(startOffset, endOffset - startOffset), change.NewText)
-                            });
+                                textChanges.Add(new TextChange(new TextSpan(startOffset, endOffset - startOffset), change.NewText));
+                            }
+
+                            sourceText = sourceText.WithChanges(textChanges);
+                        }
+                        else
+                        {
+                            foreach (var change in request.Changes)
+                            {
+                                var startOffset = sourceText.Lines.GetPosition(new LinePosition(change.StartLine, change.StartColumn));
+                                var endOffset = sourceText.Lines.GetPosition(new LinePosition(change.EndLine, change.EndColumn));
+
+                                sourceText = sourceText.WithChanges(new[] {
+                                    new TextChange(new TextSpan(startOffset, endOffset - startOffset), change.NewText)
+                                });
+                            }
                         }
 
                         solution = solution.WithDocumentText(documentId, sourceText);


### PR DESCRIPTION
Multi-cursor editing, refactor rename, and other operations are broken since the C# extension started sending changes instead of buffers to the OmniSharp. 

The reason is that changes in VSCode are reported with ranges that refer to the same version of the document being edited. The BufferManager, however, expects that changes should be applied sequentially and that the later ranges will compensate for previously applied changes.

This PR adds a flag to Request that indicates all changes should be applied together instead of sequentially. Since the flags default value would apply changes sequentially, this shouldn't break any existing clients.