### PR TITLE
Omnisharp now uses libPaths and sourcePaths defined in custom .rsp file

### DIFF
--- a/src/OmniSharp.Script/ScriptProjectProvider.cs
+++ b/src/OmniSharp.Script/ScriptProjectProvider.cs
@@ -133,16 +133,14 @@ namespace OmniSharp.Script
         {
             var defaultResolver = ScriptSourceResolver.Default;
 
-            if (searchPaths == null)
+            if (searchPaths != null)
             {
-                return defaultResolver;
-            }
+                defaultResolver = defaultResolver.WithSearchPaths(searchPaths);
 
-            defaultResolver = defaultResolver.WithSearchPaths(searchPaths);
-
-            foreach (string path in searchPaths)
-            {
-                _logger.LogInformation($"CSX source path: {path}.");
+                foreach (string path in searchPaths)
+                {
+                    _logger.LogInformation($"CSX source path: {path}.");
+                }
             }
 
             return defaultResolver;


### PR DESCRIPTION
This values were always being parsed but they were not being used. Here is an example of a .rsp file that I am using

```
# Core References
/using:System
/using:System.Core
/using:Microsoft.CSharp
/using:System
/using:System.IO
/using:System.Collections.Generic
/using:System.Console
/using:System.Diagnostics
/using:System.Dynamic
/using:System.Linq
/using:System.Linq.Expressions
/using:System.Text
/using:System.Threading.Tasks

/loadPaths:C:\\Users\\byron\\Desktop\\scriptingIncludes
```