### PR TITLE
fixed global Mono MSBuild version reporting

### DIFF
--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/MonoInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/MonoInstanceProvider.cs
@@ -103,8 +103,6 @@ Try installing MSBuild into Mono (e.g. 'sudo apt-get install msbuild') to enable
             var localMSBuildPath = FindLocalMSBuildDirectory();
             if (localMSBuildPath != null)
             {
-                microsoftBuildPath = Path.Combine(localMSBuildPath, "Current", "Bin", "Microsoft.Build.dll");
-
                 var localRoslynPath = Path.Combine(localMSBuildPath, "Current", "Bin", "Roslyn");
                 propertyOverrides.Add("CscToolPath", localRoslynPath);
                 propertyOverrides.Add("CscToolExe", "csc.exe");


### PR DESCRIPTION
This commit https://github.com/OmniSharp/omnisharp-roslyn/commit/2bfebbcf59f8bd13b74b977629621ab084950863 contains a bug where the global Mono MSBuild version was always reported the same as the bundled MSBuild.

Running on global Mono 6.12, before the changes:

```
[info]: OmniSharp.Stdio.Host
        Starting OmniSharp on MacOS 10.15.6 (x64)
[info]: OmniSharp.Services.DotNetCliService
        DotNetPath set to dotnet
[info]: OmniSharp.MSBuild.Discovery.MSBuildLocator
        Located 2 MSBuild instance(s)
            1: Mono 16.8.0 - "/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin"
            2: StandAlone 16.8.0 - "/Users/filipw/.vscode/extensions/ms-dotnettools.csharp-1.23.4/.omnisharp/1.37.3/omnisharp/.msbuild/Current/Bin"
```

After the change:

```
[info]: OmniSharp.Stdio.Host
        Starting OmniSharp on MacOS 10.15.6 (x64)
[info]: OmniSharp.Services.DotNetCliService
        DotNetPath set to dotnet
[info]: OmniSharp.MSBuild.Discovery.MSBuildLocator
        Located 2 MSBuild instance(s)
            1: Mono 16.6.0 - "/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin"
            2: StandAlone 16.8.0 - "/Users/filipw/.vscode/extensions/ms-dotnettools.csharp-1.23.4/.omnisharp/1.37.3/omnisharp/.msbuild/Current/Bin"
```