### PR TITLE
fix exception with null sdk version

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectLoadListener.cs
+++ b/src/OmniSharp.MSBuild/ProjectLoadListener.cs
@@ -87,7 +87,7 @@ namespace OmniSharp.MSBuild
 
         private static HashedString GetSdkVersion(ProjectLoadedEventArgs args)
         {
-            return _tfmAndFileHashingAlgorithm.HashInput(args.SdkVersion.ToString());
+            return _tfmAndFileHashingAlgorithm.HashInput($"{args.SdkVersion}");
         }
 
         private static HashedString GetSessionId(ProjectLoadedEventArgs args)


### PR DESCRIPTION
I've been getting errors like:

`{"Event":"log","Body":{"LogLevel":"ERROR","Name":"OmniSharp.MSBuild.ProjectLoadListener","Message":"Unexpected exception got thrown from project load listener: System.NullReferenceException: Object reference not set to an instance of an object\n  at OmniSharp.MSBuild.ProjectLoadListener.GetSdkVersion (OmniSharp.MSBuild.Notification.ProjectLoadedEventArgs args) [0x0000b] in <7e6cb753aca94549b693616e0e7d1016>:0 \n  at OmniSharp.MSBuild.ProjectLoadListener.ProjectLoaded (OmniSharp.MSBuild.Notification.ProjectLoadedEventArgs args) [0x0001a] in <7e6cb753aca94549b693616e0e7d1016>:0 "},"Seq":137,"Type":"event"}`

This happens when `dotnet` isn't available in PATH.  Omnisharp runs `dotnet --info` and if it fails, `SdkVersion` ends up null.

My change is a bit hacky.  Perhaps it would be better to propagate the null through to `ProjectConfigurationMessage.SdkVersion`?  That seems to be the only place it's used, but it might be a breaking protocol change.