### PR TITLE
Support completion of unimported types.

### DIFF
--- a/src/OmniSharp.Abstractions/Models/v1/Completion/CompletionItem.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/Completion/CompletionItem.cs
@@ -85,7 +85,7 @@ namespace OmniSharp.Models.v1.Completion
         /// <summary>
         /// Index in the completions list that this completion occurred.
         /// </summary>
-        public int Data { get; set; }
+        public (int Index, bool IsExpanded) Data { get; set; }
 
         public override string ToString()
         {

--- a/src/OmniSharp.Abstractions/Models/v1/Completion/CompletionItem.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/Completion/CompletionItem.cs
@@ -85,7 +85,7 @@ namespace OmniSharp.Models.v1.Completion
         /// <summary>
         /// Index in the completions list that this completion occurred.
         /// </summary>
-        public (int Index, bool IsExpanded) Data { get; set; }
+        public int Data { get; set; }
 
         public override string ToString()
         {

--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionOptionsProvider.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionOptionsProvider.cs
@@ -1,0 +1,23 @@
+﻿#nullable enable
+
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Options;
+using OmniSharp.Options;
+using OmniSharp.Roslyn.CSharp.Services.Intellisense;
+using OmniSharp.Roslyn.Options;
+
+namespace OmniSharp.Roslyn.CSharp.Services.Completion
+{
+    [Export(typeof(IWorkspaceOptionsProvider)), Shared]
+    public class CompletionOptionsProvider : IWorkspaceOptionsProvider
+    {
+        public int Order => 0;
+
+        public OptionSet Process(OptionSet currentOptionSet, OmniSharpOptions omniSharpOptions, IOmniSharpEnvironment omnisharpEnvironment)
+            => currentOptionSet.WithChangedOption(
+                option: CompletionItemExtensions.ShowItemsFromUnimportedNamespaces,
+                language: LanguageNames.CSharp,
+                value: omniSharpOptions.RoslynExtensionsOptions.EnableImportCompletion);
+    }
+}

--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
@@ -9,7 +9,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
@@ -432,7 +431,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
 
             switch (lastCompletionItem.GetProviderName())
             {
-
                 case CompletionItemExtensions.ExtensionMethodImportCompletionProvider:
                 case CompletionItemExtensions.TypeImportCompletionProvider:
                     var sourceText = await document.GetTextAsync();

--- a/src/OmniSharp.Shared/Options/RoslynExtensionsOptions.cs
+++ b/src/OmniSharp.Shared/Options/RoslynExtensionsOptions.cs
@@ -9,6 +9,7 @@ namespace OmniSharp.Options
     {
         public bool EnableDecompilationSupport { get; set; }
         public bool EnableAnalyzersSupport { get; set; }
+        public bool EnableImportCompletion { get; set; }
         public int DocumentAnalysisTimeoutMs { get; set; } = 10 * 1000;
     }
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
@@ -13,8 +13,9 @@ using Xunit.Abstractions;
 
 namespace OmniSharp.Roslyn.CSharp.Tests
 {
-    public class CompletionFacts : AbstractTestFixture 
+    public class CompletionFacts : AbstractTestFixture
     {
+        private const int ImportCompletionTimeout = 1000;
         private readonly ILogger _logger;
 
         private string EndpointName => OmniSharpEndpoints.Completion;
@@ -145,7 +146,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
             // Populating the completion cache should take no more than a few ms, don't let it take too
             // long
-            CancellationTokenSource cts = new CancellationTokenSource(millisecondsDelay: 100);
+            CancellationTokenSource cts = new CancellationTokenSource(millisecondsDelay: ImportCompletionTimeout);
             await Task.Run(async () =>
             {
                 while (completions.IsIncomplete)
@@ -597,7 +598,7 @@ class Foo
     public virtual void Test(string text, string moreText) {}
 }
 
-class FooChild : Foo 
+class FooChild : Foo
 {
     override $$
 }
@@ -1225,7 +1226,7 @@ class C
 
             // Populating the completion list should take no more than a few ms, don't let it take too
             // long
-            CancellationTokenSource cts = new CancellationTokenSource(millisecondsDelay: 100);
+            CancellationTokenSource cts = new CancellationTokenSource(millisecondsDelay: ImportCompletionTimeout);
             await Task.Run(async () =>
             {
                 while (completions.IsIncomplete)


### PR DESCRIPTION
This needs to call a few internal overloads for completion, instead of the public versions, in order to determine whether any completions can be expanded (ie, imported) and to get the full change for these items, including the import. The public APIs do not provide this information currently.

Todo:

* [x] More testing!
* [x] Make import completion optional. In large solutions it will almost certainly be expensive, we should provide an option to turn it off.

Preview of the change in vscode (watch the line numbers!):
![import-completion](https://user-images.githubusercontent.com/2371880/90481876-51a42300-e0e7-11ea-9957-af7907989705.gif)

Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1482