### PR TITLE
validation for highlighting range

### DIFF
--- a/src/OmniSharp.Abstractions/Models/v2/Range.cs
+++ b/src/OmniSharp.Abstractions/Models/v2/Range.cs
@@ -28,6 +28,8 @@ namespace OmniSharp.Models.V2
             return true;
         }
 
+        public bool IsValid() => Start != null && Start.Line > -1 && Start.Column > -1 && End != null && End.Line > -1 && End.Column > -1;
+
         public override bool Equals(object obj)
             => Equals(obj as Range);
 

--- a/src/OmniSharp.Roslyn.CSharp/Services/SemanticHighlight/SemanticHighlightService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/SemanticHighlight/SemanticHighlightService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Mef;
 using OmniSharp.Models.SemanticHighlight;
 
@@ -13,10 +14,14 @@ namespace OmniSharp.Roslyn.CSharp.Services.SemanticHighlight
     [OmniSharpHandler(OmniSharpEndpoints.V2.Highlight, LanguageNames.CSharp)]
     public class SemanticHighlightService : IRequestHandler<SemanticHighlightRequest, SemanticHighlightResponse>
     {
+        private readonly OmniSharpWorkspace _workspace;
+        private readonly ILogger<SemanticHighlightService> _logger;
+
         [ImportingConstructor]
-        public SemanticHighlightService(OmniSharpWorkspace workspace)
+        public SemanticHighlightService(OmniSharpWorkspace workspace, ILoggerFactory loggerFactory)
         {
             _workspace = workspace;
+            _logger = loggerFactory.CreateLogger<SemanticHighlightService>();
         }
 
         public async Task<SemanticHighlightResponse> Handle(SemanticHighlightRequest request)
@@ -33,9 +38,17 @@ namespace OmniSharp.Roslyn.CSharp.Services.SemanticHighlight
                 TextSpan textSpan;
                 if (request.Range is object)
                 {
-                    var start = text.Lines.GetPosition(new LinePosition(request.Range.Start.Line, request.Range.Start.Column));
-                    var end = text.Lines.GetPosition(new LinePosition(request.Range.End.Line, request.Range.End.Column));
-                    textSpan = new TextSpan(start, end - start);
+                    if (request.Range.IsValid())
+                    {
+                        var start = text.Lines.GetPosition(new LinePosition(request.Range.Start.Line, request.Range.Start.Column));
+                        var end = text.Lines.GetPosition(new LinePosition(request.Range.End.Line, request.Range.End.Column));
+                        textSpan = new TextSpan(start, end - start);
+                    }
+                    else
+                    {
+                        _logger.LogWarning($"Supplied highlight range {request.Range} in document {document.FilePath} is not valid.");
+                        continue;
+                    }
                 }
                 else
                 {
@@ -162,7 +175,5 @@ namespace OmniSharp.Roslyn.CSharp.Services.SemanticHighlight
             {
                 [ClassificationTypeNames.StaticSymbol] = SemanticHighlightModifier.Static,
             };
-
-        private readonly OmniSharpWorkspace _workspace;
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SemanticHighlightFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SemanticHighlightFacts.cs
@@ -20,6 +20,22 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         protected override string EndpointName => OmniSharpEndpoints.V2.Highlight;
 
         [Fact]
+        public async Task InvalidPositionDoesNotThrow()
+        {
+            var testFile = new TestFile("a.cs", @"
+namespace N1
+{
+    class C1 { int n = true; }
+}
+");
+
+            var line = -1;
+            var highlights = await GetSemanticHighlightsForLineAsync(testFile, line);
+
+            Assert.Empty(highlights);
+        }
+
+        [Fact]
         public async Task SemanticHighlightSingleLine()
         {
             var testFile = new TestFile("a.cs", @"


### PR DESCRIPTION
When the client submits negative range we hit an argument exception in Roslyn (https://github.com/OmniSharp/omnisharp-vscode/issues/4317).
This is not an optimal experience. 

This PR adds basic validation for the range. The linked VS Code bug should be separately investigated but a validation on the server is needed regardless - similarly to what we do in other endpoints.
