### PR TITLE
C# scripting should use language version "latest" by default

### DIFF
--- a/src/OmniSharp.Script/ScriptProjectProvider.cs
+++ b/src/OmniSharp.Script/ScriptProjectProvider.cs
@@ -43,7 +43,7 @@ namespace OmniSharp.Script
             "System.Threading.Tasks"
         };
 
-        private static readonly CSharpParseOptions ParseOptions = new CSharpParseOptions(LanguageVersion.CSharp8, DocumentationMode.Parse, SourceCodeKind.Script);
+        private static readonly CSharpParseOptions ParseOptions = new CSharpParseOptions(LanguageVersion.Latest, DocumentationMode.Parse, SourceCodeKind.Script);
 
         private readonly Lazy<CSharpCompilationOptions> _compilationOptions;
         private readonly Lazy<CSharpCommandLineArguments> _commandLineArgs;
@@ -103,7 +103,6 @@ namespace OmniSharp.Script
 
             compilationOptions = compilationOptions
                 .WithAllowUnsafe(true)
-
                 .WithMetadataReferenceResolver(metadataReferenceResolver)
                 .WithSourceReferenceResolver(sourceResolver)
                 .WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default)

--- a/tests/OmniSharp.Script.Tests/ScriptProjectProviderTests.cs
+++ b/tests/OmniSharp.Script.Tests/ScriptProjectProviderTests.cs
@@ -1,0 +1,23 @@
+﻿using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Services;
+using Xunit;
+
+namespace OmniSharp.Script.Tests
+{
+    public class ScriptProjectProviderTests
+    {
+        [Fact]
+        public void DefaultLanguageVersionShouldBeLatest()
+        {
+            var scriptProjectProvider = new ScriptProjectProvider(new ScriptOptions(), new OmniSharpEnvironment(), new LoggerFactory(), true, false);
+            var scriptProjectInfo = scriptProjectProvider.CreateProject("test.csx", Enumerable.Empty<MetadataReference>(), Path.GetTempPath(), typeof(CommandLineScriptGlobals));
+            Assert.Equal(LanguageVersion.Latest, ((CSharpParseOptions)scriptProjectInfo.ParseOptions).SpecifiedLanguageVersion);
+            Assert.Equal(LanguageVersion.CSharp9, ((CSharpParseOptions)scriptProjectInfo.ParseOptions).LanguageVersion);
+        }
+    }
+}

--- a/tests/OmniSharp.Script.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.Script.Tests/WorkspaceInformationTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using OmniSharp.Models.FilesChanged;
 using OmniSharp.Models.WorkspaceInformation;


### PR DESCRIPTION
In the past lang version `Latest` used to resolve to `7.1` so in order to force C# 8 in scripting we enabled it explicitly.
Now this is no longer correct, so resetting back to `Latest` as Roslyn does it https://github.com/dotnet/roslyn/blob/version-3.2.0/src/Scripting/CSharp/CSharpScriptCompiler.cs#L14

Additionally added a test so if `Latest` no longer means `9`, the test will break and let us decide how to proceed.