### PR TITLE
always log error responses with error level

### DIFF
--- a/src/OmniSharp.Stdio/Host.cs
+++ b/src/OmniSharp.Stdio/Host.cs
@@ -232,6 +232,8 @@ namespace OmniSharp.Stdio
             }
             finally
             {
+                // response gets logged when Debug or more detailed log level is enabled
+                // or when we have unsuccessful response (exception)
                 if (logger.IsEnabled(LogLevel.Debug) || !response.Success)
                 {
                     LogResponse(response.ToString(), logger, response.Success);

--- a/src/OmniSharp.Stdio/Host.cs
+++ b/src/OmniSharp.Stdio/Host.cs
@@ -232,9 +232,9 @@ namespace OmniSharp.Stdio
             }
             finally
             {
-                if (logger.IsEnabled(LogLevel.Debug))
+                if (logger.IsEnabled(LogLevel.Debug) || !response.Success)
                 {
-                    LogResponse(response.ToString(), logger);
+                    LogResponse(response.ToString(), logger, response.Success);
                 }
 
                 // actually write it
@@ -257,14 +257,22 @@ namespace OmniSharp.Stdio
             }
         }
 
-        void LogResponse(string json, ILogger logger)
+        void LogResponse(string json, ILogger logger, bool isSuccess)
         {
             var builder = _cachedStringBuilder.Acquire();
             try
             {
                 builder.AppendLine("************  Response ************ ");
                 builder.Append(JToken.Parse(json).ToString(Formatting.Indented));
-                logger.LogDebug(builder.ToString());
+
+                if (isSuccess)
+                {
+                    logger.LogDebug(builder.ToString());
+                }
+                else
+                {
+                    logger.LogError(builder.ToString());
+                }
             }
             finally
             {


### PR DESCRIPTION
At the moment an exception from an endpoint is only logged when debug level is enabled.
This leads to quite frustrating troubleshooting situations - when people experience errors on e.g. completion or code actions normally their log doesn't show any errors, until they enable debug level. On debug level, on the other hand, there is a ton of logs produced though, so often the error gets cropped anyway as it's tedious to copy the massive log stack.

This change adds automatic logging of unsuccessful (errored) endpoint responses at error level. 
This guarantees that any exceptions are automatically visible even at default logging level.