### PR TITLE
Bypass execution policy when running build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell.exe -NoProfile .\build.ps1 "%*"
+powershell.exe -NoProfile -ExecutionPolicy bypass .\build.ps1 "%*"


### PR DESCRIPTION
This fixes build errors on windows where other scripts can't be loaded