### PR TITLE
address nullability errors in DocumentationCommentSnippetService

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Reflection;
@@ -21,44 +21,47 @@ namespace OmniSharp.Roslyn.DocumentationComments
         /// <summary>
         /// IDocumentationCommentService HostLanguageServices.GetRequiredService<IDocumentationCommentService>()
         /// </summary>
-        private static MethodInfo s_getRequiredService;
+        private static readonly MethodInfo? s_getRequiredService;
         /// <summary>
         /// DocumentationCommentSnippet IDocumentationCommentService.GetDocumentationCommentSnippetOnCharacterTyped(SyntaxTree, SourceText, int, DocumentOptionSet, CancellationToken)
         /// </summary>
-        private static MethodInfo s_getDocumentationCommentSnippetOnCharacterTyped;
+        private static readonly MethodInfo? s_getDocumentationCommentSnippetOnCharacterTyped;
         /// <summary>
         /// DocumentationCommentSnippet IDocumentationCommentService.GetDocumentationCommentSnippetOnEnterTyped(SyntaxTree, SourceText, int, DocumentOptionSet, CancellationToken)
         /// </summary>
-        private static MethodInfo s_getDocumentationCommentSnippetOnEnterTyped;
+        private static readonly MethodInfo? s_getDocumentationCommentSnippetOnEnterTyped;
         /// <summary>
         /// TextSpan DocumentationCommentSnippet.SpanToReplace
         /// </summary>
-        private static PropertyInfo s_spanToReplace;
+        private static readonly PropertyInfo? s_spanToReplace;
         /// <summary>
         /// string DocumentationCommentSnippet.SnippetText
         /// </summary>
-        private static PropertyInfo s_snippetText;
+        private static readonly PropertyInfo? s_snippetText;
 
         static DocumentationCommentSnippetService()
         {
             var iDocumentationCommentSnippetServiceType = typeof(CompletionItem).Assembly.GetType("Microsoft.CodeAnalysis.DocumentationComments.IDocumentationCommentSnippetService");
-            s_getDocumentationCommentSnippetOnCharacterTyped = iDocumentationCommentSnippetServiceType.GetMethod(nameof(GetDocumentationCommentSnippetOnCharacterTyped));
-            s_getDocumentationCommentSnippetOnEnterTyped = iDocumentationCommentSnippetServiceType.GetMethod(nameof(GetDocumentationCommentSnippetOnEnterTyped));
+            s_getDocumentationCommentSnippetOnCharacterTyped = iDocumentationCommentSnippetServiceType?.GetMethod(nameof(GetDocumentationCommentSnippetOnCharacterTyped));
+            s_getDocumentationCommentSnippetOnEnterTyped = iDocumentationCommentSnippetServiceType?.GetMethod(nameof(GetDocumentationCommentSnippetOnEnterTyped));
 
             var documentationCommentSnippet = typeof(CompletionItem).Assembly.GetType("Microsoft.CodeAnalysis.DocumentationComments.DocumentationCommentSnippet");
-            s_spanToReplace = documentationCommentSnippet.GetProperty(nameof(DocumentationCommentSnippet.SpanToReplace));
-            s_snippetText = documentationCommentSnippet.GetProperty(nameof(DocumentationCommentSnippet.SnippetText));
+            s_spanToReplace = documentationCommentSnippet?.GetProperty(nameof(DocumentationCommentSnippet.SpanToReplace));
+            s_snippetText = documentationCommentSnippet?.GetProperty(nameof(DocumentationCommentSnippet.SnippetText));
 
-            s_getRequiredService = typeof(HostLanguageServices).GetMethod(nameof(HostLanguageServices.GetRequiredService)).MakeGenericMethod(iDocumentationCommentSnippetServiceType);
+            if (iDocumentationCommentSnippetServiceType is object)
+                s_getRequiredService = typeof(HostLanguageServices).GetMethod(nameof(HostLanguageServices.GetRequiredService))?.MakeGenericMethod(iDocumentationCommentSnippetServiceType);
         }
 
         public static DocumentationCommentSnippetService GetDocumentationCommentSnippetService(Document document)
         {
+            if (s_getRequiredService is null) throw new InvalidOperationException("Could not find GetRequiredService<IDocumentationCommentService> factory.");
             var service = s_getRequiredService.Invoke(document.Project.LanguageServices, Array.Empty<object>());
+            if (service is null) throw new InvalidOperationException("Could not retrieve an implementation of IDocumentationCommentService.");
             return new DocumentationCommentSnippetService(service);
         }
 
-        private object _underlying;
+        private readonly object _underlying;
 
         private DocumentationCommentSnippetService(object underlying)
         {
@@ -67,25 +70,28 @@ namespace OmniSharp.Roslyn.DocumentationComments
 
         public DocumentationCommentSnippet? GetDocumentationCommentSnippetOnCharacterTyped(SyntaxTree syntaxTree, SourceText text, int position, DocumentOptionSet options, CancellationToken cancellationToken)
         {
+            if (s_getDocumentationCommentSnippetOnCharacterTyped is null) throw new InvalidOperationException("Could not find IDocumentationCommentService.GetDocumentationCommentSnippetOnCharacterTyped(SyntaxTree, SourceText, int, DocumentOptionSet, CancellationToken).");
             var originalSnippet = s_getDocumentationCommentSnippetOnCharacterTyped.Invoke(_underlying, new object[] { syntaxTree, text, position, options, cancellationToken });
             return ConvertSnippet(originalSnippet);
         }
 
         public DocumentationCommentSnippet? GetDocumentationCommentSnippetOnEnterTyped(SyntaxTree syntaxTree, SourceText text, int position, DocumentOptionSet options, CancellationToken cancellationToken)
         {
+            if (s_getDocumentationCommentSnippetOnEnterTyped is null) throw new InvalidOperationException("Could not find IDocumentationCommentService.GetDocumentationCommentSnippetOnEnterTyped(SyntaxTree, SourceText, int, DocumentOptionSet, CancellationToken).");
             var originalSnippet = s_getDocumentationCommentSnippetOnEnterTyped.Invoke(_underlying, new object[] { syntaxTree, text, position, options, cancellationToken });
             return ConvertSnippet(originalSnippet);
         }
 
         private static DocumentationCommentSnippet? ConvertSnippet(object? originalSnippet)
         {
-            if (originalSnippet == null)
+            switch (originalSnippet)
             {
-                return null;
-            }
-            else
-            {
-                return new DocumentationCommentSnippet((TextSpan)s_spanToReplace.GetValue(originalSnippet), (string)s_snippetText.GetValue(originalSnippet));
+                case null:
+                    return null;
+                default:
+                    if (s_spanToReplace is null) throw new InvalidOperationException("Could not find DocumentationCommentSnippet.SpanToReplace.");
+                    if (s_snippetText is null) throw new InvalidOperationException("Could not find DocumentationCommentSnippet.SnippetText.");
+                    return new DocumentationCommentSnippet((TextSpan)s_spanToReplace.GetValue(originalSnippet)!, (string)s_snippetText.GetValue(originalSnippet)!);
             }
         }
     }

--- a/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Text;
 namespace OmniSharp.Roslyn.DocumentationComments
 {
     /// <summary>
-    /// Proxy service for Microsoft.CodeAnalysis.DocumentationComments.IDocumentationCommentSnippetService.
+    /// Proxy service for Microsoft.CodeAnalysis.DocumentationComments.IDocumentationCommentSnippetService. 
     /// Implementation was based on the service as of this commit: 2834b74995bb66a7cb19cb09069c17812819afdc
     /// See: https://github.com/dotnet/roslyn/blob/2834b74995bb66a7cb19cb09069c17812819afdc/src/Features/Core/Portable/DocumentationComments/IDocumentationCommentSnippetService.cs
     /// </summary>


### PR DESCRIPTION
currently the compiler reports 15 errors

```
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(45,64): error CS8602: Dereferenzierung eines möglichen Nullverweises. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(45,64): error CS8601: Mögliche Nullverweiszuweisung. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(46,60): error CS8601: Mögliche Nullverweiszuweisung. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(49,31): error CS8602: Dereferenzierung eines möglichen Nullverweises. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(49,31): error CS8601: Mögliche Nullverweiszuweisung. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(50,29): error CS8601: Mögliche Nullverweiszuweisung. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(52,36): error CS8602: Dereferenzierung eines möglichen Nullverweises. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(42,16): error CS8618: Non-Nullable-Feld "s_getDocumentationCommentSnippetOnCharacterTyped" muss beim Beenden des Konstruktors einen Wert ungleich NULL enthalten. Erwägen Sie eine Deklaration von "Feld" als Nullable. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(42,16): error CS8618: Non-Nullable-Feld "s_getDocumentationCommentSnippetOnEnterTyped" muss beim Beenden des Konstruktors einen Wert ungleich NULL enthalten. Erwägen Sie eine Deklaration von "Feld" als Nullable. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(42,16): error CS8618: Non-Nullable-Feld "s_spanToReplace" muss beim Beenden des Konstruktors einen Wert ungleich NULL enthalten. Erwägen Sie eine Deklaration von "Feld" als Nullable. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(42,16): error CS8618: Non-Nullable-Feld "s_snippetText" muss beim Beenden des Konstruktors einen Wert ungleich NULL enthalten. Erwägen Sie eine Deklaration von "Feld" als Nullable. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(58,59): error CS8604: Mögliches Nullverweisargument für den Parameter "underlying" in "DocumentationCommentSnippetService.DocumentationCommentSnippetService(object underlying)". [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(88,56): error CS8605: Unboxing eines möglichen NULL-Werts. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(88,109): error CS8600: Das NULL-Literal oder ein möglicher NULL-Wert wird in einen Non-Nullable-Typ konvertiert. [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/DocumentationComments/DocumentationCommentSnippetService.cs(88,109): error CS8604: Mögliches Nullverweisargument für den Parameter "snippetText" in "DocumentationCommentSnippet.DocumentationCommentSnippet(TextSpan spanToReplace, string snippetText)". [/Users/filipw/dev/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/OmniSharp.Roslyn.CSharp.csproj]
```