### PR TITLE
added `msbuild:UseBundledOnly` option to force the usage of bundled MSBuild

### DIFF
--- a/src/OmniSharp.Host/MSBuild/Discovery/MSBuildLocator.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/MSBuildLocator.cs
@@ -48,7 +48,12 @@ namespace OmniSharp.MSBuild.Discovery
         public static MSBuildLocator CreateDefault(ILoggerFactory loggerFactory, IAssemblyLoader assemblyLoader, IConfiguration msbuildConfiguration)
         {
             var useBundledOnly = msbuildConfiguration.GetValue<bool>("UseBundledOnly");
-            if (useBundledOnly) return CreateStandAlone(loggerFactory, assemblyLoader);
+            if (useBundledOnly)
+            {
+                var logger = loggerFactory.CreateLogger<MSBuildLocator>();
+                logger.LogInformation("Because 'UseBundledOnly' is enabled in the configuration, OmniSharp will only use the bundled MSBuild.");
+                return CreateStandAlone(loggerFactory, assemblyLoader);
+            }
 
             return new MSBuildLocator(loggerFactory, assemblyLoader,
                 ImmutableArray.Create<MSBuildInstanceProvider>(

--- a/src/OmniSharp.Host/MSBuild/Discovery/MSBuildLocator.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/MSBuildLocator.cs
@@ -46,13 +46,18 @@ namespace OmniSharp.MSBuild.Discovery
         }
 
         public static MSBuildLocator CreateDefault(ILoggerFactory loggerFactory, IAssemblyLoader assemblyLoader, IConfiguration msbuildConfiguration)
-            => new MSBuildLocator(loggerFactory, assemblyLoader,
+        {
+            var useBundledOnly = msbuildConfiguration.GetValue<bool>("UseBundledOnly");
+            if (useBundledOnly) return CreateStandAlone(loggerFactory, assemblyLoader);
+
+            return new MSBuildLocator(loggerFactory, assemblyLoader,
                 ImmutableArray.Create<MSBuildInstanceProvider>(
                     new DevConsoleInstanceProvider(loggerFactory),
                     new VisualStudioInstanceProvider(loggerFactory),
                     new MonoInstanceProvider(loggerFactory),
                     new StandAloneInstanceProvider(loggerFactory),
                     new UserOverrideInstanceProvider(loggerFactory, msbuildConfiguration)));
+        }
 
         public static MSBuildLocator CreateStandAlone(ILoggerFactory loggerFactory, IAssemblyLoader assemblyLoader)
             => new MSBuildLocator(loggerFactory, assemblyLoader,

--- a/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
+++ b/src/OmniSharp.MSBuild/Options/MSBuildOptions.cs
@@ -2,6 +2,7 @@ namespace OmniSharp.Options
 {
     public class MSBuildOptions
     {
+        public bool UseBundledOnly { get; set; } = false;
         public string ToolsVersion { get; set; }
         public string VisualStudioVersion { get; set; }
         public string Configuration { get; set; }

--- a/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/MSBuildSelectionTests.cs
@@ -260,19 +260,6 @@ namespace OmniSharp.MSBuild.Tests
         }
 
         [Fact]
-        public void CreateDefault_UseBundledOnly_False_LocatesAllInstances()
-        {
-            var configBuilder = new Microsoft.Extensions.Configuration.ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()
-            {
-                ["useBundledOnly"] = "false"
-            });
-            var loggerFactory = new LoggerFactory();
-            var locator = MSBuildLocator.CreateDefault(loggerFactory, new AssemblyLoader(loggerFactory), configBuilder.Build());
-            var instances = locator.GetInstances();
-            Assert.True(instances.Length > 1, "When bundled only is set to false, there should be at least 2 discovered instances (e.g. VS / Mono) + bundled.");
-        }
-
-        [Fact]
         public void CreateDefault_UseBundledOnly_True_LocatesOnlyStandAloneInstance()
         {
             var configBuilder = new Microsoft.Extensions.Configuration.ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()


### PR DESCRIPTION
At the moment there is no way to force bundled MSBuild on Windows.
On Linux/Mac it is possible in VS Code using `omnisharp.useGlobalMono: never` but it is a client specific option, not a universal server option for all clients.

What this PR introduces is the following setting to `omnisharp.json`

```
{
   "msbuild": {
       "useBundledOnly": true
   }
}
```

The effect is:

 - on Windows, no Visual Studio / MSBuild Tools MSBuild is discovered anymore - only the bundled MSBuild is used
 - on Linux/Mac, regardless whether running on global or local Mono - only the bundled MSBuild is used

This should unblock scenarios when:

 - user has outdated Visual Studio
 - user wants to run on global Mono but using the bundled MSBuild

Both of those have been repeated in multiple issues.