### PR TITLE
Targeted DiagnosticWorker Revert

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Helpers/DiagnosticExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/DiagnosticExtensions.cs
@@ -35,7 +35,7 @@ namespace OmniSharp.Helpers
         internal static IEnumerable<DiagnosticLocation> DistinctDiagnosticLocationsByProject(this IEnumerable<DocumentDiagnostics> documentDiagnostic)
         {
             return documentDiagnostic
-                .SelectMany(x => x.Diagnostics, (parent, child) => (projectName: parent.Project.Name, diagnostic: child))
+                .SelectMany(x => x.Diagnostics, (parent, child) => (projectName: parent.ProjectName, diagnostic: child))
                 .Select(x => new
                 {
                     location = x.diagnostic.ToDiagnosticLocation(),

--- a/src/OmniSharp.Roslyn.CSharp/Services/Diagnostics/CodeCheckService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Diagnostics/CodeCheckService.cs
@@ -47,7 +47,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
         {
             var diagnosticLocations = diagnostics
                 .Where(x => string.IsNullOrEmpty(fileName)
-                    || x.Document.FilePath == fileName)
+                    || x.DocumentPath == fileName)
                 .DistinctDiagnosticLocationsByProject()
                 .Where(x => x.FileName != null);
 

--- a/src/OmniSharp.Roslyn.CSharp/Services/Diagnostics/CodeCheckService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Diagnostics/CodeCheckService.cs
@@ -38,7 +38,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
                 return GetResponseFromDiagnostics(allDiagnostics, fileName: null);
             }
 
-            var diagnostics = await _diagWorker.GetDiagnostics(new [] { request.FileName }.ToImmutableArray());
+            var diagnostics = await _diagWorker.GetDiagnostics(ImmutableArray.Create(request.FileName));
 
             return GetResponseFromDiagnostics(diagnostics, request.FileName);
         }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/GetFixAllCodeActionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/GetFixAllCodeActionService.cs
@@ -39,7 +39,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring
 
             var allDiagnostics = await GetDiagnosticsAsync(request.Scope, document);
             var validFixes = allDiagnostics
-                .GroupBy(docAndDiag => docAndDiag.Document.Project)
+                .GroupBy(docAndDiag => docAndDiag.ProjectId)
                 .SelectMany(grouping =>
                 {
                     var projectFixProviders = GetCodeFixProviders(grouping.Key);

--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/RunFixAllCodeActionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/RunFixAllCodeActionService.cs
@@ -192,26 +192,13 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring
             }
 
             public override async Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
-            {
-                var diagnostics = await _diagnosticWorker.GetDiagnostics(project.Documents.ToImmutableArray());
-                return diagnostics.SelectMany(x => x.Diagnostics);
-            }
+                => await _diagnosticWorker.AnalyzeProjectsAsync(project, cancellationToken);
 
             public override async Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
-            {
-                var documentDiagnostics = await _diagnosticWorker.GetDiagnostics(ImmutableArray.Create(document));
-
-                if (!documentDiagnostics.Any())
-                    return new Diagnostic[] { };
-
-                return documentDiagnostics.First().Diagnostics;
-            }
+                => await _diagnosticWorker.AnalyzeDocumentAsync(document, cancellationToken);
 
             public override async Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
-            {
-                var diagnostics = await _diagnosticWorker.GetDiagnostics(project.Documents.ToImmutableArray());
-                return diagnostics.SelectMany(x => x.Diagnostics);
-            }
+                => await _diagnosticWorker.AnalyzeProjectsAsync(project, cancellationToken);
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/CachingCodeFixProviderForProjects.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/CachingCodeFixProviderForProjects.cs
@@ -41,14 +41,16 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
             };
         }
 
-        public ImmutableArray<CodeFixProvider> GetAllCodeFixesForProject(Project project)
+        public ImmutableArray<CodeFixProvider> GetAllCodeFixesForProject(ProjectId projectId)
         {
-            if (_cache.ContainsKey(project.Id))
-                return _cache[project.Id];
+            if (_cache.ContainsKey(projectId))
+                return _cache[projectId];
+
+            var project = _workspace.CurrentSolution.GetProject(projectId);
 
             if (project == null)
             {
-                _cache.TryRemove(project.Id, out _);
+                _cache.TryRemove(projectId, out _);
                 return ImmutableArray<CodeFixProvider>.Empty;
             }
 

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/AnalyzerWorkQueue.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/AnalyzerWorkQueue.cs
@@ -17,8 +17,8 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
                 Throttling = throttling;
             }
 
-            public ImmutableHashSet<Document> WorkWaitingToExecute { get; set; } = ImmutableHashSet<Document>.Empty;
-            public ImmutableHashSet<Document> WorkExecuting { get; set; } = ImmutableHashSet<Document>.Empty;
+            public ImmutableHashSet<DocumentId> WorkWaitingToExecute { get; set; } = ImmutableHashSet<DocumentId>.Empty;
+            public ImmutableHashSet<DocumentId> WorkExecuting { get; set; } = ImmutableHashSet<DocumentId>.Empty;
             public DateTime LastThrottlingBegan { get; set; } = DateTime.UtcNow;
             public TimeSpan Throttling { get; }
             public CancellationTokenSource WorkPendingToken { get; set; }
@@ -44,7 +44,7 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
             _maximumDelayWhenWaitingForResults = timeoutForPendingWorkMs;
         }
 
-        public void PutWork(IReadOnlyCollection<Document> documents, AnalyzerWorkType workType)
+        public void PutWork(IReadOnlyCollection<DocumentId> documentIds, AnalyzerWorkType workType)
         {
             lock (_queueLock)
             {
@@ -56,21 +56,21 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
                 if (queue.WorkPendingToken == null)
                     queue.WorkPendingToken = new CancellationTokenSource();
 
-                queue.WorkWaitingToExecute = queue.WorkWaitingToExecute.Union(documents);
+                queue.WorkWaitingToExecute = queue.WorkWaitingToExecute.Union(documentIds);
             }
         }
 
-        public IReadOnlyCollection<Document> TakeWork(AnalyzerWorkType workType)
+        public IReadOnlyCollection<DocumentId> TakeWork(AnalyzerWorkType workType)
         {
             lock (_queueLock)
             {
                 var queue = _queues[workType];
 
                 if (IsThrottlingActive(queue) || queue.WorkWaitingToExecute.IsEmpty)
-                    return ImmutableHashSet<Document>.Empty;
+                    return ImmutableHashSet<DocumentId>.Empty;
 
                 queue.WorkExecuting = queue.WorkWaitingToExecute;
-                queue.WorkWaitingToExecute = ImmutableHashSet<Document>.Empty;
+                queue.WorkWaitingToExecute = ImmutableHashSet<DocumentId>.Empty;
                 return queue.WorkExecuting;
             }
         }
@@ -84,12 +84,12 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
         {
             lock (_queueLock)
             {
-                if (_queues[workType].WorkExecuting.IsEmpty)
+                if(_queues[workType].WorkExecuting.IsEmpty)
                     return;
 
                 _queues[workType].WorkPendingToken?.Cancel();
                 _queues[workType].WorkPendingToken = null;
-                _queues[workType].WorkExecuting = ImmutableHashSet<Document>.Empty;
+                _queues[workType].WorkExecuting = ImmutableHashSet<DocumentId>.Empty;
             }
         }
 
@@ -107,9 +107,15 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
                 .ContinueWith(task => LogTimeouts(task));
         }
 
-        public void QueueDocumentForeground(Document document)
+        public bool TryPromote(DocumentId id)
         {
-            PutWork(new[] { document }, AnalyzerWorkType.Foreground);
+            if (_queues[AnalyzerWorkType.Background].WorkWaitingToExecute.Contains(id) || _queues[AnalyzerWorkType.Background].WorkExecuting.Contains(id))
+            {
+                PutWork(new[] { id }, AnalyzerWorkType.Foreground);
+                return true;
+            }
+
+            return false;
         }
 
         private void LogTimeouts(Task task)

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorker.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorker.cs
@@ -7,6 +7,7 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
@@ -200,6 +201,24 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
             _workspace.DocumentOpened -= OnDocumentOpened;
             _workspace.DocumentClosed -= OnDocumentOpened;
             _disposable.Dispose();
+        }
+
+        public async Task<IEnumerable<Diagnostic>> AnalyzeDocumentAsync(Document document, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await GetDiagnosticsForDocument(document, document.Project.Name);
+        }
+
+        public async Task<IEnumerable<Diagnostic>> AnalyzeProjectsAsync(Project project, CancellationToken cancellationToken)
+        {
+            var diagnostics = new List<Diagnostic>();
+            foreach (var document in project.Documents)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                diagnostics.AddRange(await GetDiagnosticsForDocument(document, project.Name));
+            }
+
+            return diagnostics;
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CsharpDiagnosticWorkerComposer.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CsharpDiagnosticWorkerComposer.cs
@@ -77,17 +77,12 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
             return _implementation.GetDiagnostics(documentPaths);
         }
 
-        public Task<ImmutableArray<DocumentDiagnostics>> GetDiagnostics(ImmutableArray<Document> documents)
-        {
-            return _implementation.GetDiagnostics(documents);
-        }
-
-        public ImmutableArray<Document> QueueDocumentsForDiagnostics()
+        public ImmutableArray<DocumentId> QueueDocumentsForDiagnostics()
         {
             return _implementation.QueueDocumentsForDiagnostics();
         }
 
-        public ImmutableArray<Document> QueueDocumentsForDiagnostics(ImmutableArray<ProjectId> projectIds)
+        public ImmutableArray<DocumentId> QueueDocumentsForDiagnostics(ImmutableArray<ProjectId> projectIds)
         {
             return _implementation.QueueDocumentsForDiagnostics(projectIds);
         }

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CsharpDiagnosticWorkerComposer.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CsharpDiagnosticWorkerComposer.cs
@@ -92,5 +92,15 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
             if (_implementation is IDisposable disposable) disposable.Dispose();
             _onChange.Dispose();
         }
+
+        public Task<IEnumerable<Diagnostic>> AnalyzeDocumentAsync(Document document, CancellationToken cancellationToken)
+        {
+            return _implementation.AnalyzeDocumentAsync(document, cancellationToken);
+        }
+
+        public Task<IEnumerable<Diagnostic>> AnalyzeProjectsAsync(Project project, CancellationToken cancellationToken)
+        {
+            return _implementation.AnalyzeProjectsAsync(project, cancellationToken);
+        }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/DocumentDiagnostics.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/DocumentDiagnostics.cs
@@ -5,14 +5,19 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
 {
     public class DocumentDiagnostics
     {
-        public DocumentDiagnostics(Document document, ImmutableArray<Diagnostic> diagnostics)
+        public DocumentDiagnostics(DocumentId documentId, string documentPath, ProjectId projectId, string projectName, ImmutableArray<Diagnostic> diagnostics)
         {
+            DocumentId = documentId;
+            DocumentPath = documentPath;
+            ProjectId = projectId;
+            ProjectName = projectName;
             Diagnostics = diagnostics;
-            Document = document;
         }
 
-        public Document Document { get;  }
-        public Project Project => Document.Project;
+        public DocumentId DocumentId { get; }
+        public ProjectId ProjectId { get; }
+        public string ProjectName { get; }
+        public string DocumentPath { get; }
         public ImmutableArray<Diagnostic> Diagnostics { get; }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/ICsDiagnosticWorker.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/ICsDiagnosticWorker.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using OmniSharp.Roslyn.CSharp.Services.Diagnostics;
@@ -9,6 +11,8 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
     {
         Task<ImmutableArray<DocumentDiagnostics>> GetDiagnostics(ImmutableArray<string> documentPaths);
         Task<ImmutableArray<DocumentDiagnostics>> GetAllDiagnosticsAsync();
+        Task<IEnumerable<Diagnostic>> AnalyzeDocumentAsync(Document document, CancellationToken cancellationToken);
+        Task<IEnumerable<Diagnostic>> AnalyzeProjectsAsync(Project project, CancellationToken cancellationToken);
         ImmutableArray<DocumentId> QueueDocumentsForDiagnostics();
         ImmutableArray<DocumentId> QueueDocumentsForDiagnostics(ImmutableArray<ProjectId> projectId);
     }

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/ICsDiagnosticWorker.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/ICsDiagnosticWorker.cs
@@ -8,9 +8,8 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
     public interface ICsDiagnosticWorker
     {
         Task<ImmutableArray<DocumentDiagnostics>> GetDiagnostics(ImmutableArray<string> documentPaths);
-        Task<ImmutableArray<DocumentDiagnostics>> GetDiagnostics(ImmutableArray<Document> documents);
         Task<ImmutableArray<DocumentDiagnostics>> GetAllDiagnosticsAsync();
-        ImmutableArray<Document> QueueDocumentsForDiagnostics();
-        ImmutableArray<Document> QueueDocumentsForDiagnostics(ImmutableArray<ProjectId> projectId);
+        ImmutableArray<DocumentId> QueueDocumentsForDiagnostics();
+        ImmutableArray<DocumentId> QueueDocumentsForDiagnostics(ImmutableArray<ProjectId> projectId);
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/AnalyzerWorkerQueueFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/AnalyzerWorkerQueueFacts.cs
@@ -6,19 +6,12 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Roslyn.CSharp.Workers.Diagnostics;
-using TestUtility;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace OmniSharp.Roslyn.CSharp.Tests
 {
-    public class AnalyzerWorkerQueueFacts : AbstractTestFixture
+    public class AnalyzerWorkerQueueFacts
     {
-        public AnalyzerWorkerQueueFacts(ITestOutputHelper output, SharedOmniSharpHostFixture sharedOmniSharpHostFixture)
-            : base(output, sharedOmniSharpHostFixture)
-        {
-        }
-
         private class Logger : ILogger
         {
             public IDisposable BeginScope<TState>(TState state)
@@ -36,7 +29,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             public ImmutableArray<string> RecordedMessages { get; set; } = ImmutableArray.Create<string>();
         }
 
-        private class TestLoggerFactory : ILoggerFactory
+        private class LoggerFactory : ILoggerFactory
         {
             public Logger Logger { get; } = new Logger();
 
@@ -60,7 +53,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         public void WhenItemsAreAddedButThrotlingIsntOverNoWorkShouldBeReturned(AnalyzerWorkType workType)
         {
             var now = DateTime.UtcNow;
-            var queue = new AnalyzerWorkQueue(new TestLoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
+            var queue = new AnalyzerWorkQueue(new LoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
             var document = CreateTestDocumentId();
 
             queue.PutWork(new[] { document }, workType);
@@ -73,7 +66,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         public void WhenWorksIsAddedToQueueThenTheyWillBeReturned(AnalyzerWorkType workType)
         {
             var now = DateTime.UtcNow;
-            var queue = new AnalyzerWorkQueue(new TestLoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
+            var queue = new AnalyzerWorkQueue(new LoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
             var document = CreateTestDocumentId();
 
             queue.PutWork(new[] { document }, workType);
@@ -91,7 +84,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         public void WhenSameItemIsAddedMultipleTimesInRowThenThrottleItemAsOne(AnalyzerWorkType workType)
         {
             var now = DateTime.UtcNow;
-            var queue = new AnalyzerWorkQueue(new TestLoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
+            var queue = new AnalyzerWorkQueue(new LoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
             var document = CreateTestDocumentId();
 
             queue.PutWork(new[] { document }, workType);
@@ -112,7 +105,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         public void WhenForegroundWorkIsAddedThenWaitNextIterationOfItReady()
         {
             var now = DateTime.UtcNow;
-            var queue = new AnalyzerWorkQueue(new TestLoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 500);
+            var queue = new AnalyzerWorkQueue(new LoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 500);
             var document = CreateTestDocumentId();
 
             queue.PutWork(new[] { document }, AnalyzerWorkType.Foreground);
@@ -134,7 +127,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         public void WhenForegroundWorkIsUnderAnalysisOutFromQueueThenWaitUntilNextIterationOfItIsReady()
         {
             var now = DateTime.UtcNow;
-            var queue = new AnalyzerWorkQueue(new TestLoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 500);
+            var queue = new AnalyzerWorkQueue(new LoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 500);
             var document = CreateTestDocumentId();
 
             queue.PutWork(new[] { document }, AnalyzerWorkType.Foreground);
@@ -156,7 +149,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         public void WhenWorkIsWaitedButTimeoutForWaitIsExceededAllowContinue()
         {
             var now = DateTime.UtcNow;
-            var loggerFactory = new TestLoggerFactory();
+            var loggerFactory = new LoggerFactory();
             var queue = new AnalyzerWorkQueue(loggerFactory, utcNow: () => now, timeoutForPendingWorkMs: 20);
             var document = CreateTestDocumentId();
 
@@ -179,7 +172,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         {
             var now = DateTime.UtcNow;
 
-            var queue = new AnalyzerWorkQueue(new TestLoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 1000);
+            var queue = new AnalyzerWorkQueue(new LoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 1000);
 
             var parallelQueues =
                 Enumerable.Range(0, 10)
@@ -211,7 +204,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         public async Task WhenWorkIsAddedAgainWhenPreviousIsAnalysing_ThenDontWaitAnotherOneToGetReady()
         {
             var now = DateTime.UtcNow;
-            var queue = new AnalyzerWorkQueue(new TestLoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
+            var queue = new AnalyzerWorkQueue(new LoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
             var document = CreateTestDocumentId();
 
             queue.PutWork(new[] { document }, AnalyzerWorkType.Foreground);
@@ -239,7 +232,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         [Fact]
         public void WhenBackgroundWorkIsAdded_DontWaitIt()
         {
-            var queue = new AnalyzerWorkQueue(new TestLoggerFactory(), timeoutForPendingWorkMs: 10*1000);
+            var queue = new AnalyzerWorkQueue(new LoggerFactory(), timeoutForPendingWorkMs: 10*1000);
             var document = CreateTestDocumentId();
 
             queue.PutWork(new[] { document }, AnalyzerWorkType.Background);
@@ -248,15 +241,15 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         }
 
         [Fact]
-        public void WhenSingleFileIsQueued_ThenPromoteItFromBackgroundQueueToForeground()
+        public void WhenSingleFileIsPromoted_ThenPromoteItFromBackgroundQueueToForeground()
         {
             var now = DateTime.UtcNow;
-            var queue = new AnalyzerWorkQueue(new TestLoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
+            var queue = new AnalyzerWorkQueue(new LoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
             var document = CreateTestDocumentId();
 
             queue.PutWork(new[] { document }, AnalyzerWorkType.Background);
 
-            queue.QueueDocumentForeground(document);
+            queue.TryPromote(document);
 
             now = PassOverThrotlingPeriod(now);
 
@@ -264,24 +257,24 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         }
 
         [Fact]
-        public void WhenFileIsntAtBackgroundQueueAndTriedToBeQueued_ThenQueue()
+        public void WhenFileIsntAtBackgroundQueueAndTriedToBePromoted_ThenDontDoNothing()
         {
             var now = DateTime.UtcNow;
-            var queue = new AnalyzerWorkQueue(new TestLoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
+            var queue = new AnalyzerWorkQueue(new LoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
             var document = CreateTestDocumentId();
 
-            queue.QueueDocumentForeground(document);
+            queue.TryPromote(document);
 
             now = PassOverThrotlingPeriod(now);
 
-            Assert.Equal(document, queue.TakeWork(AnalyzerWorkType.Foreground).Single());
+            Assert.Empty(queue.TakeWork(AnalyzerWorkType.Foreground));
         }
 
         [Fact]
         public void WhenFileIsProcessingInBackgroundQueue_ThenPromoteItAsForeground()
         {
             var now = DateTime.UtcNow;
-            var queue = new AnalyzerWorkQueue(new TestLoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
+            var queue = new AnalyzerWorkQueue(new LoggerFactory(), utcNow: () => now, timeoutForPendingWorkMs: 10*1000);
             var document = CreateTestDocumentId();
 
             queue.PutWork(new[] { document }, AnalyzerWorkType.Background);
@@ -290,7 +283,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
             var activeWork = queue.TakeWork(AnalyzerWorkType.Background);
 
-            queue.QueueDocumentForeground(document);
+            queue.TryPromote(document);
 
             now = PassOverThrotlingPeriod(now);
 
@@ -300,12 +293,16 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             Assert.NotEmpty(activeWork);
         }
 
-        private Document CreateTestDocumentId()
+        private DocumentId CreateTestDocumentId()
         {
-            string fileName = $"{Guid.NewGuid()}";
-            var newFile = new TestFile(fileName, "");
-            _ = SharedOmniSharpTestHost.AddFilesToWorkspace(newFile).Single();
-            return SharedOmniSharpTestHost.Workspace.GetDocument(fileName);
+            var projectInfo = ProjectInfo.Create(
+                id: ProjectId.CreateNewId(),
+                version: VersionStamp.Create(),
+                name: "testProject",
+                assemblyName: "AssemblyName",
+                language: LanguageNames.CSharp);
+
+            return DocumentId.CreateNewId(projectInfo.Id);
         }
     }
 }


### PR DESCRIPTION
This should fix https://github.com/OmniSharp/omnisharp-roslyn/issues/1983, fix https://github.com/OmniSharp/omnisharp-roslyn/issues/1982, and fix https://github.com/OmniSharp/omnisharp-vscode/issues/4111. I reverted the diagnostic worker change, and introduced a separate codepath for FixAll to use when calculating updated diagnostics. For easier review I broke this into 2 changes:
1. Revert select files back to 73292abe. No manual changes are in this commit.
2. Make changes to keep code compiling, and add separate bypass methods for the fixall service to use when calculating updated diagnostics.