### PR TITLE
Updated to ILSpy 6.1.0.5902

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -14,7 +14,7 @@
 
     <PackageReference Update="Dotnet.Script.DependencyModel" Version="0.53.0" />
     <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="0.53.0" />
-    <PackageReference Update="ICSharpCode.Decompiler" Version="5.0.2.5153" />
+    <PackageReference Update="ICSharpCode.Decompiler" Version="6.1.0.5902" />
     <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
 
     <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />

--- a/src/OmniSharp.Roslyn.CSharp/Services/Decompilation/AssemblyResolver.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Decompilation/AssemblyResolver.cs
@@ -39,6 +39,12 @@ namespace OmniSharp.Roslyn.CSharp.Services.Decompilation
             }
         }
 
+        public bool IsGacAssembly(IAssemblyReference reference)
+        {
+            // not called at the moment
+            throw new NotSupportedException();
+        }
+
         public PEFile Resolve(IAssemblyReference name)
         {
             Log("Resolving: {0}", name.FullName);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
@@ -483,7 +483,7 @@ class Bar {
             // second comment should indicate we have decompiled
             var comments = compilationUnit.DescendantTrivia().Where(t => t.Kind() == SyntaxKind.SingleLineCommentTrivia).ToArray();
             Assert.NotNull(comments);
-            Assert.Equal("// Decompiled with ICSharpCode.Decompiler 5.0.2.5153", comments[1].ToString());
+            Assert.Equal("// Decompiled with ICSharpCode.Decompiler 6.1.0.5902", comments[1].ToString());
 
             // contrary to regular metadata, we should have methods with full bodies
             // this condition would fail if decompilation wouldn't work


### PR DESCRIPTION
Similar to https://github.com/dotnet/roslyn/pull/46679
Release notes: https://github.com/icsharpcode/ILSpy/releases

Introduces some C# 9 feature support + plenty of C# 8 features