### PR TITLE
Remove format on newline

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Workers/Formatting/FormattingWorker.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Formatting/FormattingWorker.cs
@@ -27,19 +27,7 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Formatting
                 return new[] { change };
             }
 
-            if (character == '\n')
-            {
-                // format previous line on new line
-                var text = await document.GetTextAsync();
-                var lines = text.Lines;
-                var targetLine = lines[lines.GetLineFromPosition(position).LineNumber - 1];
-                Debug.Assert(targetLine.Text != null);
-                if (!string.IsNullOrWhiteSpace(targetLine.Text!.ToString(targetLine.Span)))
-                {
-                    return await GetFormattingChanges(document, targetLine.Start, targetLine.End, omnisharpOptions, loggerFactory);
-                }
-            }
-            else if (character == '}' || character == ';')
+            if (character == '}' || character == ';')
             {
                 // format after ; and }
                 var root = await document.GetSyntaxRootAsync();


### PR DESCRIPTION
Roslyn APIs were not intended to handle this case and doing so can cause very odd behavior, such as extraneous newlines being added for malformed code and/or automatic indentation being removed, making for a frustrating experience. Superscedes https://github.com/OmniSharp/omnisharp-roslyn/pull/2051.