### PR TITLE
Roslyn and MSBuild updates to latest stable

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -3,9 +3,9 @@
     xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <MSBuildPackageVersion>16.6.0</MSBuildPackageVersion>
+    <MSBuildPackageVersion>16.8.0</MSBuildPackageVersion>
     <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.8.0-5.final</RoslynPackageVersion>
+    <RoslynPackageVersion>3.8.0</RoslynPackageVersion>
     <XunitPackageVersion>2.4.1</XunitPackageVersion>
   </PropertyGroup>
 

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -2,7 +2,7 @@
 <packages>
     <package id="Cake" version="0.37.0" />
     <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.1" />
-    <package id="Microsoft.Build" version="16.8.0-preview-20475-05" />
+    <package id="Microsoft.Build" version="16.8.0" />
     <package id="Microsoft.Build.Framework" version="16.8.0" />
     <package id="Microsoft.Build.Runtime" version="16.8.0" />
     <package id="Microsoft.Build.Tasks.Core" version="16.8.0" />

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -3,11 +3,11 @@
     <package id="Cake" version="0.37.0" />
     <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.1" />
     <package id="Microsoft.Build" version="16.8.0-preview-20475-05" />
-    <package id="Microsoft.Build.Framework" version="16.8.0-preview-20475-05" />
-    <package id="Microsoft.Build.Runtime" version="16.8.0-preview-20475-05" />
-    <package id="Microsoft.Build.Tasks.Core" version="16.8.0-preview-20475-05" />
-    <package id="Microsoft.Build.Utilities.Core" version="16.8.0-preview-20475-05" />
-    <package id="Microsoft.Net.Compilers.Toolset" version="3.8.0-4.20480.4" />
+    <package id="Microsoft.Build.Framework" version="16.8.0" />
+    <package id="Microsoft.Build.Runtime" version="16.8.0" />
+    <package id="Microsoft.Build.Tasks.Core" version="16.8.0" />
+    <package id="Microsoft.Build.Utilities.Core" version="16.8.0" />
+    <package id="Microsoft.Net.Compilers.Toolset" version="3.8.0" />
     <package id="Microsoft.DotNet.MSBuildSdkResolver" version="5.0.100-rc.2.20480.5" />
     <package id="Microsoft.Build.NuGetSdkResolver" version="5.8.0-rc.6860" />
     <package id="Newtonsoft.Json" version="12.0.2" />
@@ -23,11 +23,11 @@
     <package id="NuGet.ProjectModel" version="5.8.0-rc.6860" />
     <package id="NuGet.Protocol" version="5.8.0-rc.6860" />
     <package id="NuGet.Versioning" version="5.8.0-rc.6860" />
-    <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0-rc.2.20475.5" />
-    <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0-rc.2.20475.5" />
-    <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0-rc.2.20475.5" />
-    <package id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" version="5.0.0-rc.2.20475.5" />
-    <package id="runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0-rc.2.20475.5" />
+    <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0" />
+    <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0" />
+    <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0" />
+    <package id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" version="5.0.0" />
+    <package id="runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0" />
     <package id="SQLitePCLRaw.bundle_green" version="1.1.2" />
     <package id="SQLitePCLRaw.core" version="1.1.2" />
     <package id="SQLitePCLRaw.provider.e_sqlite3.net45" version="1.1.2" />


### PR DESCRIPTION
We can get off some of the pre packages (at least for the time being) as everything was published as part of .NET 5.0.

Updated:

 - Roslyn to 3.8.0
 - MSBuild to 16.8.0
 - DotNetHostResolver to 5.0.0