### PR TITLE
Update included Mono to 6.12.0

### DIFF
--- a/.pipelines/init.yml
+++ b/.pipelines/init.yml
@@ -44,7 +44,7 @@ steps:
       arguments: install tools/packages.config -ExcludeVersion -OutputDirectory tools
   - ${{ if ne(parameters.MonoVersion, '') }}:
     - script: |
-        curl -o mono.pkg https://download.mono-project.com/archive/$MONO_VERSION/macos-10-universal/MonoFramework-MDK-$MONO_VERSION.105.macos10.xamarin.universal.pkg
+        curl -o mono.pkg https://download.mono-project.com/archive/$MONO_VERSION/macos-10-universal/MonoFramework-MDK-$MONO_VERSION.90.macos10.xamarin.universal.pkg
         sudo installer -pkg mono.pkg -target /
         sudo cp -rf /Library/Frameworks/Mono.framework/Versions/$MONO_VERSION/ /Library/Frameworks/Mono.framework/Versions/Current/
         MONOPREFIX=/Library/Frameworks/Mono.framework/Versions/$MONO_VERSION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 All changes to the project will be documented in this file.
 
 ## [1.37.3] - not yet released
-* Fixed a bug when the server wouldn't start on MacOS/Linux when a username contained a space (PR: 1979https://github.com/OmniSharp/omnisharp-roslyn/pull/1979))
+* Fixed a bug when the server wouldn't start on MacOS/Linux when a username contained a space (PR: [#1979](https://github.com/OmniSharp/omnisharp-roslyn/pull/1979))
+* Update to Mono 6.12.0 (PR: [#1981](https://github.com/OmniSharp/omnisharp-roslyn/pull/1981))
 
 ## [1.37.2] - 2020-10-09
 * Updated MSBuild, MSBuild resolvers and Roslyn to match .NET Core 5.0 RC2 and VS 16.8 Preview 4. (PR: [#1971](https://github.com/OmniSharp/omnisharp-roslyn/pull/1971), PR: [#1974](https://github.com/OmniSharp/omnisharp-roslyn/pull/1974))

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 OmniSharp is a .NET development platform based on [Roslyn](https://github.com/dotnet/roslyn) workspaces. It provides project dependencies and C# language services to various IDEs and plugins.
 
-OmniSharp is built with the [.NET Core SDK](https://dot.net/) on Windows and [Mono](http://www.mono-project.com/) on OSX/Linux. It targets the _net472_ target framework. For platforms other than Windows, OmniSharp ships with an _embedded Mono_ which is based on version _6.10.0_, includes MSBuild _16.8.0_ and is provisioned during the build script. If _Mono_ is globally installed on the system, OmniSharp will prefer it over the embedded version, however version _>=6.4.0_ is required (the lowest version with at least MSBuild _16.3.0_).
+OmniSharp is built with the [.NET Core SDK](https://dot.net/) on Windows and [Mono](http://www.mono-project.com/) on OSX/Linux. It targets the _net472_ target framework. For platforms other than Windows, OmniSharp ships with an _embedded Mono_ which is based on version _6.12.0_, includes MSBuild _16.8.0_ and is provisioned during the build script. If _Mono_ is globally installed on the system, OmniSharp will prefer it over the embedded version, however version _>=6.4.0_ is required (the lowest version with at least MSBuild _16.3.0_).
 
 For Arch Linux users, you need package [mono-msbuild](https://www.archlinux.org/packages/community/x86_64/mono-msbuild/) (>= 16.3).
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ variables:
   CakeVersion: "0.32.1"
   NuGetVersion: "4.9.2"
   GitVersionVersion: "5.0.1"
-  MonoVersion: "6.10.0"
+  MonoVersion: "6.12.0"
   Coverage: "$(Agent.BuildDirectory)/c"
   VstsCoverage: "$(Coverage)"
   Artifacts: $(Build.SourcesDirectory)/artifacts/

--- a/build.json
+++ b/build.json
@@ -7,9 +7,9 @@
     ],
     "RequiredMonoVersion": "6.6.0",
     "DownloadURL": "https://roslynomnisharp.blob.core.windows.net/ext",
-    "MonoRuntimeMacOS": "mono.macOS-6.10.0.104.zip",
-    "MonoRuntimeLinux32": "mono.linux-x86-6.10.0.104.zip",
-    "MonoRuntimeLinux64": "mono.linux-x86_64-6.10.0.104.zip",
+    "MonoRuntimeMacOS": "mono.macOS-6.12.0.90.zip",
+    "MonoRuntimeLinux32": "mono.linux-x86-6.12.0.90.zip",
+    "MonoRuntimeLinux64": "mono.linux-x86_64-6.12.0.90.zip",
     "HostProjects": [
         "OmniSharp.Stdio.Driver",
         "OmniSharp.Http.Driver"


### PR DESCRIPTION
I saw 6.12.0 was listed for download as stable.

Also, noticed that the 6.12.0 Mono ships with a 16.8 MSBuild meaning we can revert the meaning of `omnisharp.useGlobalMono` when we take the next release. Verified that the 6.12 Mono's MSBuild handles loading the dotnet/sdk sdk.sln which is firmly .NET 5. =)
```patch
[info]: OmniSharp.MSBuild.Discovery.MSBuildLocator
        Located 2 MSBuild instance(s)
!            1: Mono 16.8.0 - "/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin"
            2: StandAlone 16.8.0 - "/Users/joeyrobichaud/.vscode-insiders/extensions/ms-dotnettools.csharp-1.23.3/.omnisharp/1.37.1/omnisharp/.msbuild/Current/Bin"
```