### PR TITLE
Fix namespace icon

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
@@ -59,7 +59,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             { WellKnownTags.Keyword, CompletionItemKind.Keyword },
             { WellKnownTags.Label, CompletionItemKind.Text },
             { WellKnownTags.Local, CompletionItemKind.Variable },
-            { WellKnownTags.Namespace, CompletionItemKind.Text },
+            { WellKnownTags.Namespace, CompletionItemKind.Module },
             { WellKnownTags.Method, CompletionItemKind.Method },
             { WellKnownTags.Module, CompletionItemKind.Module },
             { WellKnownTags.Operator, CompletionItemKind.Operator },


### PR DESCRIPTION
Namespace was set to Text kind in the #1877, but it should be set to Module kind. 

Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/4051