### PR TITLE
Add documentation comment creation to the FormatAfterKeystrokeService

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs
@@ -1,0 +1,110 @@
+﻿#nullable enable
+
+using System;
+using System.Reflection;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+
+namespace OmniSharp.Roslyn.DocumentationComments
+{
+    /// <summary>
+    /// Proxy service for Microsoft.CodeAnalysis.DocumentationComments.IDocumentationCommentSnippetService.
+    /// Implementation was based on the service as of this commit: 2834b74995bb66a7cb19cb09069c17812819afdc
+    /// See: https://github.com/dotnet/roslyn/blob/2834b74995bb66a7cb19cb09069c17812819afdc/src/Features/Core/Portable/DocumentationComments/IDocumentationCommentSnippetService.cs
+    /// </summary>
+    public struct DocumentationCommentSnippetService
+    {
+        /// <summary>
+        /// IDocumentationCommentService HostLanguageServices.GetRequiredService<IDocumentationCommentService>()
+        /// </summary>
+        private static MethodInfo s_getRequiredService;
+        /// <summary>
+        /// DocumentationCommentSnippet IDocumentationCommentService.GetDocumentationCommentSnippetOnCharacterTyped(SyntaxTree, SourceText, int, DocumentOptionSet, CancellationToken)
+        /// </summary>
+        private static MethodInfo s_getDocumentationCommentSnippetOnCharacterTyped;
+        /// <summary>
+        /// DocumentationCommentSnippet IDocumentationCommentService.GetDocumentationCommentSnippetOnEnterTyped(SyntaxTree, SourceText, int, DocumentOptionSet, CancellationToken)
+        /// </summary>
+        private static MethodInfo s_getDocumentationCommentSnippetOnEnterTyped;
+        /// <summary>
+        /// TextSpan DocumentationCommentSnippet.SpanToReplace
+        /// </summary>
+        private static PropertyInfo s_spanToReplace;
+        /// <summary>
+        /// string DocumentationCommentSnippet.SnippetText
+        /// </summary>
+        private static PropertyInfo s_snippetText;
+
+        static DocumentationCommentSnippetService()
+        {
+            var iDocumentationCommentSnippetServiceType = typeof(CompletionItem).Assembly.GetType("Microsoft.CodeAnalysis.DocumentationComments.IDocumentationCommentSnippetService");
+            s_getDocumentationCommentSnippetOnCharacterTyped = iDocumentationCommentSnippetServiceType.GetMethod(nameof(GetDocumentationCommentSnippetOnCharacterTyped));
+            s_getDocumentationCommentSnippetOnEnterTyped = iDocumentationCommentSnippetServiceType.GetMethod(nameof(GetDocumentationCommentSnippetOnEnterTyped));
+
+            var documentationCommentSnippet = typeof(CompletionItem).Assembly.GetType("Microsoft.CodeAnalysis.DocumentationComments.DocumentationCommentSnippet");
+            s_spanToReplace = documentationCommentSnippet.GetProperty(nameof(DocumentationCommentSnippet.SpanToReplace));
+            s_snippetText = documentationCommentSnippet.GetProperty(nameof(DocumentationCommentSnippet.SnippetText));
+
+            s_getRequiredService = typeof(HostLanguageServices).GetMethod(nameof(HostLanguageServices.GetRequiredService)).MakeGenericMethod(iDocumentationCommentSnippetServiceType);
+        }
+
+        public static DocumentationCommentSnippetService GetDocumentationCommentSnippetService(Document document)
+        {
+            var service = s_getRequiredService.Invoke(document.Project.LanguageServices, Array.Empty<object>());
+            return new DocumentationCommentSnippetService(service);
+        }
+
+        private object _underlying;
+
+        private DocumentationCommentSnippetService(object underlying)
+        {
+            _underlying = underlying;
+        }
+
+        public DocumentationCommentSnippet? GetDocumentationCommentSnippetOnCharacterTyped(SyntaxTree syntaxTree, SourceText text, int position, DocumentOptionSet options, CancellationToken cancellationToken)
+        {
+            var originalSnippet = s_getDocumentationCommentSnippetOnCharacterTyped.Invoke(_underlying, new object[] { syntaxTree, text, position, options, cancellationToken });
+            return ConvertSnippet(originalSnippet);
+        }
+
+        public DocumentationCommentSnippet? GetDocumentationCommentSnippetOnEnterTyped(SyntaxTree syntaxTree, SourceText text, int position, DocumentOptionSet options, CancellationToken cancellationToken)
+        {
+            var originalSnippet = s_getDocumentationCommentSnippetOnEnterTyped.Invoke(_underlying, new object[] { syntaxTree, text, position, options, cancellationToken });
+            return ConvertSnippet(originalSnippet);
+        }
+
+        private static DocumentationCommentSnippet? ConvertSnippet(object? originalSnippet)
+        {
+            if (originalSnippet == null)
+            {
+                return null;
+            }
+            else
+            {
+                return new DocumentationCommentSnippet((TextSpan)s_spanToReplace.GetValue(originalSnippet), (string)s_snippetText.GetValue(originalSnippet));
+            }
+        }
+    }
+
+    public struct DocumentationCommentSnippet
+    {
+        public TextSpan SpanToReplace { get; }
+        public string SnippetText { get; }
+
+        public DocumentationCommentSnippet(TextSpan spanToReplace, string snippetText)
+        {
+            SpanToReplace = spanToReplace;
+            SnippetText = snippetText;
+        }
+    }
+
+    public static class WorkspaceExtensions
+    {
+        public static DocumentationCommentSnippetService GetDocumentationCommentSnippetService(this Document document)
+            => DocumentationCommentSnippetService.GetDocumentationCommentSnippetService(document);
+    }
+}

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormatAfterKeystrokeTests.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormatAfterKeystrokeTests.cs
@@ -1,0 +1,414 @@
+﻿#nullable enable
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Formatting;
+using OmniSharp.Models.Format;
+using OmniSharp.Models.UpdateBuffer;
+using OmniSharp.Roslyn.CSharp.Services.Buffer;
+using OmniSharp.Roslyn.CSharp.Services.Formatting;
+using TestUtility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OmniSharp.Roslyn.CSharp.Tests
+{
+    public class FormatAfterKeystrokeTests : AbstractTestFixture
+    {
+        public FormatAfterKeystrokeTests(ITestOutputHelper output, SharedOmniSharpHostFixture sharedOmniSharpHostFixture)
+            : base(output, sharedOmniSharpHostFixture)
+        {
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task NoComment_OnEnter(string fileName)
+        {
+            await VerifyNoChange(fileName, "\n",
+@"class C
+{
+$$
+}");
+
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task NoComment_OnSingleForwardSlash(string fileName)
+        {
+            await VerifyNoChange(fileName, "/",
+@"class C
+{
+    /$$
+}
+");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task NoComment_OnDoubleForwardSlash(string fileName)
+        {
+            await VerifyNoChange(fileName, "/",
+@"class C
+{
+    //$$
+}
+");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task NoComment_OnTripleForwardSlash_NoMember(string fileName)
+        {
+            await VerifyNoChange(fileName, "/",
+@"class C
+{
+    ///$$
+}
+");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task Comment_OnTripleForwardSlash_BeforeMethod(string fileName)
+        {
+            await VerifyChange(fileName, "/",
+@"class C
+{
+    ///$$
+    public string M<T>(string param1, int param2) { }
+}",
+@"class C
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <typeparam name=""T""></typeparam>
+    /// <param name=""param1""></param>
+    /// <param name=""param2""></param>
+    /// <returns></returns>
+    public string M<T>(string param1, int param2) { }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task Comment_OnTripleForwardSlash_BeforeType(string fileName)
+        {
+            await VerifyChange(fileName, "/",
+@"///$$
+class C
+{
+    public string M(string param1, int param2) { }
+}",
+@"/// <summary>
+/// 
+/// </summary>
+class C
+{
+    public string M(string param1, int param2) { }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task Comment_OnTripleForwardSlash_BeforeProperty(string fileName)
+        {
+            await VerifyChange(fileName, "/",
+@"class C
+{
+    ///$$
+    public int Prop { get; set; }
+}",
+@"class C
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public int Prop { get; set; }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task Comment_OnTripleForwardSlash_BeforeIndexer(string fileName)
+        {
+            await VerifyChange(fileName, "/",
+@"class C
+{
+    ///$$
+    public int this[int i] { get; set; }
+}",
+@"class C
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name=""i""></param>
+    /// <returns></returns>
+    public int this[int i] { get; set; }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task Comment_OnEnterInComment_BetweenTags_Newline(string fileName)
+        {
+            await VerifyChange(fileName, "\n",
+@"class C
+{
+    /// <summary>
+    ///
+$$
+    /// </summary>
+    /// <param name=""param1""></param>
+    /// <param name=""param2""></param>
+    /// <returns></returns>
+    public string M(string param1, int param2) { }
+}",
+@"class C
+{
+    /// <summary>
+    ///
+    /// 
+    /// </summary>
+    /// <param name=""param1""></param>
+    /// <param name=""param2""></param>
+    /// <returns></returns>
+    public string M(string param1, int param2) { }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task Comment_OnEnterInComment_BetweenTags_SameLine(string fileName)
+        {
+            await VerifyChange(fileName, "\n",
+@"class C
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name=""param1"">
+$$</param>
+    /// <param name=""param2""></param>
+    /// <returns></returns>
+    public string M(string param1, int param2) { }
+}",
+@"class C
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name=""param1"">
+    /// </param>
+    /// <param name=""param2""></param>
+    /// <returns></returns>
+    public string M(string param1, int param2) { }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task Comment_OnEnterInComment_AfterTags(string fileName)
+        {
+            await VerifyChange(fileName, "\n",
+@"class C
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name=""param1""></param>
+    /// <param name=""param2""></param>
+    /// <returns></returns>
+$$
+    public string M(string param1, int param2) { }
+}",
+@"class C
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name=""param1""></param>
+    /// <param name=""param2""></param>
+    /// <returns></returns>
+    /// 
+    public string M(string param1, int param2) { }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task Comment_OnTripleForwardSlash_VerbatimNames(string fileName)
+        {
+            await VerifyChange(fileName, "/",
+@"class C
+{
+    ///$$
+    public string M<@int>(string @float) { }
+}",
+@"class C
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <typeparam name=""int""></typeparam>
+    /// <param name=""float""></param>
+    /// <returns></returns>
+    public string M<@int>(string @float) { }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task Comment_OnTripleForwardSlash_VoidMethod(string fileName)
+        {
+            await VerifyChange(fileName, "/",
+@"class C
+{
+    ///$$
+    public void M() { }
+}",
+@"class C
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public void M() { }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task NoComment_OnTripleForwardSlash_ExistingLineAbove(string fileName)
+        {
+            await VerifyNoChange(fileName, "/",
+@"class C
+{
+    ///
+    ///$$
+    public void M() { }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task NoComment_OnTripleForwardSlash_ExistingLineBelow_01(string fileName)
+        {
+            await VerifyNoChange(fileName, "/",
+@"class C
+{
+    ///$$
+    ///
+    public void M() { }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task NoComment_OnTripleForwardSlash_ExistingLineBelow_02(string fileName)
+        {
+            await VerifyNoChange(fileName, "/",
+@"class C
+{
+    ///$$
+    /// <summary></summary>
+    public void M() { }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task NoComment_OnTripleForwardSlash_InsideMethodBody(string fileName)
+        {
+            await VerifyNoChange(fileName, "/",
+@"class C
+{
+    public void M()
+    {
+        ///$$
+    }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task NoComment_OnNewLine_InsideMethodBody(string fileName)
+        {
+            await VerifyNoChange(fileName, "/",
+@"class C
+{
+    public void M()
+    {
+        ///
+$$
+    }
+}");
+        }
+
+        private async Task VerifyNoChange(string fileName, string typedCharacter, string originalMarkup)
+        {
+            var (response, _) = await GetResponse(originalMarkup, typedCharacter, fileName);
+            Assert.Empty(response.Changes);
+        }
+
+        private async Task VerifyChange(string fileName, string typedCharacter, string originalMarkup, string expected)
+        {
+            var (response, testFile) = await GetResponse(originalMarkup, typedCharacter, fileName);
+            Assert.NotNull(response);
+
+            var fileChangedService = SharedOmniSharpTestHost.GetRequestHandler<UpdateBufferService>(OmniSharpEndpoints.UpdateBuffer);
+            _ = await fileChangedService.Handle(new UpdateBufferRequest()
+            {
+                FileName = testFile.FileName,
+                Changes = response.Changes,
+                ApplyChangesTogether = true,
+            });
+
+            var actualDoc = SharedOmniSharpTestHost.Workspace.GetDocument(testFile.FileName);
+            Assert.NotNull(actualDoc);
+            var actualText = (await actualDoc.GetTextAsync()).ToString();
+            AssertUtils.Equal(expected, actualText);
+        }
+
+        private async Task<(FormatRangeResponse, TestFile)> GetResponse(string text, string character, string fileName)
+        {
+            // Ensure system newlines are used
+            var options = SharedOmniSharpTestHost.Workspace.Options.WithChangedOption(FormattingOptions.NewLine, LanguageNames.CSharp, System.Environment.NewLine);
+            SharedOmniSharpTestHost.Workspace.TryApplyChanges(SharedOmniSharpTestHost.Workspace.CurrentSolution.WithOptions(options));
+
+            var file = new TestFile(fileName, text);
+            SharedOmniSharpTestHost.AddFilesToWorkspace(file);
+            var point = file.Content.GetPointFromPosition();
+
+            var request = new FormatAfterKeystrokeRequest
+            {
+                Line = point.Line,
+                Column = point.Offset,
+                FileName = fileName,
+                Character = character,
+            };
+
+            var requestHandler = SharedOmniSharpTestHost.GetRequestHandler<FormatAfterKeystrokeService>(OmniSharpEndpoints.FormatAfterKeystroke);
+            return (await requestHandler.Handle(request), file);
+        }
+    }
+}

--- a/tests/TestUtility/AssertUtils.cs
+++ b/tests/TestUtility/AssertUtils.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace TestUtility
@@ -23,6 +25,25 @@ namespace TestUtility
         private static string TrimLines(string source)
         {
             return string.Join("\n", source.Split('\n').Select(s => s.Trim()));
+        }
+
+        // Taken from dotnet/roslyn, MIT License.
+        // https://github.com/dotnet/roslyn/blob/2834b74995bb66a7cb19cb09069c17812819afdc/src/Compilers/Test/Core/Assert/AssertEx.cs#L188-L203
+        public static void Equal(string expected, string actual)
+        {
+            if (string.Equals(expected, actual, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var message = new StringBuilder();
+            message.AppendLine();
+            message.AppendLine("Expected:");
+            message.AppendLine(expected);
+            message.AppendLine("Actual:");
+            message.AppendLine(actual);
+
+            Assert.True(false, message.ToString());
         }
     }
 }


### PR DESCRIPTION
IDocumentationCommentSnippetService was recently moved down to the Features layer, which means omnisharp can now take advantage of it and generate documentation comment snippets on typing. There are a couple of caveats:

1. LSP's "/onTypingFormat" endpoint has no support for setting the cursor location after format, which means that the cursor ends up after the inserted block. This is fine for newlines inside doc comments, but awkward for the initial expansion. However, unless we want to add special support with a custom endpoint, we can't get around this (the custom endpoint is how Roslyn does it).
2. The service itself is still internal, so I had to add a few new reflection points.

Server-side of https://github.com/OmniSharp/omnisharp-vscode/issues/8. It also needs a vscode change, but it's a one-line change I'll submit later after we get this merged and I can write some integration tests.
