### PR TITLE
Do not call FindReferencesAsync for null symbol

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindUsagesService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindUsagesService.cs
@@ -35,6 +35,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
             var document = await _workspace.GetDocumentFromFullProjectModelAsync(request.FileName);
             if (document == null)
             {
+                _logger.LogWarning($"No document found. File: {request.FileName}.");
                 return new QuickFixResponse();
             }
 

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindUsagesService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindUsagesService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -6,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Helpers;
 using OmniSharp.Mef;
 using OmniSharp.Models;
@@ -17,11 +19,14 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
     public class FindUsagesService : IRequestHandler<FindUsagesRequest, QuickFixResponse>
     {
         private readonly OmniSharpWorkspace _workspace;
+        private readonly ILogger<FindUsagesService> _logger;
 
         [ImportingConstructor]
-        public FindUsagesService(OmniSharpWorkspace workspace)
+        public FindUsagesService(OmniSharpWorkspace workspace, ILoggerFactory loggerFactory)
         {
             _workspace = workspace;
+            _logger = loggerFactory.CreateLogger<FindUsagesService>();
+
         }
 
         public async Task<QuickFixResponse> Handle(FindUsagesRequest request)
@@ -37,6 +42,12 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
             var sourceText = await document.GetTextAsync();
             var position = sourceText.Lines.GetPosition(new LinePosition(request.Line, request.Column));
             var symbol = await SymbolFinder.FindSymbolAtPositionAsync(semanticModel, position, _workspace);
+            if (symbol is null)
+            {
+                _logger.LogWarning($"No symbol found. File: {request.FileName}, Line: {request.Line}, Column: {request.Column}.");
+                return new QuickFixResponse();
+            }
+
             var definition = await SymbolFinder.FindSourceDefinitionAsync(symbol, _workspace.CurrentSolution);
             var usages = request.OnlyThisFile
                 ? await SymbolFinder.FindReferencesAsync(definition ?? symbol, _workspace.CurrentSolution, ImmutableHashSet.Create(document))
@@ -60,6 +71,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                                             .OrderBy(q => q.FileName)
                                             .ThenBy(q => q.Line)
                                             .ThenBy(q => q.Column));
+
         }
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindReferencesFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindReferencesFacts.cs
@@ -19,6 +19,12 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
         protected override string EndpointName => OmniSharpEndpoints.FindUsages;
 
+        // [Fact]
+        // public void Foo(string event) 
+        // {
+
+        // }
+
         [Fact]
         public async Task CanFindReferencesOfLocalVariable()
         {
@@ -51,6 +57,28 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
             var usages = await FindUsagesAsync(code);
             Assert.Equal(2, usages.QuickFixes.Count());
+        }
+
+        [Fact]
+        public async Task DoesNotCrashOnInvalidReference()
+        {
+            const string code = @"
+                public class Foo
+                {
+                    public Foo(string $$event)
+                    {
+                        var prop = event + 'abc';
+                    }
+                }";
+
+            
+            var exception = await Record.ExceptionAsync(async () => 
+            {
+                var usages = await FindUsagesAsync(code);
+                Assert.Empty(usages.QuickFixes);
+            });
+            
+            Assert.Null(exception);
         }
 
         [Fact]

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/FindReferencesFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/FindReferencesFacts.cs
@@ -19,12 +19,6 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 
         protected override string EndpointName => OmniSharpEndpoints.FindUsages;
 
-        // [Fact]
-        // public void Foo(string event) 
-        // {
-
-        // }
-
         [Fact]
         public async Task CanFindReferencesOfLocalVariable()
         {


### PR DESCRIPTION
At the moment, on finding references, when the requested symbol is null, we still call Roslyn reference finder API which then results in an ugly unhandled exception.

```
System.InvalidOperationException: Unexpected null\r\n at Roslyn.Utilities.Contract.Fail(String message)\r\n at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.MapToAppropriateSymbol(ISymbol symbol)\r\n at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.d__20.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.d__19.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.d__8.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.d__8.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.d__8.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n at Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.d__34.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n at Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.d__37.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n at OmniSharp.Roslyn.CSharp.Services.Navigation.FindUsagesService.d__2.MoveNext() in D:\\a\\1\\s\\src\\OmniSharp.Roslyn.CSharp\\Services\\Navigation\\FindUsagesService.cs:line 41
```

This happens automatically when the member is invalid and in VS Code shows up in a horrible way:

<img width="223" alt="Bildschirmfoto 2021-02-11 um 09 26 24" src="https://user-images.githubusercontent.com/1710369/107788932-4148ca00-6d51-11eb-89c1-fb91734fc333.png">

This also happens when you click anywhere in the code on a non-symbol e.g. the "public" keyword and try to use "find references"

Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/4382
Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/2054
