### PR TITLE
Update Tools packages to match .NET 5.0.100 SDK

### DIFF
--- a/tools/packages.config
+++ b/tools/packages.config
@@ -8,21 +8,21 @@
     <package id="Microsoft.Build.Tasks.Core" version="16.8.0" />
     <package id="Microsoft.Build.Utilities.Core" version="16.8.0" />
     <package id="Microsoft.Net.Compilers.Toolset" version="3.8.0" />
-    <package id="Microsoft.DotNet.MSBuildSdkResolver" version="5.0.100-rc.2.20480.5" />
-    <package id="Microsoft.Build.NuGetSdkResolver" version="5.8.0-rc.6860" />
+    <package id="Microsoft.DotNet.MSBuildSdkResolver" version="5.0.101-servicing.20564.2" />
+    <package id="Microsoft.Build.NuGetSdkResolver" version="5.8.0-rc.6930" />
     <package id="Newtonsoft.Json" version="12.0.2" />
-    <package id="NuGet.Build.Tasks" version="5.8.0-rc.6860" />
-    <package id="NuGet.Commands" version="5.8.0-rc.6860" />
-    <package id="NuGet.Common" version="5.8.0-rc.6860" />
-    <package id="NuGet.Configuration" version="5.8.0-rc.6860" />
-    <package id="NuGet.Credentials" version="5.8.0-rc.6860" />
-    <package id="NuGet.DependencyResolver.Core" version="5.8.0-rc.6860" />
-    <package id="NuGet.Frameworks" version="5.8.0-rc.6860" />
-    <package id="NuGet.LibraryModel" version="5.8.0-rc.6860" />
-    <package id="NuGet.Packaging" version="5.8.0-rc.6860" />
-    <package id="NuGet.ProjectModel" version="5.8.0-rc.6860" />
-    <package id="NuGet.Protocol" version="5.8.0-rc.6860" />
-    <package id="NuGet.Versioning" version="5.8.0-rc.6860" />
+    <package id="NuGet.Build.Tasks" version="5.8.0-rc.6930" />
+    <package id="NuGet.Commands" version="5.8.0-rc.6930" />
+    <package id="NuGet.Common" version="5.8.0-rc.6930" />
+    <package id="NuGet.Configuration" version="5.8.0-rc.6930" />
+    <package id="NuGet.Credentials" version="5.8.0-rc.6930" />
+    <package id="NuGet.DependencyResolver.Core" version="5.8.0-rc.6930" />
+    <package id="NuGet.Frameworks" version="5.8.0-rc.6930" />
+    <package id="NuGet.LibraryModel" version="5.8.0-rc.6930" />
+    <package id="NuGet.Packaging" version="5.8.0-rc.6930" />
+    <package id="NuGet.ProjectModel" version="5.8.0-rc.6930" />
+    <package id="NuGet.Protocol" version="5.8.0-rc.6930" />
+    <package id="NuGet.Versioning" version="5.8.0-rc.6930" />
     <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0" />
     <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0" />
     <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="5.0.0" />
@@ -38,7 +38,7 @@
     <package id="System.Resources.Extensions" version="4.7.1" />
     <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" />
     <package id="System.Text.Encodings.Web" version="4.7.1" />
-    <package id="System.Text.Json" version="4.7.1" />
+    <package id="System.Text.Json" version="4.7.2" />
     <package id="System.Threading.Tasks.Dataflow" version="4.11.1" />
     <package id="System.Threading.Tasks.Extensions" version="4.5.4" />
     <package id="xunit.runner.console" version="2.4.0" />


### PR DESCRIPTION
A follow up to https://github.com/OmniSharp/omnisharp-roslyn/pull/2015. Updates other packages to match the .NET 5 GA.