### PR TITLE
Apply bulk changes

### DIFF
--- a/src/OmniSharp.Abstractions/Models/Request.cs
+++ b/src/OmniSharp.Abstractions/Models/Request.cs
@@ -11,5 +11,6 @@ namespace OmniSharp.Models
         public int Column { get; set; }
         public string Buffer { get; set; }
         public IEnumerable<LinePositionSpanTextChange> Changes { get; set; }
+        public bool ApplyChangesTogether { get; set; }
     }
 }

--- a/src/OmniSharp.Abstractions/Models/Request.cs
+++ b/src/OmniSharp.Abstractions/Models/Request.cs
@@ -11,6 +11,7 @@ namespace OmniSharp.Models
         public int Column { get; set; }
         public string Buffer { get; set; }
         public IEnumerable<LinePositionSpanTextChange> Changes { get; set; }
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public bool ApplyChangesTogether { get; set; }
     }
 }

--- a/src/OmniSharp.Roslyn/BufferManager.cs
+++ b/src/OmniSharp.Roslyn/BufferManager.cs
@@ -32,7 +32,7 @@ namespace OmniSharp.Roslyn
 
         public bool IsTransientDocument(DocumentId documentId)
         {
-            lock(_lock)
+            lock (_lock)
             {
                 return _transientDocumentIds.Contains(documentId);
             }
@@ -74,14 +74,30 @@ namespace OmniSharp.Roslyn
                         var document = solution.GetDocument(documentId);
                         var sourceText = await document.GetTextAsync();
 
-                        foreach (var change in request.Changes)
+                        if (request.ApplyChangesTogether)
                         {
-                            var startOffset = sourceText.Lines.GetPosition(new LinePosition(change.StartLine, change.StartColumn));
-                            var endOffset = sourceText.Lines.GetPosition(new LinePosition(change.EndLine, change.EndColumn));
+                            var textChanges = new List<TextChange>();
+                            foreach (var change in request.Changes)
+                            {
+                                var startOffset = sourceText.Lines.GetPosition(new LinePosition(change.StartLine, change.StartColumn));
+                                var endOffset = sourceText.Lines.GetPosition(new LinePosition(change.EndLine, change.EndColumn));
 
-                            sourceText = sourceText.WithChanges(new[] {
-                                new TextChange(new TextSpan(startOffset, endOffset - startOffset), change.NewText)
-                            });
+                                textChanges.Add(new TextChange(new TextSpan(startOffset, endOffset - startOffset), change.NewText));
+                            }
+
+                            sourceText = sourceText.WithChanges(textChanges);
+                        }
+                        else
+                        {
+                            foreach (var change in request.Changes)
+                            {
+                                var startOffset = sourceText.Lines.GetPosition(new LinePosition(change.StartLine, change.StartColumn));
+                                var endOffset = sourceText.Lines.GetPosition(new LinePosition(change.EndLine, change.EndColumn));
+
+                                sourceText = sourceText.WithChanges(new[] {
+                                    new TextChange(new TextSpan(startOffset, endOffset - startOffset), change.NewText)
+                                });
+                            }
                         }
 
                         solution = solution.WithDocumentText(documentId, sourceText);


### PR DESCRIPTION
I rebased this on current master and added an additional setting to `ApplyChangesTogether` to default it to false when not present.

@JoeRobich can you describe the issues you were still seeing in vscode with this change applied? I tried reverting the revert of my vscode-side change and adding this flag (https://github.com/OmniSharp/omnisharp-vscode/pull/4088), and everything that I've tried since has seemed to work. Completion still triggers correctly, colorization appears to work, etc, but I'm not sure if I'm missing a test scenario you had? What I tried:
1. Wait for omnisharp to load
2. Rename a local used in multiple location/Use multiple cursors to type garbage in a bunch of locations
3. Verify that the buffer update had multiple updates in it, not one big update.
4. Tested colorization and intellisense after doing this