### PR TITLE
Only run dotnet --info once for the working directory

### DIFF
--- a/src/OmniSharp.Host/CompositionHostBuilder.cs
+++ b/src/OmniSharp.Host/CompositionHostBuilder.cs
@@ -59,12 +59,12 @@ namespace OmniSharp
             // We must register an MSBuild instance before composing MEF to ensure that
             // our AssemblyResolve event is hooked up first.
             var msbuildLocator = _serviceProvider.GetRequiredService<IMSBuildLocator>();
+            var dotNetInfo = dotNetCliService.GetInfo(workingDirectory);
 
             // Don't register the default instance if an instance is already registered!
             // This is for tests, where the MSBuild instance may be registered early.
             if (msbuildLocator.RegisteredInstance == null)
             {
-                var dotNetInfo = dotNetCliService.GetInfo(workingDirectory);
                 msbuildLocator.RegisterDefaultInstance(logger, dotNetInfo);
             }
 
@@ -82,7 +82,8 @@ namespace OmniSharp
                 .WithProvider(MefValueProvider.From(analyzerAssemblyLoader))
                 .WithProvider(MefValueProvider.From(dotNetCliService))
                 .WithProvider(MefValueProvider.From(msbuildLocator))
-                .WithProvider(MefValueProvider.From(eventEmitter));
+                .WithProvider(MefValueProvider.From(eventEmitter))
+                .WithProvider(MefValueProvider.From(dotNetInfo));
 
             foreach (var exportDescriptorProvider in _exportDescriptorProviders)
             {

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -87,8 +87,9 @@ namespace TestUtility
             IEnumerable<ExportDescriptorProvider> additionalExports = null,
             [CallerMemberName] string callerName = "")
         {
+            var environment = serviceProvider.GetRequiredService<IOmniSharpEnvironment>();
             var compositionHost = new CompositionHostBuilder(serviceProvider, s_lazyAssemblies.Value, additionalExports)
-                .Build(workingDirectory: null);
+                .Build(environment.TargetDirectory);
 
             WorkspaceInitializer.Initialize(serviceProvider, compositionHost);
 


### PR DESCRIPTION
At the moment we run `dotnet --info` twice in the working directory when OmniSharp starts up.
This PR changes it to be once only, shaving about 300ms from the startup time (on my machine).