### PR TITLE
Quote config_file in Mono ENV Options

### DIFF
--- a/mono-packaging/run
+++ b/mono-packaging/run
@@ -19,7 +19,7 @@ if [ "$1" = "--no-omnisharp" ]; then
 fi
 
 export MONO_CFG_DIR=${etc_dir}
-export MONO_ENV_OPTIONS="--assembly-loader=strict --config ${config_file}"
+export MONO_ENV_OPTIONS="--assembly-loader=strict --config \"${config_file}\""
 
 if [ "$no_omnisharp" = true ]; then
     "${mono_cmd}" "$@"


### PR DESCRIPTION
This should fix an issue when there's a space in the path where OmniSharp is installed.