### PR TITLE
raise default GotoDefinitionRequest timeout from 2s to 10s

### DIFF
--- a/src/OmniSharp.Abstractions/Models/v1/GotoDefinition/GotoDefinitionRequest.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/GotoDefinition/GotoDefinitionRequest.cs
@@ -5,7 +5,7 @@ namespace OmniSharp.Models.GotoDefinition
     [OmniSharpEndpoint(OmniSharpEndpoints.GotoDefinition, typeof(GotoDefinitionRequest), typeof(GotoDefinitionResponse))]
     public class GotoDefinitionRequest : Request
     {
-        public int Timeout { get; set; } = 2000;
+        public int Timeout { get; set; } = 10000;
         public bool WantMetadata { get; set; }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/ExternalSourceServiceFactory.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/ExternalSourceServiceFactory.cs
@@ -32,7 +32,7 @@ namespace OmniSharp.Roslyn.CSharp.Services
         public CancellationToken CreateCancellationToken(OmniSharpOptions omniSharpOptions, int timeout)
         {
             var enableDecompilationSupport = omniSharpOptions.RoslynExtensionsOptions.EnableDecompilationSupport;
-            // since decompilation is slower, use a larger cancellation time (default is 2s per request)
+            // since decompilation is slower, use a larger cancellation time
             var cancellationTimeout = enableDecompilationSupport
                 ? timeout <= 10000 ? 10000 : timeout // minimum 10s for decompilation
                 : timeout; // request defined for metadata


### PR DESCRIPTION
The 2s timeout is quite aggressive and it was reported already a few times that it doesn't complete in time especially on large metadata files.

The client can still supply its own timeout, it's just the default is now 10s (VS Code Extension doesn't set it so it will automatically benefit from the higher timeout). 

Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/4260 