### PR TITLE
use "variable" kind for parameter completion

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
@@ -63,7 +63,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             { WellKnownTags.Method, CompletionItemKind.Method },
             { WellKnownTags.Module, CompletionItemKind.Module },
             { WellKnownTags.Operator, CompletionItemKind.Operator },
-            { WellKnownTags.Parameter, CompletionItemKind.Value },
+            { WellKnownTags.Parameter, CompletionItemKind.Variable },
             { WellKnownTags.Property, CompletionItemKind.Property },
             { WellKnownTags.RangeVariable, CompletionItemKind.Variable },
             { WellKnownTags.Reference, CompletionItemKind.Reference },

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
@@ -69,6 +69,25 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         [Theory]
         [InlineData("dummy.cs")]
         [InlineData("dummy.csx")]
+        public async Task ParameterCompletion(string filename)
+        {
+            const string input =
+                @"public class Class1 {
+                    public Class1(string foo)
+                        {
+                            foo$$
+                        }
+                    }";
+
+            var completions = await FindCompletionsAsync(filename, input, SharedOmniSharpTestHost);
+            Assert.Contains("foo", completions.Items.Select(c => c.Label));
+            Assert.Contains("foo", completions.Items.Select(c => c.TextEdit.NewText));
+            Assert.Equal(CompletionItemKind.Variable, completions.Items.First(c => c.TextEdit.NewText == "foo").Kind);
+        }
+
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
         public async Task DocumentationIsResolved(string filename)
         {
             const string input =


### PR DESCRIPTION
We used to do it this way until the switch to CompletionService. This PR restores the old mapping of parameter to variable.

Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/2060
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/4314 