### PR TITLE
Correct regex completion

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
@@ -174,6 +174,16 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
                     string providerName = completion.GetProviderName();
                     switch (providerName)
                     {
+                        case CompletionItemExtensions.EmeddedLanguageCompletionProvider:
+                            // The Regex completion provider can change escapes based on whether
+                            // we're in a verbatim string or not
+                            {
+                                CompletionChange change = await completionService.GetChangeAsync(document, completion);
+                                Debug.Assert(typedSpan == change.TextChange.Span);
+                                insertText = change.TextChange.NewText!;
+                            }
+                            break;
+
                         case CompletionItemExtensions.InternalsVisibleToCompletionProvider:
                             // The IVT completer doesn't add extra things before the completion
                             // span, only assembly keys at the end if they exist.

--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
@@ -26,6 +26,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
         internal const string XmlDocCommentCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.XmlDocCommentCompletionProvider";
         internal const string TypeImportCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.TypeImportCompletionProvider";
         internal const string ExtensionMethodImportCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.ExtensionMethodImportCompletionProvider";
+        internal const string EmeddedLanguageCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.EmbeddedLanguageCompletionProvider";
         private const string ProviderName = nameof(ProviderName);
         private const string SymbolCompletionItem = "Microsoft.CodeAnalysis.Completion.Providers.SymbolCompletionItem";
         private const string SymbolKind = nameof(SymbolKind);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
@@ -1336,6 +1336,48 @@ class C
             Assert.Equal("AssemblyNameVal", completions.Items[0].InsertText);
         }
 
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task RegexCompletionInNormalString(string filename)
+        {
+            const string input = @"
+using System.Text.RegularExpressions;
+class Foo
+{
+    public void M()
+    {
+        _ = new Regex(""$$"");
+    }
+}";
+
+            var completions = await FindCompletionsAsync(filename, input, SharedOmniSharpTestHost);
+            var aCompletion = completions.Items.First(c => c.Label == @"\A");
+            Assert.NotNull(aCompletion);
+            Assert.Equal(@"\\A", aCompletion.InsertText);
+        }
+
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task RegexCompletionInVerbatimString(string filename)
+        {
+            const string input = @"
+using System.Text.RegularExpressions;
+class Foo
+{
+    public void M()
+    {
+        _ = new Regex(@""$$"");
+    }
+}";
+
+            var completions = await FindCompletionsAsync(filename, input, SharedOmniSharpTestHost);
+            var aCompletion = completions.Items.First(c => c.Label == @"\A");
+            Assert.NotNull(aCompletion);
+            Assert.Equal(@"\A", aCompletion.InsertText);
+        }
+
         private CompletionService GetCompletionService(OmniSharpTestHost host)
             => host.GetRequestHandler<CompletionService>(EndpointName);
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
@@ -1336,7 +1336,7 @@ class C
             Assert.Equal("AssemblyNameVal", completions.Items[0].InsertText);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(WindowsOnly))]
         [InlineData("dummy.cs")]
         [InlineData("dummy.csx")]
         public async Task RegexCompletionInNormalString(string filename)
@@ -1357,7 +1357,7 @@ class Foo
             Assert.Equal(@"\\A", aCompletion.InsertText);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(WindowsOnly))]
         [InlineData("dummy.cs")]
         [InlineData("dummy.csx")]
         public async Task RegexCompletionInVerbatimString(string filename)


### PR DESCRIPTION
Depending on whether the context is a verbatim string or not, the regex provider will escape the text, so we need to realize it ahead of time. Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1949.
