### PR TITLE
Fix lack of trailing italics

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Helpers/MarkdownHelpers.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/MarkdownHelpers.cs
@@ -189,6 +189,7 @@ namespace OmniSharp.Roslyn.CSharp.Helpers
                             stringBuilder.Append('`');
                         }
                         stringBuilder.Append(current.Text);
+                        brokeLine = false;
                         break;
                 }
             }
@@ -198,10 +199,16 @@ namespace OmniSharp.Roslyn.CSharp.Helpers
                 endBlock();
             }
 
+            if (!brokeLine && markdownFormat == MarkdownFormat.Italicize)
+            {
+                stringBuilder.Append("_");
+            }
+
             return;
 
             void addText(string text)
             {
+                brokeLine = false;
                 afterFirstLine = true;
                 if (!isInCodeBlock)
                 {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/QuickInfoProviderFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/QuickInfoProviderFacts.cs
@@ -709,6 +709,23 @@ class Program
             Assert.Equal("```csharp\nvoid Program.B()\n```\n\n\\*This should be escaped\\*", response.Markdown);
         }
 
+        [Fact]
+        public async Task NullableIsItalicized()
+        {
+            string content = @"
+#nullable enable
+class Program
+{
+    public static void A(string s)
+    {
+        _ = s$$;
+    }
+
+}";
+            var response = await GetTypeLookUpResponse(content);
+            Assert.Equal("```csharp\n(parameter) string s\n```\n\n_'s' is not null here\\._", response.Markdown);
+        }
+
         private async Task<QuickInfoResponse> GetTypeLookUpResponse(string content)
         {
             TestFile testFile = new TestFile("dummy.cs", content);


### PR DESCRIPTION
When the section ended without a newline, we weren't correctly ending the italic section.