### PR TITLE
delay project system init to avoid solution update race

### DIFF
--- a/src/OmniSharp.Host/WorkspaceInitializer.cs
+++ b/src/OmniSharp.Host/WorkspaceInitializer.cs
@@ -27,11 +27,22 @@ namespace OmniSharp
 
             var projectEventForwarder = compositionHost.GetExport<ProjectEventForwarder>();
             projectEventForwarder.Initialize();
-            var projectSystems = compositionHost.GetExports<IProjectSystem>();
 
             workspace.EditorConfigEnabled = options.CurrentValue.FormattingOptions.EnableEditorConfigSupport;
             options.OnChange(x => workspace.EditorConfigEnabled = x.FormattingOptions.EnableEditorConfigSupport);
 
+            logger.LogDebug("Starting with OmniSharp options: {options}", options.CurrentValue);
+            ProvideWorkspaceOptions(compositionHost, workspace, options, logger, omnisharpEnvironment);
+
+            // when configuration options change
+            // run workspace options providers automatically
+            options.OnChange(o =>
+            {
+                logger.LogDebug("OmniSharp options changed: {options}", options.CurrentValue);
+                ProvideWorkspaceOptions(compositionHost, workspace, options, logger, omnisharpEnvironment);
+            });
+
+            var projectSystems = compositionHost.GetExports<IProjectSystem>();
             foreach (var projectSystem in projectSystems)
             {
                 try
@@ -55,19 +66,8 @@ namespace OmniSharp
                 }
             }
 
-            logger.LogDebug("Starting with OmniSharp options: {options}", options.CurrentValue);
-            ProvideWorkspaceOptions(compositionHost, workspace, options, logger, omnisharpEnvironment);
-
             // Mark the workspace as initialized
             workspace.Initialized = true;
-
-            // when configuration options change
-            // run workspace options providers automatically
-            options.OnChange(o =>
-            {
-                logger.LogDebug("OmniSharp options changed: {options}", options.CurrentValue);
-                ProvideWorkspaceOptions(compositionHost, workspace, options, logger, omnisharpEnvironment);
-            });
 
             logger.LogInformation("Configuration finished.");
         }


### PR DESCRIPTION
I've been getting this error intermittently:

https://github.com/OmniSharp/omnisharp-roslyn/blob/8f3b6ea9915c4e692ca324a1e2e58e394a6cac75/src/OmniSharp.MSBuild/ProjectManager.cs#L375

I tracked it down to a race between `TryApplyChanges` calls.

Adding the project happens on a worker thread, and is queued on the main thread inside:

https://github.com/OmniSharp/omnisharp-roslyn/blob/8f3b6ea9915c4e692ca324a1e2e58e394a6cac75/src/OmniSharp.Host/WorkspaceInitializer.cs#L43

I believe `AddProject` can be called on a worker thread any time after this.

The other call is on the main thread via:

https://github.com/OmniSharp/omnisharp-roslyn/blob/8f3b6ea9915c4e692ca324a1e2e58e394a6cac75/src/OmniSharp.Host/WorkspaceInitializer.cs#L59

https://github.com/OmniSharp/omnisharp-roslyn/blob/8f3b6ea9915c4e692ca324a1e2e58e394a6cac75/src/OmniSharp.Host/WorkspaceInitializer.cs#L91

This change rearranges workspace init to avoid this particular race.  It doesn't seem like anything attempts to retry solution changes, so if there are other races it may be a more serious problem.