### PR TITLE
LSP Update

### DIFF
--- a/src/OmniSharp.LanguageServerProtocol/Eventing/LanguageServerEventEmitter.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Eventing/LanguageServerEventEmitter.cs
@@ -49,24 +49,24 @@ namespace OmniSharp.LanguageServerProtocol.Eventing
                 case EventTypes.ProjectAdded:
                 case EventTypes.ProjectChanged:
                 case EventTypes.ProjectRemoved:
-                    _server.SendNotification($"o#/{kind}", JToken.FromObject(args)); // ProjectInformationResponse
+                    _server.SendNotification($"o#/{kind}".ToLowerInvariant(), JToken.FromObject(args)); // ProjectInformationResponse
                     break;
 
                 // work done??
                 case EventTypes.PackageRestoreStarted:
                 case EventTypes.PackageRestoreFinished:
                 case EventTypes.UnresolvedDependencies:
-                    _server.SendNotification($"o#/{kind}", JToken.FromObject(args));
+                    _server.SendNotification($"o#/{kind}".ToLowerInvariant(), JToken.FromObject(args));
                     break;
 
                 case EventTypes.Error:
                 case EventTypes.ProjectConfiguration:
                 case EventTypes.ProjectDiagnosticStatus:
-                    _server.SendNotification($"o#/{kind}", JToken.FromObject(args));
+                    _server.SendNotification($"o#/{kind}".ToLowerInvariant(), JToken.FromObject(args));
                     break;
 
                 default:
-                    _server.SendNotification($"o#/{kind}", JToken.FromObject(args));
+                    _server.SendNotification($"o#/{kind}".ToLowerInvariant(), JToken.FromObject(args));
                     break;
             }
         }

--- a/src/OmniSharp.LanguageServerProtocol/Helpers.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Helpers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Extensions;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -16,16 +17,23 @@ namespace OmniSharp.LanguageServerProtocol
     {
         public static Diagnostic ToDiagnostic(this DiagnosticLocation location)
         {
+            var tags = new List<DiagnosticTag>();
+            foreach (var tag in location?.Tags ?? Array.Empty<string>())
+            {
+                if (tag == "Unnecessary") tags.Add(DiagnosticTag.Unnecessary);
+                if (tag == "Deprecated") tags.Add(DiagnosticTag.Deprecated);
+            }
             return new Diagnostic()
             {
                 // We don't have a code at the moment
                 // Code = quickFix.,
-                Message = location.Text,
+                Message = !string.IsNullOrWhiteSpace(location.Text) ? location.Text : location.Id,
                 Range = location.ToRange(),
                 Severity = ToDiagnosticSeverity(location.LogLevel),
                 Code = location.Id,
                 // TODO: We need to forward this type though if we add something like Vb Support
                 Source = "csharp",
+                Tags = tags,
             };
         }
 
@@ -133,6 +141,7 @@ namespace OmniSharp.LanguageServerProtocol
             { OmniSharp.Models.V2.SymbolKinds.Interface, SymbolKind.Interface },
             { OmniSharp.Models.V2.SymbolKinds.Struct, SymbolKind.Struct },
             { OmniSharp.Models.V2.SymbolKinds.Constant, SymbolKind.Constant },
+            { OmniSharp.Models.V2.SymbolKinds.Constructor, SymbolKind.Constructor },
             { OmniSharp.Models.V2.SymbolKinds.Destructor, SymbolKind.Method },
             { OmniSharp.Models.V2.SymbolKinds.EnumMember, SymbolKind.EnumMember },
             { OmniSharp.Models.V2.SymbolKinds.Event, SymbolKind.Event },

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -270,11 +270,12 @@ namespace OmniSharp.LanguageServerProtocol
             // and not loose any functionality.
             server.Register(r =>
             {
+                var defaultOptions = new JsonRpcHandlerOptions() {RequestProcessType = RequestProcessType.Parallel};
                 var interop = InitializeInterop(compositionHost);
                 foreach (var osHandler in interop)
                 {
                     var method = $"o#/{osHandler.Key.Trim('/').ToLowerInvariant()}";
-                    r.OnJsonRequest(method, CreateInteropHandler(osHandler.Value));
+                    r.OnJsonRequest(method, CreateInteropHandler(osHandler.Value), defaultOptions);
                     logger.LogTrace("O# Handler: {Method}", method);
                 }
 
@@ -286,12 +287,12 @@ namespace OmniSharp.LanguageServerProtocol
                 };
 
                 r.OnRequest<JToken, object>($"o#/{OmniSharpEndpoints.CheckAliveStatus.Trim('/').ToLowerInvariant()}",
-                    (request, cancellationToken) => Task.FromResult<object>(true));
+                    (request, cancellationToken) => Task.FromResult<object>(true), defaultOptions);
                 r.OnRequest<JToken, object>($"o#/{OmniSharpEndpoints.CheckReadyStatus.Trim('/').ToLowerInvariant()}",
                     (request, cancellationToken) =>
-                        Task.FromResult<object>(compositionHost.GetExport<OmniSharpWorkspace>().Initialized));
+                        Task.FromResult<object>(compositionHost.GetExport<OmniSharpWorkspace>().Initialized), defaultOptions);
                 r.OnRequest<JToken, object>($"o#/{OmniSharpEndpoints.StopServer.Trim('/').ToLowerInvariant()}",
-                    async (request, cancellationToken) => await server.Shutdown.ToTask(cancellationToken));
+                    async (request, cancellationToken) => await server.Shutdown.ToTask(cancellationToken), defaultOptions);
             });
             logger.LogTrace("--- Handler Definitions ---");
 

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/DiagnosticExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/DiagnosticExtensions.cs
@@ -10,7 +10,7 @@ namespace OmniSharp.Helpers
     internal static class DiagnosticExtensions
     {
         private static readonly ImmutableHashSet<string> _tagFilter =
-            ImmutableHashSet.Create("Unnecessary");
+            ImmutableHashSet.Create("Unnecessary", "Deprecated");
 
         internal static DiagnosticLocation ToDiagnosticLocation(this Diagnostic diagnostic)
         {

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorker.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorker.cs
@@ -38,12 +38,10 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
             _workspace.DocumentClosed += OnDocumentOpened;
 
             _disposable = openDocumentsSubject
-                .GroupByUntil(x => true, group => Observable.Amb(
-                    group.Throttle(TimeSpan.FromMilliseconds(200)),
-                    group.Distinct().Skip(99))
-                )
-                .Select(x => x.ToArray())
-                .Merge()
+                .Buffer(() => Observable.Amb(
+                    openDocumentsSubject.Skip(99).Select(z => Unit.Default),
+                    Observable.Timer(TimeSpan.FromMilliseconds(100)).Select(z => Unit.Default)
+                ))
                 .SubscribeOn(TaskPoolScheduler.Default)
                 .Select(ProcessQueue)
                 .Merge()
@@ -69,7 +67,7 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
             {
                 var newDocument = changeEvent.NewSolution.GetDocument(changeEvent.DocumentId);
 
-                EmitDiagnostics(_workspace.GetOpenDocumentIds().Select(x => _workspace.CurrentSolution.GetDocument(x).FilePath).ToArray());
+                EmitDiagnostics(new [] {newDocument.Id}.Concat(_workspace.GetOpenDocumentIds()).Select(x => _workspace.CurrentSolution.GetDocument(x).FilePath).ToArray());
             }
             else if (changeEvent.Kind == WorkspaceChangeKind.ProjectAdded || changeEvent.Kind == WorkspaceChangeKind.ProjectReloaded)
             {

--- a/tests/OmniSharp.Lsp.Tests/AbstractLanguageServerTestBase.cs
+++ b/tests/OmniSharp.Lsp.Tests/AbstractLanguageServerTestBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Composition.Hosting.Core;
 using System.IO;
@@ -11,9 +12,11 @@ using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using OmniSharp.Eventing;
 using OmniSharp.Extensions.JsonRpc.Testing;
 using OmniSharp.Extensions.LanguageProtocol.Testing;
 using OmniSharp.Extensions.LanguageServer.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
@@ -22,6 +25,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 using OmniSharp.Extensions.LanguageServer.Server;
 using OmniSharp.LanguageServerProtocol;
+using OmniSharp.LanguageServerProtocol.Eventing;
 using OmniSharp.Models;
 using OmniSharp.Models.FilesChanged;
 using OmniSharp.Models.UpdateBuffer;
@@ -29,6 +33,7 @@ using TestUtility;
 using TestUtility.Logging;
 using Xunit;
 using Xunit.Abstractions;
+using Diagnostic = OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic;
 
 namespace OmniSharp.Lsp.Tests
 {
@@ -39,15 +44,21 @@ namespace OmniSharp.Lsp.Tests
         private LanguageServerHost _host;
         private Task startUpTask;
         private IConfiguration _setupConfiguration;
+
+        private readonly ConcurrentDictionary<DocumentUri, IEnumerable<Diagnostic>> _diagnostics =
+            new ConcurrentDictionary<DocumentUri, IEnumerable<Diagnostic>>();
+
         protected ILogger Logger { get; }
 
-        protected AbstractLanguageServerTestBase(ITestOutputHelper output, IConfiguration configuration = null) : this(output,
+        protected AbstractLanguageServerTestBase(ITestOutputHelper output, IConfiguration configuration = null) : this(
+            output,
             new LoggerFactory().AddXunit(output))
         {
             _setupConfiguration = configuration;
         }
 
-        private AbstractLanguageServerTestBase(ITestOutputHelper output, ILoggerFactory loggerFactory, IConfiguration configuration = null) : base(
+        private AbstractLanguageServerTestBase(ITestOutputHelper output, ILoggerFactory loggerFactory,
+            IConfiguration configuration = null) : base(
             new JsonRpcTestOptions()
                 .WithClientLoggerFactory(loggerFactory)
                 .WithServerLoggerFactory(loggerFactory)
@@ -76,8 +87,8 @@ namespace OmniSharp.Lsp.Tests
                             .AddConfiguration(server.Configuration.GetSection("csharp"))
                             .AddConfiguration(server.Configuration.GetSection("omnisharp"));
                         if (_setupConfiguration != null) configBuilder.AddConfiguration(_setupConfiguration);
-                        var config =  configBuilder.Build();
-                        OmniSharpTestHost = CreateOmniSharpHost(config);
+                        var config = configBuilder.Build();
+                        OmniSharpTestHost = CreateOmniSharpHost(config, new LanguageServerEventEmitter(server));
                         var handlers =
                             LanguageServerHost.ConfigureCompositionHost(server, OmniSharpTestHost.CompositionHost);
                         _host.UnderTest(OmniSharpTestHost.ServiceProvider, OmniSharpTestHost.CompositionHost);
@@ -91,7 +102,8 @@ namespace OmniSharp.Lsp.Tests
             return (serverPipe.Reader.AsStream(), clientPipe.Writer.AsStream());
         }
 
-        public async Task Restart(IConfiguration configuration = null, IDictionary<string, string> configurationData = null)
+        public async Task Restart(IConfiguration configuration = null,
+            IDictionary<string, string> configurationData = null)
         {
             _host.Dispose();
             Disposable.Remove(Client);
@@ -106,7 +118,7 @@ namespace OmniSharp.Lsp.Tests
 
         public async Task InitializeAsync()
         {
-            var(client, configurationProvider) = await InitializeClientWithConfiguration(x =>
+            var (client, configurationProvider) = await InitializeClientWithConfiguration(x =>
             {
                 x.WithCapability(new WorkspaceEditCapability()
                 {
@@ -116,6 +128,12 @@ namespace OmniSharp.Lsp.Tests
                     {
                         ResourceOperationKind.Create, ResourceOperationKind.Delete, ResourceOperationKind.Rename
                     }
+                });
+
+                x.OnPublishDiagnostics(result =>
+                {
+                    _diagnostics.AddOrUpdate(result.Uri, result.Diagnostics,
+                        (a, b) => result.Diagnostics);
                 });
                 x.OnApplyWorkspaceEdit(async @params =>
                 {
@@ -242,7 +260,8 @@ namespace OmniSharp.Lsp.Tests
             OmniSharpTestHost.Workspace.AddProject(projectInfo);
             await OmniSharpTestHost.RestoreProject(testProject);
             await OmniSharpTestHost.GetFilesChangedService().Handle(Directory.GetFiles(testProject.Directory)
-                .Select(file => new FilesChangedRequest() {FileName = file, ChangeType = FileWatching.FileChangeType.Create}));
+                .Select(file => new FilesChangedRequest()
+                    {FileName = file, ChangeType = FileWatching.FileChangeType.Create}));
             var project = OmniSharpTestHost.Workspace.CurrentSolution.GetProject(projectInfo.Id);
             return project;
         }
@@ -254,9 +273,90 @@ namespace OmniSharp.Lsp.Tests
 
         protected OmniSharpTestHost CreateOmniSharpHost(
             IConfiguration configurationData,
+            IEventEmitter eventEmitter,
             string path = null,
             DotNetCliVersion dotNetCliVersion = DotNetCliVersion.Current,
             IEnumerable<ExportDescriptorProvider> additionalExports = null)
-            => OmniSharpTestHost.Create(path, this._output, configurationData, dotNetCliVersion, additionalExports);
+            => OmniSharpTestHost.Create(path, this._output, configurationData, dotNetCliVersion, additionalExports,
+                eventEmitter: eventEmitter);
+
+
+        public IEnumerable<ProjectId> AddFilesToWorkspace(params TestFile[] testFiles)
+            => AddFilesToWorkspace(Directory.GetCurrentDirectory(), testFiles);
+
+        public IEnumerable<ProjectId> AddFilesToWorkspace(string folderPath, params TestFile[] testFiles)
+        {
+            folderPath = folderPath ?? Directory.GetCurrentDirectory();
+            var projects = TestHelpers.AddProjectToWorkspace(
+                OmniSharpTestHost.Workspace,
+                Path.Combine(folderPath, "project.csproj"),
+                new[] {"net472"},
+                testFiles.Where(f => f.FileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)).ToArray());
+
+            foreach (var csxFile in testFiles.Where(
+                f => f.FileName.EndsWith(".csx", StringComparison.OrdinalIgnoreCase)))
+            {
+                TestHelpers.AddCsxProjectToWorkspace(OmniSharpTestHost.Workspace, csxFile);
+            }
+
+            return projects;
+        }
+
+        public IEnumerable<Diagnostic> GetDiagnostics(object path)
+        {
+            return path switch
+            {
+                DocumentUri documentUri => _diagnostics[documentUri],
+                string stringPath => _diagnostics[stringPath],
+                _ => throw new NotSupportedException()
+            };
+        }
+
+        public async Task WaitForDiagnostics(int frequency = 100, int timeout = 10000)
+        {
+            await TestHelpers.WaitUntil(() => Task.FromResult(_diagnostics.Count > 0),
+                frequency,
+                timeout
+            );
+            await SettleNext();
+        }
+
+        public async Task OpenFile(string path, string folderPath = null)
+        {
+            folderPath ??= Directory.GetCurrentDirectory();
+            var document = OmniSharpTestHost.Workspace.GetDocument(path);
+            Client.TextDocument.DidOpenTextDocument(new DidOpenTextDocumentParams()
+            {
+                TextDocument = new TextDocumentItem()
+                {
+                    Text = (await document.GetTextAsync()).ToString(),
+                    Uri = DocumentUri.File(Path.Combine(folderPath, path)),
+                    Version = 1,
+                    LanguageId = path.EndsWith("cs") || path.EndsWith("csx") ? "csharp" : "unknown"
+                }
+            });
+        }
+
+        public Task CloseFile(string path, string folderPath = null)
+        {
+            folderPath ??= Directory.GetCurrentDirectory();
+            Client.TextDocument.DidCloseTextDocument(new DidCloseTextDocumentParams()
+            {
+                TextDocument = new TextDocumentIdentifier()
+                {
+                    Uri = DocumentUri.File(Path.Combine(folderPath, path)),
+                }
+            });
+            return Task.CompletedTask;
+        }
+
+        public void ClearWorkspace()
+        {
+            var projectIds = OmniSharpTestHost.Workspace.CurrentSolution.Projects.Select(x => x.Id);
+            foreach (var projectId in projectIds)
+            {
+                OmniSharpTestHost.Workspace.RemoveProject(projectId);
+            }
+        }
     }
 }

--- a/tests/OmniSharp.Lsp.Tests/OmnisharpPublishDiagnosticFacts.cs
+++ b/tests/OmniSharp.Lsp.Tests/OmnisharpPublishDiagnosticFacts.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using OmniSharp.Extensions.LanguageServer.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Models.Diagnostics;
+using TestUtility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OmniSharp.Lsp.Tests
+{
+    public class OmnisharpPublishDiagnosticFacts : AbstractLanguageServerTestBase
+    {
+        public OmnisharpPublishDiagnosticFacts(ITestOutputHelper testOutput) : base(testOutput)
+        {
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CodeCheckSpecifiedFileOnly(bool roslynAnalyzersEnabled)
+        {
+            await ReadyHost(roslynAnalyzersEnabled);
+            var testFile = new TestFile("a.cs", "class C { int n = true; }");
+            AddFilesToWorkspace(testFile);
+            await OpenFile(testFile.FileName);
+
+            await WaitForDiagnostics();
+
+            var quickFixes = GetDiagnostics("a.cs");
+            Assert.Contains(quickFixes, x => x.Code == "CS0029");
+        }
+
+        private Task ReadyHost(bool roslynAnalyzersEnabled)
+        {
+            return Restart(configurationData: new Dictionary<string, string>
+                {{"RoslynExtensionsOptions:EnableAnalyzersSupport", roslynAnalyzersEnabled.ToString()}});
+        }
+
+        [Fact]
+        public async Task CheckAllFilesOnNonAnalyzerReturnImmediatlyAllResults()
+        {
+            await ReadyHost(false);
+            AddFilesToWorkspace(
+                new TestFile("a.cs", "class C1 { int n = true; }"),
+                new TestFile("b.cs", "class C2 { int n = true; }"));
+
+            await SettleNext();
+
+            Assert.Contains(GetDiagnostics("a.cs"), x => x.Code == "CS0029");
+            Assert.Contains(GetDiagnostics("b.cs"), x => x.Code == "CS0029");
+        }
+
+        [Fact]
+        public async Task CheckAllFilesWithAnalyzersWillEventuallyReturnAllResults()
+        {
+            await ReadyHost(true);
+            AddFilesToWorkspace(
+                new TestFile("a.cs", "class C1 { int n = true; }"),
+                new TestFile("b.cs", "class C2 { int n = true; }"));
+
+            await WaitForDiagnostics();
+
+            Assert.Contains(GetDiagnostics("a.cs"),
+                x => x.Code == "CS0029");
+            Assert.Contains(GetDiagnostics("b.cs"),
+                x => x.Code == "CS0029");
+        }
+
+        // [Theory]
+        // [InlineData(true)]
+        // [InlineData(false)]
+        // public async Task WhenFileIsDeletedFromWorkSpaceThenResultsAreNotReturnedAnyMore(bool roslynAnalyzersEnabled)
+        // {
+        //     await ReadyHost(roslynAnalyzersEnabled);
+        //     AddFilesToWorkspace(new TestFile("a.cs", "class C1 { int n = true; }"));
+        //         await host.RequestCodeCheckAsync();
+        //
+        //         foreach (var doc in host.Workspace.CurrentSolution.Projects.SelectMany(x => x.Documents))
+        //         {
+        //             // Theres document for each targeted framework, lets delete all.
+        //             host.Workspace.RemoveDocument(doc.Id);
+        //         }
+        //
+        //         var quickFixes = await host.RequestCodeCheckAsync();
+        //
+        //         Assert.DoesNotContain(quickFixes.QuickFixes.OfType<DiagnosticLocation>(),
+        //             x => x.Id == "CS0029" && x.FileName == "a.cs");
+        // }
+
+        [Fact]
+        public async Task AnalysisSupportBuiltInIDEAnalysers()
+        {
+            await ReadyHost(true);
+            AddFilesToWorkspace(new TestFile("a.cs", "class C1 { int n = true; }"));
+
+            await WaitForDiagnostics();
+            Assert.Contains(GetDiagnostics("a.cs"), x => x.Code == "IDE0044");
+        }
+
+        [Fact]
+        public async Task WhenUnusedImportExistsWithoutAnalyzersEnabled_ThenReturnEmptyTags()
+        {
+            await ReadyHost(false);
+            AddFilesToWorkspace(
+                new TestFile("returnemptytags.cs", @"using System.IO;"));
+
+            await WaitForDiagnostics();
+
+            var allDiagnostics = GetDiagnostics("returnemptytags.cs");
+
+            Assert.Empty(allDiagnostics.SelectMany(x => x.Tags));
+        }
+
+        [Fact]
+        public async Task WhenUnusedImportIsFoundAndAnalyzersEnabled_ThenReturnUnnecessaryTag()
+        {
+            await ReadyHost(true);
+            AddFilesToWorkspace(
+                new TestFile("returnidetags.cs", @"using System.IO;"));
+
+            await WaitForDiagnostics();
+
+            Assert.Contains(DiagnosticTag.Unnecessary,
+                GetDiagnostics("returnidetags.cs")
+                .Single(x => x.Code == "IDE0005")
+                .Tags);
+        }
+
+        [Fact]
+        // issue: https://github.com/OmniSharp/omnisharp-roslyn/issues/1619
+        public async Task DoesNotErroneouslyReportCS0019_WhenComparingToDefault()
+        {
+            await ReadyHost(true);
+            AddFilesToWorkspace(
+                new TestFile("a.cs", "class C1 { bool Test(object input) => input == default; }"));
+
+            await WaitForDiagnostics();
+
+            var allDiagnostics = GetDiagnostics("a.cs").Where(x => x.Code == "CS0019");
+            Assert.Empty(allDiagnostics);
+        }
+    }
+}

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/DiagnosticsFacts.cs
@@ -18,7 +18,6 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             _testOutput = testOutput;
         }
 
-
         [Theory]
         [InlineData(true)]
         [InlineData(false)]


### PR DESCRIPTION
* Added LSP publish diagnostic tests
* Added diagnostic helper methods to `AbstractLanguageServerTestBase`
* OmniSharp events were not sending with the expected name (all lower case)
* Added Diagnostic tags
* Ensure LSP interop is always using parallel requests and responses - Avoids sending extra `Content Modified` errors,

LSP update Fixes: #1898