### PR TITLE
use an OmniSharp specific message for MSB3644

### DIFF
--- a/src/OmniSharp.MSBuild/Logging/ErrorMessages.cs
+++ b/src/OmniSharp.MSBuild/Logging/ErrorMessages.cs
@@ -2,6 +2,6 @@ namespace OmniSharp.MSBuild.Logging
 {
     internal class ErrorMessages
     {
-        internal static string ReferenceAssembliesNotFoundUnix = "This project targets .NET version that requires reference assemblies that do not ship with OmniSharp out of the box (e.g. .NET Framework). The most common solution is to make sure Mono is installed on your machine (https://mono-project.com/download/) and that OmniSharp is started with that Mono installation (e.g. 'omnisharp.useGlobalMono':'always' in C# Extension for VS Code).";
+        internal const string ReferenceAssembliesNotFoundUnix = "This project targets .NET version that requires reference assemblies that do not ship with OmniSharp out of the box (e.g. .NET Framework). The most common solution is to make sure Mono is installed on your machine (https://mono-project.com/download/) and that OmniSharp is started with that Mono installation (e.g. 'omnisharp.useGlobalMono':'always' in C# Extension for VS Code).";
     }
 }

--- a/src/OmniSharp.MSBuild/Logging/ErrorMessages.cs
+++ b/src/OmniSharp.MSBuild/Logging/ErrorMessages.cs
@@ -1,0 +1,7 @@
+namespace OmniSharp.MSBuild.Logging
+{
+    internal class ErrorMessages
+    {
+        internal static string ReferenceAssembliesNotFoundUnix = "This project targets .NET version that requires reference assemblies that do not ship with OmniSharp out of the box (e.g. .NET Framework). The most common solution is to make sure Mono is installed on your machine (https://mono-project.com/download/) and that OmniSharp is started with that Mono installation (e.g. 'omnisharp.useGlobalMono':'always' in C# Extension for VS Code).";
+    }
+}

--- a/src/OmniSharp.MSBuild/Logging/MSBuildLogger.cs
+++ b/src/OmniSharp.MSBuild/Logging/MSBuildLogger.cs
@@ -26,8 +26,9 @@ namespace OmniSharp.MSBuild.Logging
 
         private void OnError(object sender, Microsoft.Build.Framework.BuildErrorEventArgs args)
         {
-            _logger.LogError(args.Message);
-            _diagnostics.Add(MSBuildDiagnostic.CreateFrom(args));
+            var msBuildDiagnostic = MSBuildDiagnostic.CreateFrom(args);
+            _logger.LogError(msBuildDiagnostic.Message);
+            _diagnostics.Add(msBuildDiagnostic);
         }
 
         private void OnWarning(object sender, Microsoft.Build.Framework.BuildWarningEventArgs args)

--- a/tests/OmniSharp.MSBuild.Tests/MSBuildDiagnosticTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/MSBuildDiagnosticTests.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Build.Framework;
+using OmniSharp.MSBuild.Logging;
+using OmniSharp.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OmniSharp.MSBuild.Tests
+{
+    public class MSBuildDiagnosticTests : AbstractMSBuildTestFixture
+    {
+        public MSBuildDiagnosticTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void MSB3644_CustomMessage()
+        {
+            var sourceDiagnostic = new BuildErrorEventArgs("test-subcategory", "MSB3644", "foo.cs", 1, 1, 1, 1, "Reference assemblies not found!", "help-keyword", "dummy-sender");
+            var msbuildDiagnostic = MSBuildDiagnostic.CreateFrom(sourceDiagnostic);
+
+            Assert.Equal(Platform.Current.OperatingSystem != OperatingSystem.Windows
+                ? ErrorMessages.ReferenceAssembliesNotFoundUnix : sourceDiagnostic.Message, msbuildDiagnostic.Message);
+        }
+    }
+}

--- a/tests/OmniSharp.MSBuild.Tests/OmniSharp.MSBuild.Tests.csproj
+++ b/tests/OmniSharp.MSBuild.Tests/OmniSharp.MSBuild.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OmniSharp.MSBuild\OmniSharp.MSBuild.csproj" />
+    <ProjectReference Include="..\..\src\OmniSharp.Shared\OmniSharp.Shared.csproj" />
     <ProjectReference Include="..\TestUtility\TestUtility.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/2029 

Instead of printing the default MSBuild message for MSB3644 which is Windows specific and has been very confusing to the users:

> The reference assemblies for {0} were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks

we now change it into a more relevant OmniSharp message on Unix:

> This project targets .NET version that requires reference assemblies that do not ship with OmniSharp out of the box (e.g. .NET Framework). The most common solution is to make sure Mono is installed on your machine (https://mono-project.com/download/) and that OmniSharp is started with that Mono installation (e.g. 'omnisharp.useGlobalMono':'always' in C# Extension for VS Code).

