### PR TITLE
changed the default RunFixAllRequest timeout to 10 seconds

### DIFF
--- a/src/OmniSharp.Abstractions/Models/v1/FixAll/RunFixAllRequest.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/FixAll/RunFixAllRequest.cs
@@ -10,7 +10,7 @@ namespace OmniSharp.Abstractions.Models.V1.FixAll
 
         // If this is null -> filter not set -> try to fix all issues in current defined scope.
         public FixAllItem[] FixAllFilter { get; set; }
-        public int Timeout { get; set; } = 3000;
+        public int Timeout { get; set; } = 10000;
         public bool WantsAllCodeActionOperations { get; set; }
         public bool WantsTextChanges { get; set; }
         // Nullable for backcompat: null == true, for requests that don't set it


### PR DESCRIPTION
This is now equal to the go to metadata timeout which is also 10 seconds. Three seconds is too short especially for solution wide fixes.

That said, it would be good for editors to have their own setting.