### PR TITLE
Correctly handle multiple reference aliases

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -671,7 +671,14 @@ namespace OmniSharp.MSBuild
                     {
                         if (!string.IsNullOrEmpty(projectReferenceAliases))
                         {
-                            aliases = projectReferenceAliases.Split(';').ToImmutableArray();
+                            var trimmed = projectReferenceAliases.Split(',');
+                            
+                            for(var i = 0; i < trimmed.Length; i++)
+                            {
+                                trimmed[i] = trimmed[i].Trim();
+                            }
+                            
+                            aliases = trimmed.ToImmutableArray();
                             _logger.LogDebug($"Setting aliases: {projectReferencePath}, {projectReferenceAliases} ");
                         }
                     }
@@ -740,7 +747,14 @@ namespace OmniSharp.MSBuild
                         {
                             if (!string.IsNullOrEmpty(aliases))
                             {
-                                reference = reference.WithAliases(aliases.Split(';'));
+                                var trimmed = aliases.Split(',');
+
+                                for(var i = 0; i < trimmed.Length; i++)
+                                {
+                                    trimmed[i] = trimmed[i].Trim();
+                                }
+
+                                reference = reference.WithAliases(trimmed);
                                 _logger.LogDebug($"setting aliases: {referencePath}, {aliases} ");
                             }
                         }

--- a/test-assets/test-projects/ExternAlias/ExternAlias.App/ExternAlias.App.csproj
+++ b/test-assets/test-projects/ExternAlias/ExternAlias.App/ExternAlias.App.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <Reference Include="ExternAlias.Lib">
         <HintPath>$(ProjectDir)../ExternAlias.Lib/bin/$(Configuration)/netstandard2.0/ExternAlias.Lib.dll</HintPath>
-        <Aliases>abc</Aliases>
+        <Aliases>abc,def</Aliases>
     </Reference>
   </ItemGroup>
 

--- a/test-assets/test-projects/ExternAlias/ExternAlias.App/Program.cs
+++ b/test-assets/test-projects/ExternAlias/ExternAlias.App/Program.cs
@@ -1,4 +1,5 @@
 ﻿extern alias abc;
+extern alias def;
 using System;
 
 namespace ExternAlias.App
@@ -8,6 +9,7 @@ namespace ExternAlias.App
         static void Main(string[] args)
         {
             new abc::ExternAlias.Lib.Class1();
+            new def::ExternAlias.Lib.Class1();
             Console.WriteLine("Hello World!");
         }
     }

--- a/test-assets/test-projects/ExternAlias/ExternAlias.App2/ExternAlias.App2.csproj
+++ b/test-assets/test-projects/ExternAlias/ExternAlias.App2/ExternAlias.App2.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../ExternAlias.Lib/ExternAlias.Lib.csproj">
-        <Aliases>abc</Aliases>
+        <Aliases>abc,def</Aliases>
     </ProjectReference>
   </ItemGroup>
 

--- a/test-assets/test-projects/ExternAlias/ExternAlias.App2/Program.cs
+++ b/test-assets/test-projects/ExternAlias/ExternAlias.App2/Program.cs
@@ -1,4 +1,5 @@
 ﻿extern alias abc;
+extern alias def;
 using System;
 
 namespace ExternAlias.App
@@ -8,6 +9,7 @@ namespace ExternAlias.App
         static void Main(string[] args)
         {
             new abc::ExternAlias.Lib.Class1();
+            new def::ExternAlias.Lib.Class1();
             Console.WriteLine("Hello World!");
         }
     }

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -159,7 +159,7 @@ namespace OmniSharp.MSBuild.Tests
 
                 var libpath = Path.Combine(testProject.Directory, "ExternAlias.Lib", "bin", "Debug", "netstandard2.0", "ExternAlias.Lib.dll");
                 Assert.True(projectFileInfo.ReferenceAliases.ContainsKey(libpath));
-                Assert.Equal("abc", projectFileInfo.ReferenceAliases[libpath]);
+                Assert.Equal("abc,def", projectFileInfo.ReferenceAliases[libpath]);
             }
         }
 
@@ -179,7 +179,7 @@ namespace OmniSharp.MSBuild.Tests
 
                 var projectReferencePath = Path.Combine(testProject.Directory, "ExternAlias.Lib", "ExternAlias.Lib.csproj");
                 Assert.True(projectFileInfo.ProjectReferenceAliases.ContainsKey(projectReferencePath));
-                Assert.Equal("abc", projectFileInfo.ProjectReferenceAliases[projectReferencePath]);
+                Assert.Equal("abc,def", projectFileInfo.ProjectReferenceAliases[projectReferencePath]);
             }
         }
 

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -317,7 +317,9 @@ namespace OmniSharp.MSBuild.Tests
                     .ProjectReferences
                     .Single(x => x.ProjectId == lib.Id);
 
-                Assert.Equal("abc", projectReference.Aliases.Single());
+                Assert.Collection(projectReference.Aliases,
+                    referenceA => Assert.Equal("abc",referenceA),
+                    referenceB => Assert.Equal("def",referenceB));
             }
         }
 
@@ -337,7 +339,9 @@ namespace OmniSharp.MSBuild.Tests
                     .MetadataReferences
                     .Single(x => x.Display == "ExternAlias.Lib.dll");
 
-                Assert.Equal("abc", reference.Properties.Aliases.Single());
+                Assert.Collection(reference.Properties.Aliases,
+                    referenceA => Assert.Equal("abc",referenceA),
+                    referenceB => Assert.Equal("def",referenceB));
             }
         }
     }


### PR DESCRIPTION
The <Aliases> element of a <Reference> or <ProjectReference> supports multiple aliases.  Currently, OmniSharp will flag attempted usings of these aliases as errors, despite the fact that they are valid and the project will still build without issue.
I can find no hard documentation of this specification, but have manually tested to confirm the three primary points of this PR:

1. Multiple aliases are supported
2. They are comma separated (semicolons trigger build errors)
3. They are insensitive to both leading and trailing whitespace.