### PR TITLE
Correctly handle <ProjectReferences> that don't produce references

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectFile/MetadataNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/MetadataNames.cs
@@ -5,7 +5,7 @@
         public const string FullPath = nameof(FullPath);
         public const string IsImplicitlyDefined = nameof(IsImplicitlyDefined);
         public const string Project = nameof(Project);
-        public const string OriginalItemSpec = nameof(OriginalItemSpec);
+        public const string MSBuildSourceProjectFile = nameof(MSBuildSourceProjectFile);
         public const string ReferenceSourceTarget = nameof(ReferenceSourceTarget);
         public const string Version = nameof(Version);
         public const string Aliases = nameof(Aliases);

--- a/src/OmniSharp.MSBuild/ProjectFile/MetadataNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/MetadataNames.cs
@@ -5,7 +5,7 @@
         public const string FullPath = nameof(FullPath);
         public const string IsImplicitlyDefined = nameof(IsImplicitlyDefined);
         public const string Project = nameof(Project);
-        public const string MSBuildSourceProjectFile = nameof(MSBuildSourceProjectFile);
+        public const string ProjectReferenceOriginalItemSpec = nameof(ProjectReferenceOriginalItemSpec);
         public const string ReferenceSourceTarget = nameof(ReferenceSourceTarget);
         public const string Version = nameof(Version);
         public const string Aliases = nameof(Aliases);

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
@@ -240,8 +240,10 @@ namespace OmniSharp.MSBuild.ProjectFile
                     documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, warningsAsErrors, warningsNotAsErrors, signAssembly, assemblyOriginatorKeyFile, treatWarningsAsErrors, defaultNamespace, runAnalyzers, runAnalyzersDuringLiveAnalysis, ruleset: null);
             }
 
-            public static ProjectData Create(MSB.Execution.ProjectInstance projectInstance, MSB.Evaluation.Project project)
+            public static ProjectData Create(string projectFilePath, MSB.Execution.ProjectInstance projectInstance, MSB.Evaluation.Project project)
             {
+                var projectFolderPath = Path.GetDirectoryName(projectFilePath);
+
                 var guid = PropertyConverter.ToGuid(projectInstance.GetPropertyValue(PropertyNames.ProjectGuid));
                 var name = projectInstance.GetPropertyValue(PropertyNames.ProjectName);
                 var assemblyName = projectInstance.GetPropertyValue(PropertyNames.AssemblyName);
@@ -300,14 +302,16 @@ namespace OmniSharp.MSBuild.ProjectFile
                     // MSBuild logic is adding or removing properties too.
                     if (StringComparer.OrdinalIgnoreCase.Equals(referenceSourceTarget, ItemNames.ProjectReference))
                     {
-                        var sourceProjectFile = referencePathItem.GetMetadataValue(MetadataNames.MSBuildSourceProjectFile);
-                        if (sourceProjectFile.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+                        var projectReferenceOriginalItemSpec = referencePathItem.GetMetadataValue(MetadataNames.ProjectReferenceOriginalItemSpec);
+                        if (projectReferenceOriginalItemSpec.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
                         {
-                            projectReferences.Add(sourceProjectFile);
+                            var projectReferenceFilePath = Path.GetFullPath(Path.Combine(projectFolderPath, projectReferenceOriginalItemSpec));
+
+                            projectReferences.Add(projectReferenceFilePath);
 
                             if (!string.IsNullOrEmpty(aliases))
                             {
-                                projectReferenceAliases[sourceProjectFile] = aliases;
+                                projectReferenceAliases[projectReferenceFilePath] = aliases;
                             }
 
                             continue;

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -119,7 +119,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 return (null, diagnostics, null);
             }
 
-            var data = ProjectData.Create(projectInstance, project);
+            var data = ProjectData.Create(filePath, projectInstance, project);
             var projectFileInfo = new ProjectFileInfo(projectIdInfo, filePath, data, sessionId, dotNetInfo);
             var eventArgs = new ProjectLoadedEventArgs(projectIdInfo.Id,
                                                        project,
@@ -143,7 +143,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 return (null, diagnostics, null);
             }
 
-            var data = ProjectData.Create(projectInstance, project);
+            var data = ProjectData.Create(FilePath, projectInstance, project);
             var projectFileInfo = new ProjectFileInfo(ProjectIdInfo, FilePath, data, SessionId, DotNetInfo);
             var eventArgs = new ProjectLoadedEventArgs(Id,
                                                        project,

--- a/test-assets/test-projects/ProjectWithAnalyzersFromReference/Analyzer/Analyzer.csproj
+++ b/test-assets/test-projects/ProjectWithAnalyzersFromReference/Analyzer/Analyzer.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test-assets/test-projects/ProjectWithAnalyzersFromReference/Analyzer/Class1.cs
+++ b/test-assets/test-projects/ProjectWithAnalyzersFromReference/Analyzer/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Analyzer
+{
+    public class Class1
+    {
+    }
+}

--- a/test-assets/test-projects/ProjectWithAnalyzersFromReference/ConsumingProject/ConsumingProject.csproj
+++ b/test-assets/test-projects/ProjectWithAnalyzersFromReference/ConsumingProject/ConsumingProject.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Analyzer\Analyzer.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/test-assets/test-projects/ProjectWithAnalyzersFromReference/ConsumingProject/Program.cs
+++ b/test-assets/test-projects/ProjectWithAnalyzersFromReference/ConsumingProject/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConsumingProject.App
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/test-assets/test-projects/ProjectWithAnalyzersFromReference/ProjectWithAnalyzersFromReference.sln
+++ b/test-assets/test-projects/ProjectWithAnalyzersFromReference/ProjectWithAnalyzersFromReference.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Analyzer", "Analyzer\Analyzer.csproj", "{447E6D15-63B0-47F3-9E44-D6F0D0087C46}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsumingProject", "ConsumingProject\ConsumingProject.csproj", "{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{447E6D15-63B0-47F3-9E44-D6F0D0087C46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{447E6D15-63B0-47F3-9E44-D6F0D0087C46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{447E6D15-63B0-47F3-9E44-D6F0D0087C46}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{447E6D15-63B0-47F3-9E44-D6F0D0087C46}.Debug|x64.Build.0 = Debug|Any CPU
+		{447E6D15-63B0-47F3-9E44-D6F0D0087C46}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{447E6D15-63B0-47F3-9E44-D6F0D0087C46}.Debug|x86.Build.0 = Debug|Any CPU
+		{447E6D15-63B0-47F3-9E44-D6F0D0087C46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{447E6D15-63B0-47F3-9E44-D6F0D0087C46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{447E6D15-63B0-47F3-9E44-D6F0D0087C46}.Release|x64.ActiveCfg = Release|Any CPU
+		{447E6D15-63B0-47F3-9E44-D6F0D0087C46}.Release|x64.Build.0 = Release|Any CPU
+		{447E6D15-63B0-47F3-9E44-D6F0D0087C46}.Release|x86.ActiveCfg = Release|Any CPU
+		{447E6D15-63B0-47F3-9E44-D6F0D0087C46}.Release|x86.Build.0 = Release|Any CPU
+		{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}.Debug|x64.Build.0 = Debug|Any CPU
+		{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}.Debug|x86.Build.0 = Debug|Any CPU
+		{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}.Release|x64.ActiveCfg = Release|Any CPU
+		{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}.Release|x64.Build.0 = Release|Any CPU
+		{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}.Release|x86.ActiveCfg = Release|Any CPU
+		{ECC29DFA-3AC0-474E-9C5C-C8AD4D3DD17D}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -229,5 +229,19 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.Equal(ReportDiagnostic.Suppress, compilationOptions.SpecificDiagnosticOptions["CS7081"]);
             }
         }
+
+        [Fact]
+        public async Task ProjectReferenceProducingAnalyzerItems()
+        {
+            using (var host = CreateOmniSharpHost())
+            using (var testProject = await _testAssets.GetTestProjectAsync("ProjectWithAnalyzersFromReference"))
+            {
+                var projectFilePath = Path.Combine(testProject.Directory, "ConsumingProject", "ConsumingProject.csproj");
+                var projectFileInfo = CreateProjectFileInfo(host, testProject, projectFilePath);
+                Assert.Empty(projectFileInfo.ProjectReferences);
+                var analyzerFileReference = Assert.Single(projectFileInfo.Analyzers);
+                Assert.EndsWith("Analyzer.dll", analyzerFileReference);
+            }
+        }
     }
 }


### PR DESCRIPTION
<ProjectReference> elements can have metadata that specify what type of item to create, or that they shouldn't create items at all. The existing code that was processing references wasn't checking for this metadata, so you could end up with project references between projects that shouldn't be there.

The approach to take here is to never look at the <ProjectReference> items directly, rather only look at the ReferencePath items that are produced, and if we see metadata that indicates it came from a project, convert it to a project reference at that point.