### PR TITLE
Fix completion on part of existing string

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass .\build.ps1 "%*"
+powershell.exe -NoProfile -ExecutionPolicy Bypass %~dp0build.ps1 "%*"

--- a/build.ps1
+++ b/build.ps1
@@ -42,7 +42,7 @@ http://cakebuild.net
 Param(
     [parameter(position=0)]
     [string]$Target = "Default",
-    [string]$Script = "build.cake",
+    [string]$Script = "$PSScriptRoot/build.cake",
     [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Debug",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
@@ -84,10 +84,6 @@ function MD5HashFile([string] $filePath)
 }
 
 Write-Host "Preparing to run build script..."
-
-if(!$PSScriptRoot){
-    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
-}
 
 $TOOLS_DIR = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "tools"))
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"

--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
@@ -242,6 +242,19 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
                                     break;
                                 }
 
+                                // If the span we are using is re-using part of the typed text we just need to grab the completion an prefix it
+                                // with the existing text. Such as Onenabled -> OnEnabled, this will re-use On of the typed text
+                                if (typedSpan.Start < change.TextChange.Span.Start && typedSpan.Start < change.TextChange.Span.End && typedSpan.End == change.TextChange.Span.End)
+                                {
+                                    var prefix = typedText.Substring(0, change.TextChange.Span.Start - typedSpan.Start);
+                                    
+                                    (insertText, insertTextFormat) = getAdjustedInsertTextWithPosition(change, position, newOffset: 0);
+
+                                    insertText = prefix + insertText;
+
+                                    break;
+                                }
+
                                 int additionalEditEndOffset;
                                 (additionalTextEdits, additionalEditEndOffset) = await GetAdditionalTextEdits(change, sourceText, (CSharpParseOptions)syntax!.Options, typedSpan, completion.DisplayText, providerName);
 


### PR DESCRIPTION
When completion re-uses part of existing string the proposed change should re-use the part of the string in the original span and commit the change. 

Fix https://github.com/OmniSharp/omnisharp-vscode/issues/4063