### PR TITLE
added binding redirects for Microsoft.CodeAnalysis.Features and Microsoft.CodeAnalysis.CSharp.Features

### DIFF
--- a/src/OmniSharp.Http.Driver/app.config
+++ b/src/OmniSharp.Http.Driver/app.config
@@ -17,6 +17,14 @@
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
                 <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
+            </dependentAssembly>
 
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>

--- a/src/OmniSharp.LanguageServerProtocol/app.config
+++ b/src/OmniSharp.LanguageServerProtocol/app.config
@@ -7,15 +7,23 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
             </dependentAssembly>
 
             <dependentAssembly>

--- a/src/OmniSharp.Stdio.Driver/app.config
+++ b/src/OmniSharp.Stdio.Driver/app.config
@@ -17,6 +17,14 @@
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
                 <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
+            </dependentAssembly>
 
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>

--- a/tests/app.config
+++ b/tests/app.config
@@ -17,6 +17,14 @@
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
                 <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-3.8.0.0" newVersion="3.8.0.0"/>
+            </dependentAssembly>
 
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>


### PR DESCRIPTION
This is a best guess attempt to improve the behavior mentioned in https://github.com/OmniSharp/omnisharp-vscode/issues/4090

The error is vague but looks like somehow there are different versions of `CompletionList` loaded simultaneously. 
At the moment there are no binding redirects for its parent assembly `Microsoft.CodeAnalysis.Features` so it wouldn't hurt to add that.

cc @333fred 