### PR TITLE
Marked /autocomplete as obsolete

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/IntellisenseService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/IntellisenseService.cs
@@ -15,6 +15,7 @@ using OmniSharp.Roslyn.CSharp.Services.Documentation;
 
 namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
 {
+    [Obsolete("Please use CompletionService.")]
     [OmniSharpHandler(OmniSharpEndpoints.AutoComplete, LanguageNames.CSharp)]
     public class IntellisenseService : IRequestHandler<AutoCompleteRequest, IEnumerable<AutoCompleteResponse>>
     {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/IntellisenseFacts.cs
@@ -475,6 +475,33 @@ class C
             Assert.Contains(@"The ""G"" standard format specifier", gStandardCompletion.Description);
         }
 
+        [ConditionalTheory(typeof(WindowsOnly))]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task Embedded_language_completion_provider_for_regex(string filename)
+        {
+            const string source = @"		
+ using System;		
+ using System.Text.RegularExpressions;		
+ class C		
+ {		
+     void M()		
+     {		
+         var r = Regex.Match(""foo"", ""$$""		
+     }		
+ }		
+ ";
+
+            var completions = await FindCompletionsAsync(filename, source);
+
+            Assert.NotEmpty(completions);
+
+            var wCompletion = completions.FirstOrDefault(x => x.CompletionText == @"\w");
+            Assert.NotNull(wCompletion);
+            Assert.Equal("word character", wCompletion.DisplayText);
+            Assert.Contains(@"matches any word character", wCompletion.Description);
+        }
+
         [Fact]
         public async Task Scripting_by_default_returns_completions_for_CSharp7_1()
         {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/OmniSharp.Roslyn.CSharp.Tests.csproj
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/OmniSharp.Roslyn.CSharp.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net472</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <WarningsNotAsErrors>CS0618</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The clients should be switching to  `/completion` and `/completion/resolve`.
Additionally based on the conversation in https://github.com/OmniSharp/omnisharp-roslyn/pull/1950 I restored one deleted test as conditional on Windows only.