### PR TITLE
Exclude Misc project from InternalsVisibleTo completion

### DIFF
--- a/src/OmniSharp.Abstractions/Configuration.cs
+++ b/src/OmniSharp.Abstractions/Configuration.cs
@@ -10,6 +10,7 @@ namespace OmniSharp
         public readonly static string RoslynFeatures = GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.Features");
         public readonly static string RoslynCSharpFeatures = GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.CSharp.Features");
         public readonly static string RoslynWorkspaces = GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.Workspaces");
+        public readonly static string OmniSharpMiscProjectName = "OmniSharpMiscellaneousFiles";
 
         private static string GetRoslynAssemblyFullName(string name)
         {

--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
@@ -151,7 +151,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             }
 
             var triggerCharactersBuilder = ImmutableArray.CreateBuilder<char>(completions.Rules.DefaultCommitCharacters.Length);
-            var completionsBuilder = new List<CompletionItem>();
+            var completionsBuilder = ImmutableArray.CreateBuilder<CompletionItem>();
 
             // If we don't encounter any unimported types, and the completion context thinks that some would be available, then
             // that completion provider is still creating the cache. We'll mark this completion list as not completed, and the
@@ -282,7 +282,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             return new CompletionResponse
             {
                 IsIncomplete = isIncomplete,
-                Items = completionsBuilder.MoveToImmutable()
+                Items = completionsBuilder.ToImmutableArray()
             };
 
             CompletionTrigger getCompletionTrigger(bool includeTriggerCharacter)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
@@ -152,8 +152,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             for (int i = 0; i < completions.Items.Length; i++)
             {
                 var completion = completions.Items[i];
-                if (!completion.IsVisible()) continue;
-
                 var commitCharacters = buildCommitCharacters(completions, completion.Rules.CommitCharacterRules, triggerCharactersBuilder);
 
                 var insertTextFormat = InsertTextFormat.PlainText;
@@ -168,7 +166,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
                             // span, only assembly keys at the end if they exist.
                             {
                                 // if the completion is for the hidden Misc files project, skip it
-                                
+                                if (completion.DisplayText == Configuration.OmniSharpMiscProjectName) continue;
                                 CompletionChange change = await completionService.GetChangeAsync(document, completion);
                                 Debug.Assert(typedSpan == change.TextChange.Span);
                                 insertText = change.TextChange.NewText!;

--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
@@ -103,17 +103,5 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
 
             return response;
         }
-
-        public static bool IsVisible(this CompletionItem item)
-        {
-            switch (item.GetProviderName())
-            {
-                case InternalsVisibleToCompletionProvider:
-                    if (item.DisplayText == Configuration.OmniSharpMiscProjectName) return false;
-                    break;
-            }
-
-            return true;
-        }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
@@ -39,15 +39,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
             _getProviderName = typeof(CompletionItem).GetProperty(ProviderName, BindingFlags.NonPublic | BindingFlags.Instance);
         }
 
-        internal static string GetProviderName(this CompletionItem item)
-        {
-            return (string)_getProviderName.GetValue(item);
-        }
+        internal static string GetProviderName(this CompletionItem item) => (string)_getProviderName.GetValue(item);
 
-        public static bool IsObjectCreationCompletionItem(this CompletionItem item)
-        {
-            return GetProviderName(item) == ObjectCreationCompletionProvider;
-        }
+        public static bool IsObjectCreationCompletionItem(this CompletionItem item) => GetProviderName(item) == ObjectCreationCompletionProvider;
 
         public static async Task<IEnumerable<ISymbol>> GetCompletionSymbolsAsync(this CompletionItem completionItem, IEnumerable<ISymbol> recommendedSymbols, Document document)
         {
@@ -81,10 +75,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
             return provider == NamedParameterCompletionProvider || provider == OverrideCompletionProvider || provider == PartialMethodCompletionProvider;
         }
 
-        public static bool TryGetInsertionText(this CompletionItem completionItem, out string insertionText)
-        {
-            return completionItem.Properties.TryGetValue(InsertionText, out insertionText);
-        }
+        public static bool TryGetInsertionText(this CompletionItem completionItem, out string insertionText) => completionItem.Properties.TryGetValue(InsertionText, out insertionText);
 
         public static AutoCompleteResponse ToAutoCompleteResponse(this CompletionItem item, bool wantKind, bool isSuggestionMode, bool preselect)
         {
@@ -111,6 +102,19 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
             }
 
             return response;
+        }
+
+        public static bool IsVisible(this CompletionItem item)
+        {
+            var providerName = GetProviderName(item);
+            switch (item.GetProviderName())
+            {
+                case CompletionItemExtensions.InternalsVisibleToCompletionProvider:
+                    if (item.DisplayText == "OmniSharpMiscellaneousFiles") return false;
+                    break;
+            }
+
+            return true;
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
@@ -106,11 +106,10 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
 
         public static bool IsVisible(this CompletionItem item)
         {
-            var providerName = GetProviderName(item);
             switch (item.GetProviderName())
             {
-                case CompletionItemExtensions.InternalsVisibleToCompletionProvider:
-                    if (item.DisplayText == "OmniSharpMiscellaneousFiles") return false;
+                case InternalsVisibleToCompletionProvider:
+                    if (item.DisplayText == Configuration.OmniSharpMiscProjectName) return false;
                     break;
             }
 

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorker.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorker.cs
@@ -163,8 +163,8 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
         private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsForDocument(Document document, string projectName)
         {
             // Only basic syntax check is available if file is miscellanous like orphan .cs file.
-            // Those projects are on hard coded virtual project named 'MiscellaneousFiles.csproj'.
-            if (projectName == "MiscellaneousFiles.csproj")
+            // Those projects are on hard coded virtual project
+            if (projectName == $"{Configuration.OmniSharpMiscProjectName}.csproj")
             {
                 var syntaxTree = await document.GetSyntaxTreeAsync();
                 return syntaxTree.GetDiagnostics().ToImmutableArray();

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
@@ -230,8 +230,8 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
                 var diagnostics = ImmutableArray<Diagnostic>.Empty;
 
                 // Only basic syntax check is available if file is miscellanous like orphan .cs file.
-                // Those projects are on hard coded virtual project named 'MiscellaneousFiles.csproj'.
-                if (project.Name == "MiscellaneousFiles.csproj")
+                // Those projects are on hard coded virtual project
+                if (project.Name == $"{Configuration.OmniSharpMiscProjectName}.csproj")
                 {
                     var syntaxTree = await document.GetSyntaxTreeAsync();
                     diagnostics = syntaxTree.GetDiagnostics().ToImmutableArray();

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -219,14 +219,13 @@ namespace OmniSharp
 
         private ProjectInfo CreateMiscFilesProject(string language)
         {
-            const string assemblyName = "OmniSharpMiscellaneousFiles";
             var projectInfo = ProjectInfo.Create(
                    id: ProjectId.CreateNewId(),
                    version: VersionStamp.Create(),
-                   name: $"{assemblyName}.csproj",
+                   name: $"{Configuration.OmniSharpMiscProjectName}.csproj",
                    metadataReferences: DefaultMetadataReferenceHelper.GetDefaultMetadataReferenceLocations()
                                        .Select(loc => MetadataReference.CreateFromFile(loc)),
-                   assemblyName: assemblyName,
+                   assemblyName: Configuration.OmniSharpMiscProjectName,
                    language: language);
 
             AddProject(projectInfo);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
@@ -608,33 +608,6 @@ class C
             });
         }
 
-        [Fact]
-        public async Task InternalsVisibleTo()
-        {
-            const string source =
-                @"  /// <summary>
-                    /// A comment. <see cref=""My$$"" /> for more details
-                    /// </summary>
-                  public class MyClass1 {
-                  }
-                ";
-
-            var completions = await FindCompletionsAsync("dummy.cs", source);
-            Assert.Contains(completions.Items, c => c.Label == "MyClass1");
-            Assert.All(completions.Items, c =>
-            {
-                switch (c.Label)
-                {
-                    case "MyClass1":
-                        Assert.True(c.Preselect);
-                        break;
-                    default:
-                        Assert.False(c.Preselect);
-                        break;
-                }
-            });
-        }
-
         [Theory]
         [InlineData("dummy.cs")]
         [InlineData("dummy.csx")]

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
@@ -1185,7 +1185,7 @@ class C
             const string input = @"
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""$$";
 
-            var completions = await FindCompletionsAsync("dummy.cs", input);
+            var completions = await FindCompletionsAsync("dummy.cs", input, SharedOmniSharpTestHost);
             Assert.Single(completions.Items);
             Assert.Equal("AssemblyNameVal", completions.Items[0].Label);
             Assert.Equal("AssemblyNameVal", completions.Items[0].InsertText);


### PR DESCRIPTION
The misc project for loose .cs files should not show up in InternalsVisibleTo suggestion.

cc @333fred 