### PR TITLE
Allow LegacySDKResolver to find SDK path in tests

### DIFF
--- a/tests/TestUtility/TestServiceProvider.cs
+++ b/tests/TestUtility/TestServiceProvider.cs
@@ -82,7 +82,7 @@ namespace TestUtility
 
             var assemblyLoader = CreateAssemblyLoader(loggerFactory);
             var dotNetCliService = CreateDotNetCliService(dotNetCliVersion, loggerFactory, eventEmitter);
-            var configuration = CreateConfiguration(configurationData, dotNetCliService);
+            var configuration = CreateConfiguration(configurationData);
             var msbuildLocator = CreateMSBuildLocator(loggerFactory, assemblyLoader);
             var sharedTextWriter = CreateSharedTextWriter(testOutput);
             var analyzerAssemblyLoader = new AnalyzerAssemblyLoader();
@@ -106,7 +106,7 @@ namespace TestUtility
             eventEmitter = eventEmitter ?? NullEventEmitter.Instance;
 
             var dotNetCliService = CreateDotNetCliService(dotNetCliVersion, loggerFactory, eventEmitter);
-            var configuration = CreateConfiguration(configurationData, dotNetCliService);
+            var configuration = CreateConfiguration(configurationData);
             var sharedTextWriter = CreateSharedTextWriter(testOutput);
 
             return new TestServiceProvider(
@@ -117,13 +117,9 @@ namespace TestUtility
         private static IAssemblyLoader CreateAssemblyLoader(ILoggerFactory loggerFactory)
             => new AssemblyLoader(loggerFactory);
 
-        private static IConfigurationRoot CreateConfiguration(IConfiguration configurationData,
-            IDotNetCliService dotNetCliService)
+        private static IConfigurationRoot CreateConfiguration(IConfiguration configurationData)
         {
-            var info = dotNetCliService.GetInfo();
-            var msbuildSdksPath = Path.Combine(info.BasePath, "Sdks");
-
-            var builder = new Microsoft.Extensions.Configuration.ConfigurationBuilder();
+            var builder = new ConfigurationBuilder();
 
             if (configurationData != null)
             {
@@ -138,8 +134,7 @@ namespace TestUtility
             // within the appropriate .NET Core SDK.
             var msbuildProperties = new Dictionary<string, string>()
             {
-                [$"MSBuild:{nameof(MSBuildOptions.UseLegacySdkResolver)}"] = "true",
-                [$"MSBuild:{nameof(MSBuildOptions.MSBuildSDKsPath)}"] = msbuildSdksPath
+                [$"MSBuild:{nameof(MSBuildOptions.UseLegacySdkResolver)}"] = "true"
             };
 
             builder.AddInMemoryCollection(msbuildProperties);


### PR DESCRIPTION
As noted in https://github.com/OmniSharp/omnisharp-roslyn/pull/2034#issuecomment-745548208, when running tests we were always using the 5.0.100 sdk path. This change allows the LegacySdkResolver to locate the sdk that matches the global.json pinned version.

Instead of seeing this during testing

```
                Loading project: /tmp/hy317v4y.d81/NetCore21Project/NetCore21Project.csproj
        [dbug]: OmniSharp.MSBuild.SdksPathResolver
                Set MSBuildSDKsPath environment variable to: /home/vsts/work/1/s/.dotnet/sdk/5.0.100/Sdks
```

You see this

```
                Loading project: /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/9h7u5eac.5fx/NetCore21Project/NetCore21Project.csproj
        [dbug]: OmniSharp.MSBuild.SdksPathResolver
                Set MSBuildSDKsPath environment variable to: /Users/runner/work/1/s/.dotnet/sdk/2.1.811/Sdks
```