### PR TITLE
When an analyzer fails to load, log an error

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
@@ -81,7 +81,7 @@ namespace OmniSharp.MSBuild.ProjectFile
 
         public static ProjectInfo CreateProjectInfo(this ProjectFileInfo projectFileInfo, IAnalyzerAssemblyLoader analyzerAssemblyLoader)
         {
-            var analyzerReferences = ResolveAnalyzerReferencesForProject(projectFileInfo, analyzerAssemblyLoader);
+            var analyzerReferences = projectFileInfo.ResolveAnalyzerReferencesForProject(analyzerAssemblyLoader);
 
             return ProjectInfo.Create(
                 id: projectFileInfo.Id,
@@ -95,11 +95,11 @@ namespace OmniSharp.MSBuild.ProjectFile
                 analyzerReferences: analyzerReferences).WithDefaultNamespace(projectFileInfo.DefaultNamespace);
         }
 
-        private static IEnumerable<AnalyzerReference> ResolveAnalyzerReferencesForProject(ProjectFileInfo projectFileInfo, IAnalyzerAssemblyLoader analyzerAssemblyLoader)
+        public static ImmutableArray<AnalyzerFileReference> ResolveAnalyzerReferencesForProject(this ProjectFileInfo projectFileInfo, IAnalyzerAssemblyLoader analyzerAssemblyLoader)
         {
             if (!projectFileInfo.RunAnalyzers || !projectFileInfo.RunAnalyzersDuringLiveAnalysis)
             {
-                return Enumerable.Empty<AnalyzerReference>();
+                return ImmutableArray<AnalyzerFileReference>.Empty;
             }
 
             foreach(var analyzerAssemblyPath in projectFileInfo.Analyzers.Distinct())
@@ -107,7 +107,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 analyzerAssemblyLoader.AddDependencyLocation(analyzerAssemblyPath);
             }
 
-            return projectFileInfo.Analyzers.Select(analyzerCandicatePath => new AnalyzerFileReference(analyzerCandicatePath, analyzerAssemblyLoader));
+            return projectFileInfo.Analyzers.Select(analyzerCandicatePath => new AnalyzerFileReference(analyzerCandicatePath, analyzerAssemblyLoader)).ToImmutableArray();
         }
     }
 }

--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -476,15 +476,8 @@ namespace OmniSharp.MSBuild
 
         private void UpdateAnalyzerReferences(Project project, ProjectFileInfo projectFileInfo)
         {
-            if (!projectFileInfo.RunAnalyzers || !projectFileInfo.RunAnalyzersDuringLiveAnalysis)
-            {
-                _workspace.SetAnalyzerReferences(project.Id, ImmutableArray<AnalyzerFileReference>.Empty);
-                return;
-            }
+            var analyzerFileReferences = projectFileInfo.ResolveAnalyzerReferencesForProject(_analyzerAssemblyLoader);
 
-            var analyzerFileReferences = projectFileInfo.Analyzers
-                .Select(analyzerReferencePath => new AnalyzerFileReference(analyzerReferencePath, _analyzerAssemblyLoader))
-                .ToImmutableArray();
 
             _workspace.SetAnalyzerReferences(project.Id, analyzerFileReferences);
         }


### PR DESCRIPTION
Right now we just silently fail which isn't a good debugging experience. Ideally these would be shown in the error list but this is good enough when trying to track things down.