### PR TITLE
Include version matched target files with minimal MSBuild

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -331,6 +331,14 @@ Task("CreateMSBuildFolder")
             }
         }
 
+        Information("Copying MSBuild runtime...");
+
+        var msbuildSourceFolder = CombinePaths(env.Folders.Tools, "Microsoft.Build.Runtime", "contentFiles", "any", "net472");
+        DirectoryHelper.Copy(msbuildSourceFolder, msbuildCurrentBinTargetFolder, copySubDirectories: false);
+
+        var msbuild15SourceFolder = CombinePaths(msbuildSourceFolder, "Current");
+        DirectoryHelper.Copy(msbuild15SourceFolder, msbuildCurrentTargetFolder);
+
         Information("Copying MSBuild libraries...");
 
         foreach (var library in msbuildLibraries)
@@ -457,9 +465,9 @@ Task("CreateMSBuildFolder")
         source: CombinePaths(env.Folders.Tools, "Newtonsoft.Json", "lib", "net45", "Newtonsoft.Json.dll"),
         destination: CombinePaths(msbuildCurrentBinTargetFolder, "Newtonsoft.Json.dll"));
 
-    // Copy content of Microsoft.Net.Compilers
-    Information("Copying Microsoft.Net.Compilers...");
-    var compilersSourceFolder = CombinePaths(env.Folders.Tools, "Microsoft.Net.Compilers", "tools");
+    // Copy content of Microsoft.Net.Compilers.Toolset
+    Information("Copying Microsoft.Net.Compilers.Toolset...");
+    var compilersSourceFolder = CombinePaths(env.Folders.Tools, "Microsoft.Net.Compilers.Toolset", "tasks", "net472");
     var compilersTargetFolder = CombinePaths(msbuildCurrentBinTargetFolder, "Roslyn");
 
     DirectoryHelper.Copy(compilersSourceFolder, compilersTargetFolder);

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -7,7 +7,7 @@
     <package id="Microsoft.Build.Runtime" version="16.8.0-preview-20371-01" />
     <package id="Microsoft.Build.Tasks.Core" version="16.8.0-preview-20371-01" />
     <package id="Microsoft.Build.Utilities.Core" version="16.8.0-preview-20371-01" />
-    <package id="Microsoft.Net.Compilers" version="3.8.0-1.20373.6" />
+    <package id="Microsoft.Net.Compilers.Toolset" version="3.8.0-1.20373.6" />
     <package id="Microsoft.DotNet.MSBuildSdkResolver" version="5.0.100-preview.8.20362.1" />
     <package id="Microsoft.Build.NuGetSdkResolver" version="5.8.0-preview.1.6718" />
     <package id="Newtonsoft.Json" version="12.0.2" />


### PR DESCRIPTION
Instead of including the .target files from the Mono on the build machine. Overwrit those .target files with the versions from the MSBuild Runtime. Also, use the non-deprecated compiler toolset package.