### PR TITLE
Allow build.cmd to run from any directory

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass .\build.ps1 "%*"
+powershell.exe -NoProfile -ExecutionPolicy Bypass %~dp0build.ps1 "%*"

--- a/build.ps1
+++ b/build.ps1
@@ -42,7 +42,7 @@ http://cakebuild.net
 Param(
     [parameter(position=0)]
     [string]$Target = "Default",
-    [string]$Script = "build.cake",
+    [string]$Script = "$PSScriptRoot/build.cake",
     [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Debug",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
@@ -84,10 +84,6 @@ function MD5HashFile([string] $filePath)
 }
 
 Write-Host "Preparing to run build script..."
-
-if(!$PSScriptRoot){
-    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
-}
 
 $TOOLS_DIR = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "tools"))
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"


### PR DESCRIPTION
Use paths relative to the location of build.cmd and build.ps1 when looking for dependencies, this allows the build to be run from any current directory.