### PR TITLE
Use ExecutionPolicy Bypass when running powershell.exe

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell.exe -NoProfile .\build.ps1 "%*"
+powershell.exe -NoProfile -ExecutionPolicy Bypass .\build.ps1 "%*"

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -223,7 +223,7 @@ public class BuildEnvironment
         if (Platform.Current.IsWindows) this.DotNetCommand += ".exe";
 
         this.ShellCommand = Platform.Current.IsWindows ? "powershell" : "bash";
-        this.ShellArgument = Platform.Current.IsWindows ? "-NoProfile /Command" : "-C";
+        this.ShellArgument = Platform.Current.IsWindows ? "-NoProfile -ExecutionPolicy Bypass /Command" : "-C";
         this.ShellScriptFileExtension = Platform.Current.IsWindows ? "ps1" : "sh";
         this.MonoRuntimes = new []
         {


### PR DESCRIPTION
Using Bypass policy will avoid errors when running build.cmd on system that does not have ExecutionPolicy set in powershell.exe, or when running build.ps1 from PowerShell Core (pwsh.exe).