### PR TITLE
log request when response fails

### DIFF
--- a/src/OmniSharp.Stdio/Host.cs
+++ b/src/OmniSharp.Stdio/Host.cs
@@ -198,7 +198,7 @@ namespace OmniSharp.Stdio
             var request = RequestPacket.Parse(json);
             if (logger.IsEnabled(LogLevel.Debug))
             {
-                LogRequest(json, logger);
+                LogRequest(json, logger, LogLevel.Debug);
             }
 
             var response = request.Reply();
@@ -236,6 +236,13 @@ namespace OmniSharp.Stdio
                 // or when we have unsuccessful response (exception)
                 if (logger.IsEnabled(LogLevel.Debug) || !response.Success)
                 {
+                    // if logging is at Debug level, request would have already been logged
+                    // however not for higher log levels, so we want to explicitly log the request too
+                    if (!logger.IsEnabled(LogLevel.Debug))
+                    {
+                        LogRequest(json, logger, LogLevel.Warning);
+                    }
+
                     LogResponse(response.ToString(), logger, response.Success);
                 }
 
@@ -244,14 +251,14 @@ namespace OmniSharp.Stdio
             }
         }
 
-        void LogRequest(string json, ILogger logger)
+        void LogRequest(string json, ILogger logger, LogLevel logLevel)
         {
             var builder = _cachedStringBuilder.Acquire();
             try
             {
                 builder.AppendLine("************ Request ************");
                 builder.Append(JToken.Parse(json).ToString(Formatting.Indented));
-                logger.LogDebug(builder.ToString());
+                logger.Log(logLevel, builder.ToString());
             }
             finally
             {


### PR DESCRIPTION
In https://github.com/OmniSharp/omnisharp-roslyn/pull/1963 we added a change that always logged responses at error level when an exception occurred. 

This PR extends this further, and in case of exceptions, when the server is running at log level higher than Debug, additionally logs corresponding request with Warning too.

This will improve the "out of the box" troubleshooting experience.