### PR TITLE
Workaround Roslyn formatting bug

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Workers/Formatting/FormattingWorker.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Formatting/FormattingWorker.cs
@@ -36,7 +36,7 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Formatting
                 Debug.Assert(targetLine.Text != null);
                 if (!string.IsNullOrWhiteSpace(targetLine.Text!.ToString(targetLine.Span)))
                 {
-                    return await GetFormattingChanges(document, targetLine.Start, targetLine.End, omnisharpOptions, loggerFactory);
+                    return await GetFormattingChanges(document, targetLine.Start, targetLine.End, omnisharpOptions, loggerFactory, trimExtendingChanges: true);
                 }
             }
             else if (character == '}' || character == ';')
@@ -47,7 +47,7 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Formatting
                 var node = FindFormatTarget(root!, position);
                 if (node != null)
                 {
-                    return await GetFormattingChanges(document, node.FullSpan.Start, node.FullSpan.End, omnisharpOptions, loggerFactory);
+                    return await GetFormattingChanges(document, node.FullSpan.Start, node.FullSpan.End, omnisharpOptions, loggerFactory, trimExtendingChanges: false);
                 }
             }
 
@@ -91,10 +91,10 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Formatting
             return null;
         }
 
-        public static async Task<IEnumerable<LinePositionSpanTextChange>> GetFormattingChanges(Document document, int start, int end, OmniSharpOptions omnisharpOptions, ILoggerFactory loggerFactory)
+        public static async Task<IEnumerable<LinePositionSpanTextChange>> GetFormattingChanges(Document document, int start, int end, OmniSharpOptions omnisharpOptions, ILoggerFactory loggerFactory, bool trimExtendingChanges = false)
         {
             var newDocument = await FormatDocument(document, omnisharpOptions, loggerFactory, TextSpan.FromBounds(start, end));
-            return await TextChanges.GetAsync(newDocument, document);
+            return await TextChanges.GetAsync(newDocument, document, trimExtendingChanges ? end : (int?)null);
         }
 
         public static async Task<string> GetFormattedText(Document document, OmniSharpOptions omnisharpOptions, ILoggerFactory loggerFactory)

--- a/src/OmniSharp.Roslyn/Utilities/TextChangeHelper.cs
+++ b/src/OmniSharp.Roslyn/Utilities/TextChangeHelper.cs
@@ -48,13 +48,16 @@ namespace OmniSharp.Roslyn.Utilities
                             // becoming an extra blank line, we extend the span an addition 2 or 1 characters to replace
                             // that point.
                             int newLength = span.Length - (span.End - oEnd);
-                            if (newText.EndsWith("\r\n"))
+                            if (newText[newText.Length - 1] == '\n')
                             {
-                                newLength += 2;                                
-                            }
-                            else if (newText.EndsWith("\n"))
-                            {
-                                newLength += 1;
+                                // The new text ends with a newline. Check the original text to see what type of newline
+                                // it used at the end location and increase by that amount
+                                newLength += oldText[oEnd] switch
+                                {
+                                    '\r' => 2,
+                                    '\n' => 1,
+                                    _ => 0
+                                };
                             }
 
                             span = new TextSpan(span.Start, newLength);
@@ -93,7 +96,7 @@ namespace OmniSharp.Roslyn.Utilities
                         EndLine = linePositionSpan.End.Line,
                         EndColumn = linePositionSpan.End.Character
                     };
-                });
+                }).ToList();
         }
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormatAfterKeystrokeTests.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormatAfterKeystrokeTests.cs
@@ -364,6 +364,82 @@ $$
 }");
         }
 
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task LeadingSpacesNotRemovedOnNewline_ExtraWhitespaceOnPreviousLine(string fileName)
+        {
+            await VerifyChange(fileName, "\n",
+@"class C
+{
+    public void M()
+    {
+        // There is a space after the ; here
+        var i = 1; 
+        $$
+    }
+}",
+@"class C
+{
+    public void M()
+    {
+        // There is a space after the ; here
+        var i = 1;
+        
+    }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task LeadingSpacesNotRemovedOnNewline_FormattingChangesOnPreviousLine(string fileName)
+        {
+            await VerifyChange(fileName, "\n",
+@"class C
+{
+    public void M()
+    {
+        var i =1;
+        $$
+    }
+}",
+@"class C
+{
+    public void M()
+    {
+        var i = 1;
+        
+    }
+}");
+        }
+
+        [Theory]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task LeadingSpacesNotRemovedOnNewline_NewlinesWithSpaceAfter(string fileName)
+        {
+            await VerifyChange(fileName, "\n",
+@"class C
+{
+    public void M()
+    {
+        var i =1;
+        $$
+        
+    }
+}",
+@"class C
+{
+    public void M()
+    {
+        var i = 1;
+        
+        
+    }
+}");
+        }
+
         private async Task VerifyNoChange(string fileName, string typedCharacter, string originalMarkup)
         {
             var (response, _) = await GetResponse(originalMarkup, typedCharacter, fileName);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FormatAfterKeystrokeTests.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FormatAfterKeystrokeTests.cs
@@ -440,6 +440,30 @@ $$
 }");
         }
 
+        [Theory(Skip = "https://github.com/dotnet/roslyn/issues/50130")]
+        [InlineData("file.cs")]
+        [InlineData("file.csx")]
+        public async Task LeadingSpacesNotRemovedOnNewline_IncompleteDeclaration(string fileName)
+        {
+            await VerifyChange(fileName, "\n",
+@"class C
+{
+    public void M()
+    {
+        var i 
+        $$
+    }
+}",
+@"class C
+{
+    public void M()
+    {
+        var i
+        
+    }
+}");
+        }
+
         private async Task VerifyNoChange(string fileName, string typedCharacter, string originalMarkup)
         {
             var (response, _) = await GetResponse(originalMarkup, typedCharacter, fileName);


### PR DESCRIPTION
Due to https://github.com/dotnet/roslyn/issues/50129, `FormatAsync` will give us changes past the location that we wanted if there were changes to be made on the current line. This can lead to a frustrating typing experience now that we listen for `\n` in vscode to trigger formatting. I've implemented a simple workaround for this while the bug is fixed upstream.
