### PR TITLE
fixed localization of LSP tests

### DIFF
--- a/tests/OmniSharp.Lsp.Tests/AbstractLanguageServerTestBase.cs
+++ b/tests/OmniSharp.Lsp.Tests/AbstractLanguageServerTestBase.cs
@@ -50,6 +50,11 @@ namespace OmniSharp.Lsp.Tests
 
         protected ILogger Logger { get; }
 
+        static AbstractLanguageServerTestBase()
+        {
+            TestHelpers.SetDefaultCulture();
+        }
+
         protected AbstractLanguageServerTestBase(ITestOutputHelper output, IConfiguration configuration = null) : this(
             output,
             new LoggerFactory().AddXunit(output))


### PR DESCRIPTION
At the moment 12 LSP tests fail on a non-English machines with these types of errors (taken from my de-CH setup):

```
    OmniSharp.Lsp.Tests.OmniSharpCodeActionHandlerFacts.Can_extract_method(roslynAnalyzersEnabled: False) [FAIL]
      Assert.Contains() Failure
      Not found: Extract Method
      In value:  WhereSelectEnumerableIterator<CommandOrCodeAction, String> ["using System;", "System.Console", "Variable \"Console\" generieren -> Eigenschaft \"C"..., "Variable \"Console\" generieren -> Feld \"Class1.C"..., "Variable \"Console\" generieren -> Schreibgeschütz"..., ...]
```

The rest of the tests already resets the culture for the purpose of tests to `en-US`, this PR fixes it for LSP tests too.