### PR TITLE
Editorconfig improvements - do not lose state, trigger re-analysis on change

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
@@ -24,15 +24,13 @@ namespace OmniSharp.MSBuild.ProjectFile
                         .WithSpecificDiagnosticOptions(projectFileInfo.GetDiagnosticOptions())
                         .WithOverflowChecks(projectFileInfo.CheckForOverflowUnderflow);
 
-            if (projectFileInfo.AllowUnsafeCode)
+            if (projectFileInfo.AllowUnsafeCode != compilationOptions.AllowUnsafe)
             {
-                compilationOptions = compilationOptions.WithAllowUnsafe(true);
+                compilationOptions = compilationOptions.WithAllowUnsafe(projectFileInfo.AllowUnsafeCode);
             }
 
-            if (projectFileInfo.TreatWarningsAsErrors)
-            {
-                compilationOptions = compilationOptions.WithGeneralDiagnosticOption(ReportDiagnostic.Error);
-            }
+            compilationOptions = projectFileInfo.TreatWarningsAsErrors ?
+                        compilationOptions.WithGeneralDiagnosticOption(ReportDiagnostic.Error) : compilationOptions.WithGeneralDiagnosticOption(ReportDiagnostic.Default);
 
             if (projectFileInfo.NullableContextOptions != compilationOptions.NullableContextOptions)
             {

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
@@ -15,10 +15,14 @@ namespace OmniSharp.MSBuild.ProjectFile
         public static CSharpCompilationOptions CreateCompilationOptions(this ProjectFileInfo projectFileInfo)
         {
             var compilationOptions = new CSharpCompilationOptions(projectFileInfo.OutputKind);
+            return projectFileInfo.CreateCompilationOptions(compilationOptions);
+        }
 
-            compilationOptions = compilationOptions.WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default)
-                                    .WithSpecificDiagnosticOptions(projectFileInfo.GetDiagnosticOptions())
-                                    .WithOverflowChecks(projectFileInfo.CheckForOverflowUnderflow);
+        public static CSharpCompilationOptions CreateCompilationOptions(this ProjectFileInfo projectFileInfo, CSharpCompilationOptions existingCompilationOptions)
+        {
+            var compilationOptions = existingCompilationOptions.WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default)
+                        .WithSpecificDiagnosticOptions(projectFileInfo.GetDiagnosticOptions())
+                        .WithOverflowChecks(projectFileInfo.CheckForOverflowUnderflow);
 
             if (projectFileInfo.AllowUnsafeCode)
             {

--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -486,7 +486,7 @@ namespace OmniSharp.MSBuild
                 var newCompilationOptions = projectFileInfo.CreateCompilationOptions(existingCompilationOptions);
                 if (newCompilationOptions != existingCompilationOptions)
                 {
-                    _workspace.UpdateCompilationOptionsForProject(project.Id, existingCompilationOptions);
+                    _workspace.UpdateCompilationOptionsForProject(project.Id, newCompilationOptions);
                     _logger.LogDebug("Updated project compilation options on project {project.Id}.");
                 }
             }

--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -533,6 +533,7 @@ namespace OmniSharp.MSBuild
         {
             if (!_workspace.EditorConfigEnabled)
             {
+                _logger.LogDebug($".editorconfig files were configured by the project {project.Name} but will not be respected because the feature is switched off in OmniSharp. Enable .editorconfig support in OmniSharp to take advantage of them.");
                 return;
             }
 
@@ -548,6 +549,10 @@ namespace OmniSharp.MSBuild
                 {
                     _logger.LogDebug($".editorconfig file for project {project.Name}: {file}");
                     _workspace.AddAnalyzerConfigDocument(project.Id, file);
+                }
+                else
+                {
+                    _logger.LogDebug($".editorconfig file for project {project.Name}: {file} was expected but not found on disk.");
                 }
             }
         }

--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -546,6 +546,7 @@ namespace OmniSharp.MSBuild
             {
                 if (File.Exists(file))
                 {
+                    _logger.LogDebug($".editorconfig file for project {project.Name}: {file}");
                     _workspace.AddAnalyzerConfigDocument(project.Id, file);
                 }
             }

--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -37,12 +37,14 @@ namespace OmniSharp.MSBuild
             public ProjectIdInfo ProjectIdInfo;
             public string FilePath { get; }
             public bool AllowAutoRestore { get; set; }
+            public string ChangeTriggerPath { get; }
             public ProjectLoadedEventArgs LoadedEventArgs { get; set; }
 
-            public ProjectToUpdate(string filePath, bool allowAutoRestore, ProjectIdInfo projectIdInfo)
+            public ProjectToUpdate(string filePath, bool allowAutoRestore, ProjectIdInfo projectIdInfo, string changeTriggerPath)
             {
                 ProjectIdInfo = projectIdInfo ?? throw new ArgumentNullException(nameof(projectIdInfo));
                 FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+                ChangeTriggerPath = changeTriggerPath;
                 AllowAutoRestore = allowAutoRestore;
             }
         }
@@ -158,10 +160,10 @@ namespace OmniSharp.MSBuild
         public IEnumerable<ProjectFileInfo> GetAllProjects() => _projectFiles.GetItems();
         public bool TryGetProject(string projectFilePath, out ProjectFileInfo projectFileInfo) => _projectFiles.TryGetValue(projectFilePath, out projectFileInfo);
 
-        public void QueueProjectUpdate(string projectFilePath, bool allowAutoRestore, ProjectIdInfo projectId)
+        public void QueueProjectUpdate(string projectFilePath, bool allowAutoRestore, ProjectIdInfo projectId, string changeTriggerFilePath = null)
         {
             _logger.LogInformation($"Queue project update for '{projectFilePath}'");
-            _queue.Post(new ProjectToUpdate(projectFilePath, allowAutoRestore, projectId));
+            _queue.Post(new ProjectToUpdate(projectFilePath, allowAutoRestore, projectId, changeTriggerFilePath));
         }
 
         public async Task WaitForQueueEmptyAsync()
@@ -262,7 +264,7 @@ namespace OmniSharp.MSBuild
                 {
                     foreach (var project in projectList)
                     {
-                        UpdateProject(project.FilePath);
+                        UpdateProject(project.FilePath, project.ChangeTriggerPath);
 
                         // Fire loaded events
                         if (project.LoadedEventArgs != null)
@@ -382,7 +384,7 @@ namespace OmniSharp.MSBuild
             // as "updates". We should properly remove projects that are deleted.
             _fileSystemWatcher.Watch(projectFileInfo.FilePath, (file, changeType) =>
             {
-                QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: true, projectFileInfo.ProjectIdInfo);
+                QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: true, projectFileInfo.ProjectIdInfo, file);
             });
 
             if (_workspace.EditorConfigEnabled)
@@ -390,7 +392,7 @@ namespace OmniSharp.MSBuild
                 // Watch beneath the Project folder for changes to .editorconfig files.
                 _fileSystemWatcher.Watch(".editorconfig", (file, changeType) =>
                 {
-                    QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo);
+                    QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo, file);
                 });
 
                 // Watch in folders above the Project folder for changes to .editorconfig files.
@@ -404,7 +406,7 @@ namespace OmniSharp.MSBuild
 
                     _fileSystemWatcher.Watch(Path.Combine(parentPath, ".editorconfig"), (file, changeType) =>
                     {
-                        QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo);
+                        QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo, file);
                     });
                 }
             }
@@ -413,7 +415,7 @@ namespace OmniSharp.MSBuild
             {
                 _fileSystemWatcher.Watch(projectFileInfo.RuleSet.FilePath, (file, changeType) =>
                 {
-                    QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo);
+                    QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo, file);
                 });
             }
 
@@ -421,7 +423,7 @@ namespace OmniSharp.MSBuild
             {
                 _fileSystemWatcher.Watch(projectFileInfo.ProjectAssetsFile, (file, changeType) =>
                 {
-                    QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo);
+                    QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo, file);
                 });
 
                 var restoreDirectory = Path.GetDirectoryName(projectFileInfo.ProjectAssetsFile);
@@ -432,22 +434,22 @@ namespace OmniSharp.MSBuild
 
                 _fileSystemWatcher.Watch(nugetCacheFile, (file, changeType) =>
                 {
-                    QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo);
+                    QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo, file);
                 });
 
                 _fileSystemWatcher.Watch(nugetPropsFile, (file, changeType) =>
                 {
-                    QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo);
+                    QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo, file);
                 });
 
                 _fileSystemWatcher.Watch(nugetTargetsFile, (file, changeType) =>
                 {
-                    QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo);
+                    QueueProjectUpdate(projectFileInfo.FilePath, allowAutoRestore: false, projectFileInfo.ProjectIdInfo, file);
                 });
             }
         }
 
-        private void UpdateProject(string projectFilePath)
+        private void UpdateProject(string projectFilePath, string changeTriggerFilePath)
         {
             if (!_projectFiles.TryGetValue(projectFilePath, out var projectFileInfo))
             {
@@ -462,6 +464,15 @@ namespace OmniSharp.MSBuild
                 return;
             }
 
+            // if the update was triggered by a change to an editorconfig file, only reload that analyzer config file
+            // this will propagata a reanalysis of the project
+            if (changeTriggerFilePath != null && changeTriggerFilePath.ToLowerInvariant().EndsWith(".editorconfig"))
+            {
+                UpdateAnalyzerConfigFile(project, changeTriggerFilePath);
+                return;
+            }
+
+            // for other update triggers, perform a full check of all options
             UpdateSourceFiles(project, projectFileInfo.SourceFiles);
             UpdateParseOptions(project, projectFileInfo.LanguageVersion, projectFileInfo.PreprocessorSymbolNames, !string.IsNullOrWhiteSpace(projectFileInfo.DocumentationFile));
             UpdateProjectReferences(project, projectFileInfo.ProjectReferences);
@@ -487,7 +498,7 @@ namespace OmniSharp.MSBuild
                 if (newCompilationOptions != existingCompilationOptions)
                 {
                     _workspace.UpdateCompilationOptionsForProject(project.Id, newCompilationOptions);
-                    _logger.LogDebug("Updated project compilation options on project {project.Id}.");
+                    _logger.LogDebug($"Updated project compilation options on project {project.Name}.");
                 }
             }
         }
@@ -545,6 +556,31 @@ namespace OmniSharp.MSBuild
             }
         }
 
+        private void UpdateAnalyzerConfigFile(Project project, string analyzerConfigFile)
+        {
+            if (!_workspace.EditorConfigEnabled)
+            {
+                _logger.LogDebug($".editorconfig files were configured by the project {project.Name} but will not be respected because the feature is switched off in OmniSharp. Enable .editorconfig support in OmniSharp to take advantage of them.");
+                return;
+            }
+
+            var currentAnalyzerConfigDocument = project.AnalyzerConfigDocuments.FirstOrDefault(x => x.FilePath.Equals(analyzerConfigFile));
+            if (currentAnalyzerConfigDocument == null)
+            {
+                _logger.LogDebug($"The change was reported in {analyzerConfigFile} but it doesn't belong to any project.");
+                return;
+            }
+
+            if (!File.Exists(analyzerConfigFile))
+            {
+                _logger.LogWarning($"The change was reported in {analyzerConfigFile} but it doesn't exist on disk.");
+                return;
+            }
+
+            _workspace.ReloadAnalyzerConfigDocument(currentAnalyzerConfigDocument.Id, analyzerConfigFile);
+            _logger.LogDebug($"Reloaded {analyzerConfigFile} in project {project.Name}.");
+        }
+
         private void UpdateAnalyzerConfigFiles(Project project, IList<string> analyzerConfigFiles)
         {
             if (!_workspace.EditorConfigEnabled)
@@ -556,6 +592,7 @@ namespace OmniSharp.MSBuild
             var currentAnalyzerConfigDocuments = project.AnalyzerConfigDocuments;
             foreach (var document in currentAnalyzerConfigDocuments)
             {
+                _logger.LogDebug($".editorconfig file '{document.Name}' removed from project {project.Name}");
                 _workspace.RemoveAnalyzerConfigDocument(document.Id);
             }
 
@@ -563,12 +600,12 @@ namespace OmniSharp.MSBuild
             {
                 if (File.Exists(file))
                 {
-                    _logger.LogDebug($".editorconfig file for project {project.Name}: {file}");
                     _workspace.AddAnalyzerConfigDocument(project.Id, file);
+                    _logger.LogDebug($".editorconfig file '{file}' added for project {project.Name}");
                 }
                 else
                 {
-                    _logger.LogDebug($".editorconfig file for project {project.Name}: {file} was expected but not found on disk.");
+                    _logger.LogWarning($".editorconfig file '{file}' for project {project.Name} was expected but not found on disk.");
                 }
             }
         }

--- a/src/OmniSharp.MSBuild/ProjectManager.cs
+++ b/src/OmniSharp.MSBuild/ProjectManager.cs
@@ -578,7 +578,7 @@ namespace OmniSharp.MSBuild
             }
 
             _workspace.ReloadAnalyzerConfigDocument(currentAnalyzerConfigDocument.Id, analyzerConfigFile);
-            _logger.LogDebug($"Reloaded {analyzerConfigFile} in project {project.Name}.");
+            _logger.LogDebug($"Reloaded {currentAnalyzerConfigDocument.Id} from {analyzerConfigFile} in project {project.Name}.");
         }
 
         private void UpdateAnalyzerConfigFiles(Project project, IList<string> analyzerConfigFiles)

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
@@ -173,15 +173,15 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
                         _logger.LogDebug($"Tried to remove non existent document from analysis, document: {changeEvent.DocumentId}");
                     }
                     break;
+                case WorkspaceChangeKind.AnalyzerConfigDocumentChanged:
+                    _logger.LogDebug($"Analyzer config document {changeEvent.DocumentId} changed, which triggered re-analysis of project {changeEvent.ProjectId}.");
+                    QueueForAnalysis(_workspace.CurrentSolution.GetProject(changeEvent.ProjectId).Documents.Select(x => x.Id).ToImmutableArray(), AnalyzerWorkType.Background);
+                    break;
                 case WorkspaceChangeKind.ProjectAdded:
                 case WorkspaceChangeKind.ProjectChanged:
                 case WorkspaceChangeKind.ProjectReloaded:
-                // at the moment we remove and re-add analyzer documents when project update is requested
-                // therefore it is enough to just listen to "AnalyzerConfigDocumentAdded" event to trigger re-analysis
-                case WorkspaceChangeKind.AnalyzerConfigDocumentAdded:
                     _logger.LogDebug($"Project {changeEvent.ProjectId} updated, reanalyzing its diagnostics.");
-                    var projectDocumentIds = _workspace.CurrentSolution.GetProject(changeEvent.ProjectId).Documents.Select(x => x.Id).ToImmutableArray();
-                    QueueForAnalysis(projectDocumentIds, AnalyzerWorkType.Background);
+                    QueueForAnalysis(_workspace.CurrentSolution.GetProject(changeEvent.ProjectId).Documents.Select(x => x.Id).ToImmutableArray(), AnalyzerWorkType.Background);
                     break;
                 case WorkspaceChangeKind.SolutionAdded:
                 case WorkspaceChangeKind.SolutionChanged:

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
@@ -176,6 +176,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
                 case WorkspaceChangeKind.ProjectAdded:
                 case WorkspaceChangeKind.ProjectChanged:
                 case WorkspaceChangeKind.ProjectReloaded:
+                // at the moment we remove and re-add analyzer documents when project update is requested
+                // therefore it is enough to just listen to "AnalyzerConfigDocumentAdded" event to trigger re-analysis
+                case WorkspaceChangeKind.AnalyzerConfigDocumentAdded:
                     _logger.LogDebug($"Project {changeEvent.ProjectId} updated, reanalyzing its diagnostics.");
                     var projectDocumentIds = _workspace.CurrentSolution.GetProject(changeEvent.ProjectId).Documents.Select(x => x.Id).ToImmutableArray();
                     QueueForAnalysis(projectDocumentIds, AnalyzerWorkType.Background);

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -556,6 +556,12 @@ namespace OmniSharp
             OnAnalyzerConfigDocumentAdded(documentInfo);
         }
 
+        public void ReloadAnalyzerConfigDocument(DocumentId documentId, string filePath)
+        {
+            var loader = new OmniSharpTextLoader(filePath);
+            OnAnalyzerConfigDocumentTextLoaderChanged(documentId, loader);
+        }
+
         public void RemoveAdditionalDocument(DocumentId documentId)
         {
             OnAdditionalDocumentRemoved(documentId);

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -149,6 +149,7 @@ namespace OmniSharp
             var newAnalyzerConfigFiles = EditorConfigFinder
                 .GetEditorConfigPaths(filePath)
                 .Except(analyzerConfigFiles);
+
             foreach (var analyzerConfigFile in newAnalyzerConfigFiles)
             {
                 AddAnalyzerConfigDocument(projectInfo.Id, analyzerConfigFile);


### PR DESCRIPTION
1. at the moment we set brand new `CompilationOptions` based on the csproj file when a project update is triggered (e.g. rebuild, change in csproj). This causes us to lose the editorconfig state because it is kept in `SyntaxTreeOptionsProvider` which gets reset then. The PR ensures the new compilation options are created only when necessary, and also derived from the previous ones. 
  - fixes https://github.com/OmniSharp/omnisharp-vscode/issues/4184  
  - fixes https://github.com/OmniSharp/omnisharp-vscode/issues/4165
  - fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1955
2. when editorconfig file changes, even though we watch for changes, there is currently no event raised that would trigger a re-analysis. This PR introduces new targeted handling of editorconfig - if an editorconfig file changes, we raise a relevant workspace event (`AnalyzerConfigDocumentChanged`) which is now newly handled to trigger re-analysis.  
  - fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/1904 