### PR TITLE
LSP and Completion tweaks

### DIFF
--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpCodeActionHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpCodeActionHandler.cs
@@ -87,7 +87,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
             foreach (var ca in omnisharpResponse.CodeActions)
             {
                 CodeActionKind kind;
-                if (ca.Identifier.StartsWith("using ")) { kind = CodeActionKind.SourceOrganizeImports; }
+                if (ca.Identifier.StartsWith("using ")) { kind = CodeActionKind.QuickFix; }
                 else if (ca.Identifier.StartsWith("Inline ")) { kind = CodeActionKind.RefactorInline; }
                 else if (ca.Identifier.StartsWith("Extract ")) { kind = CodeActionKind.RefactorExtract; }
                 else if (ca.Identifier.StartsWith("Change ")) { kind = CodeActionKind.QuickFix; }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
@@ -132,7 +132,13 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
                 return new CompletionResponse { Items = ImmutableArray<CompletionItem>.Empty };
             }
 
-            if (request.TriggerCharacter == ' ' && !completions.Items.Any(c => c.IsObjectCreationCompletionItem()))
+            if (request.TriggerCharacter == ' ' && !completions.Items.Any(c =>
+            {
+                var providerName = c.GetProviderName();
+                return providerName == CompletionItemExtensions.OverrideCompletionProvider ||
+                       providerName == CompletionItemExtensions.PartialMethodCompletionProvider ||
+                       providerName == CompletionItemExtensions.ObjectCreationCompletionProvider;
+            }))
             {
                 // Only trigger on space if there is an object creation completion
                 return new CompletionResponse { Items = ImmutableArray<CompletionItem>.Empty };

--- a/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Intellisense/CompletionItemExtensions.cs
@@ -18,7 +18,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Intellisense
     {
         private const string GetSymbolsAsync = nameof(GetSymbolsAsync);
         private const string InsertionText = nameof(InsertionText);
-        private const string ObjectCreationCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.ObjectCreationCompletionProvider";
+        internal const string ObjectCreationCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.ObjectCreationCompletionProvider";
         private const string NamedParameterCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.NamedParameterCompletionProvider";
         internal const string OverrideCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.OverrideCompletionProvider";
         internal const string PartialMethodCompletionProvider = "Microsoft.CodeAnalysis.CSharp.Completion.Providers.PartialMethodCompletionProvider";


### PR DESCRIPTION
This is a couple of small tweaks to resolve LSP and completion behavior:

1. We don't resolve partial and override completion on ` ` after an `override`, which is a behavior gap from VS.
2. Making the add using code action `SourceOrganizeImports` triggers special behavior and filtering in vscode, which is undesirable. Instead, just categorize it as a quickfix.