### PR TITLE
Lsp init fix

### DIFF
--- a/src/OmniSharp.Abstractions/Plugins/Plugin.cs
+++ b/src/OmniSharp.Abstractions/Plugins/Plugin.cs
@@ -107,6 +107,12 @@ namespace OmniSharp.Plugins
             Task.Run(() => Run());
         }
 
+        public Task WaitForIdleAsync()
+        {
+            // TODO: Call out to process
+            return Task.CompletedTask;
+        }
+
         public Task<object> GetWorkspaceModelAsync(WorkspaceInformationRequest request)
         {
             // TODO: Call out to process

--- a/src/OmniSharp.Abstractions/Services/IProjectSystem.cs
+++ b/src/OmniSharp.Abstractions/Services/IProjectSystem.cs
@@ -24,6 +24,11 @@ namespace OmniSharp.Services
         void Initalize(IConfiguration configuration);
 
         /// <summary>
+        /// Wait until the project system is not busy.
+        /// </summary>
+        Task WaitForIdleAsync();
+
+        /// <summary>
         /// Get a model of the entire workspace loaded in this project system.
         /// </summary>
         Task<object> GetWorkspaceModelAsync(WorkspaceInformationRequest request);

--- a/src/OmniSharp.Cake/CakeProjectSystem.cs
+++ b/src/OmniSharp.Cake/CakeProjectSystem.cs
@@ -231,6 +231,8 @@ namespace OmniSharp.Cake
             }
         }
 
+        public Task WaitForIdleAsync() => Task.CompletedTask;
+
         public Task<object> GetWorkspaceModelAsync(WorkspaceInformationRequest request)
         {
             var scriptContextModels = new List<CakeContextModel>();

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -128,6 +128,8 @@ namespace OmniSharp.MSBuild
             }
         }
 
+        public Task WaitForIdleAsync() { return _manager.WaitForQueueEmptyAsync();  }
+
         private IEnumerable<(string, ProjectIdInfo)> GetInitialProjectPathsAndIds()
         {
             // If a solution was provided, use it.

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -152,6 +152,8 @@ namespace OmniSharp.Script
             return projectFileInfo;
         }
 
+        Task IProjectSystem.WaitForIdleAsync() => Task.CompletedTask;
+
         Task<object> IProjectSystem.GetProjectModelAsync(string filePath)
         {
             // only react to .CSX file paths

--- a/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
+++ b/tests/OmniSharp.Http.Tests/EndpointMiddlewareFacts.cs
@@ -80,6 +80,8 @@ namespace OmniSharp.Http.Tests
             public bool EnabledByDefault { get; } = true;
             public bool Initialized { get; } = true;
 
+            public Task WaitForIdleAsync() => throw new NotImplementedException();
+
             public Task<object> GetWorkspaceModelAsync(WorkspaceInformationRequest request)
             {
                 throw new NotImplementedException();

--- a/tests/OmniSharp.Lsp.Tests/AbstractLanguageServerTestBase.cs
+++ b/tests/OmniSharp.Lsp.Tests/AbstractLanguageServerTestBase.cs
@@ -97,7 +97,7 @@ namespace OmniSharp.Lsp.Tests
                         var handlers =
                             LanguageServerHost.ConfigureCompositionHost(server, OmniSharpTestHost.CompositionHost);
                         _host.UnderTest(OmniSharpTestHost.ServiceProvider, OmniSharpTestHost.CompositionHost);
-                        LanguageServerHost.RegisterHandlers(server, OmniSharpTestHost.CompositionHost, handlers, Unit.Task);
+                        LanguageServerHost.RegisterHandlers(server, OmniSharpTestHost.CompositionHost, handlers);
                         return Task.CompletedTask;
                     }),
                 CancellationTokenSource.CreateLinkedTokenSource(CancellationToken)

--- a/tests/OmniSharp.Lsp.Tests/AbstractLanguageServerTestBase.cs
+++ b/tests/OmniSharp.Lsp.Tests/AbstractLanguageServerTestBase.cs
@@ -97,7 +97,7 @@ namespace OmniSharp.Lsp.Tests
                         var handlers =
                             LanguageServerHost.ConfigureCompositionHost(server, OmniSharpTestHost.CompositionHost);
                         _host.UnderTest(OmniSharpTestHost.ServiceProvider, OmniSharpTestHost.CompositionHost);
-                        LanguageServerHost.RegisterHandlers(server, OmniSharpTestHost.CompositionHost, handlers);
+                        LanguageServerHost.RegisterHandlers(server, OmniSharpTestHost.CompositionHost, handlers, Unit.Task);
                         return Task.CompletedTask;
                     }),
                 CancellationTokenSource.CreateLinkedTokenSource(CancellationToken)

--- a/tests/OmniSharp.Stdio.Tests/EndpointHandlerFacts.cs
+++ b/tests/OmniSharp.Stdio.Tests/EndpointHandlerFacts.cs
@@ -104,6 +104,8 @@ namespace OmniSharp.Stdio.Tests
 
             public bool Initialized => true;
 
+            public Task WaitForIdleAsync() => throw new NotImplementedException();
+
             public Task<object> GetProjectModelAsync(string filePath)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
Some background:

https://github.com/coc-extensions/coc-omnisharp/issues/33

https://github.com/coc-extensions/coc-omnisharp/issues/35

https://github.com/OmniSharp/omnisharp-roslyn/issues/1742

https://github.com/OmniSharp/omnisharp-roslyn/issues/1515

https://github.com/OmniSharp/omnisharp-roslyn/issues/1083

--------

In short, there's race condition between (workspace initialization + project reference adding) and (client requests coming in at a random point of time).

This PR blocks incoming LSP requests until the initial project system processing is completed. Should help us to get rid of a bunch of issues.