### PR TITLE
Updated to latest lsp version.  

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -136,7 +136,7 @@ Task("CleanUpMonoAssets")
     .WithCriteria(() => !Platform.Current.IsWindows)
     .Does(() =>
 {
-    if (DirectoryHelper.Exists(env.Folders.Mono)) 
+    if (DirectoryHelper.Exists(env.Folders.Mono))
     {
         DirectoryHelper.Delete(env.Folders.Mono, recursive: true);
     }
@@ -146,7 +146,7 @@ Task("InstallMonoAssets")
     .WithCriteria(() => !Platform.Current.IsWindows)
     .Does(() =>
 {
-    if (DirectoryHelper.Exists(env.Folders.Mono)) 
+    if (DirectoryHelper.Exists(env.Folders.Mono))
     {
         Information("Skipping Mono assets installation, because they already exist.");
         return;
@@ -935,11 +935,11 @@ Task("Install")
         }
 
         var outputFolder = PathHelper.GetFullPath(CombinePaths(env.Folders.ArtifactsPublish, project, platform));
-        var targetFolder = PathHelper.GetFullPath(CombinePaths(installFolder));
+        var targetFolder = PathHelper.GetFullPath(CombinePaths(installFolder, project));
 
         DirectoryHelper.Copy(outputFolder, targetFolder);
 
-        CreateRunScript(project, installFolder, env.Folders.ArtifactsScripts);
+        CreateRunScript(project, CombinePaths(installFolder, project), env.Folders.ArtifactsScripts);
 
         Information($"OmniSharp is installed locally at {installFolder}");
     }

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -1,87 +1,86 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0"
-    xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-    <MSBuildPackageVersion>16.8.0</MSBuildPackageVersion>
-    <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
-    <RoslynPackageVersion>3.9.0-2.20570.24</RoslynPackageVersion>
-    <XunitPackageVersion>2.4.1</XunitPackageVersion>
-  </PropertyGroup>
+    <PropertyGroup>
+        <MSBuildPackageVersion>16.8.0</MSBuildPackageVersion>
+        <NuGetPackageVersion>5.2.0</NuGetPackageVersion>
+        <RoslynPackageVersion>3.9.0-2.20570.24</RoslynPackageVersion>
+        <XunitPackageVersion>2.4.1</XunitPackageVersion>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Cake.Scripting.Transport" Version="0.3.0" />
+    <ItemGroup>
+        <PackageReference Update="Cake.Scripting.Transport" Version="0.3.0" />
 
-    <PackageReference Update="Dotnet.Script.DependencyModel" Version="1.0.2" />
-    <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="1.0.1" />
-    <PackageReference Update="ICSharpCode.Decompiler" Version="6.1.0.5902" />
-    <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
+        <PackageReference Update="Dotnet.Script.DependencyModel" Version="1.0.2" />
+        <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="1.0.1" />
+        <PackageReference Update="ICSharpCode.Decompiler" Version="6.1.0.5902" />
+        <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
 
-    <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
-    <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-    <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="2.1.1" />
-    <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
+        <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
+        <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+        <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="2.1.1" />
+        <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
 
-    <PackageReference Update="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
-    <PackageReference Update="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
-    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageVersion)" />
-    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
 
-    <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
 
-    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.1" />
-    <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
+        <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="3.1.12" />
+        <PackageReference Update="Microsoft.Extensions.Configuration" Version="3.1.12" />
+        <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="3.1.12" />
+        <PackageReference Update="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.12" />
+        <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.12" />
+        <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="3.1.12" />
+        <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="3.1.12" />
+        <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
+        <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="3.1.12" />
+        <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.12" />
+        <PackageReference Update="Microsoft.Extensions.Logging" Version="3.1.12" />
+        <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="3.1.12" />
+        <PackageReference Update="Microsoft.Extensions.Options" Version="3.1.12" />
+        <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.12" />
 
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Update="Microsoft.TestPlatform.TranslationLayer" Version="16.6.1" />
-    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.14.114" />
-    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.12" />
+        <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Update="Microsoft.TestPlatform.TranslationLayer" Version="16.6.1" />
+        <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.14.114" />
+        <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.12" />
 
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+        <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
 
-    <PackageReference Update="NuGet.Packaging" Version="$(NuGetPackageVersion)" />
-    <PackageReference Update="NuGet.Packaging.Core" Version="$(NuGetPackageVersion)" />
-    <PackageReference Update="NuGet.ProjectModel" Version="$(NuGetPackageVersion)" />
-    <PackageReference Update="NuGet.Versioning" Version="$(NuGetPackageVersion)" />
+        <PackageReference Update="NuGet.Packaging" Version="$(NuGetPackageVersion)" />
+        <PackageReference Update="NuGet.Packaging.Core" Version="$(NuGetPackageVersion)" />
+        <PackageReference Update="NuGet.ProjectModel" Version="$(NuGetPackageVersion)" />
+        <PackageReference Update="NuGet.Versioning" Version="$(NuGetPackageVersion)" />
 
-    <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.19.0-beta0004" />
-    <PackageReference Update="OmniSharp.Extensions.LanguageProtocol.Testing" Version="0.19.0-beta0004" />
+        <PackageReference Update="OmniSharp.Extensions.LanguageServer" Version="0.19.0" />
+        <PackageReference Update="OmniSharp.Extensions.LanguageProtocol.Testing" Version="0.19.0" />
 
-    <PackageReference Update="SQLitePCLRaw.bundle_green" Version="1.1.2" />
-    <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
-    <PackageReference Update="System.Composition" Version="1.0.31" />
-    <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
-    <PackageReference Update="System.Reflection.Metadata" Version="1.4.2" />
-    <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-    <PackageReference Update="System.ValueTuple" Version="4.5.0" />
+        <PackageReference Update="SQLitePCLRaw.bundle_green" Version="1.1.2" />
+        <PackageReference Update="System.Collections.Immutable" Version="1.4.0" />
+        <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
+        <PackageReference Update="System.Composition" Version="1.0.31" />
+        <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
+        <PackageReference Update="System.Reflection.Metadata" Version="1.4.2" />
+        <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+        <PackageReference Update="System.ValueTuple" Version="4.5.0" />
 
-    <PackageReference Update="System.Reactive" Version="4.4.1" />
+        <PackageReference Update="System.Reactive" Version="4.4.1" />
 
-    <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
+        <PackageReference Update="System.Reflection.DispatchProxy" Version="4.5.1" />
 
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Update="xunit" Version="$(XunitPackageVersion)" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
+        <PackageReference Update="xunit.runner.visualstudio" Version="2.4.3" />
+        <PackageReference Update="xunit" Version="$(XunitPackageVersion)" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    </ItemGroup>
 </Project>

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -194,9 +194,10 @@ namespace OmniSharp.LanguageServerProtocol
             Action<ILoggingBuilder> configureLogging)
         {
             var logLevel = GetLogLevel(initializeParams.Trace);
-            var root = Helpers.FromUri(initializeParams.RootUri);
             var environment = new OmniSharpEnvironment(
-                string.IsNullOrEmpty(root) ? application.ApplicationRoot : root,
+                // TODO: Support solution selection from the server side in the future
+                // For now selection can be done by passing -s to the server
+                !string.IsNullOrEmpty(application.ApplicationRoot) ? application.ApplicationRoot : Helpers.FromUri(initializeParams.RootUri),
                 Convert.ToInt32(initializeParams.ProcessId ?? application.HostPid),
                 application.LogLevel < logLevel ? application.LogLevel : logLevel,
                 application.OtherArgs.ToArray());

--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -15,7 +15,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Endpoint;
 using OmniSharp.Extensions.JsonRpc;
@@ -105,6 +107,9 @@ namespace OmniSharp.LanguageServerProtocol
                 Section = "omnisharp"
             });
             services.AddSingleton(new DocumentVersions());
+            // This allows us to log normal messages over std error
+            // which then ensures that all communication over std out are LSP messages
+            services.Configure<ConsoleLoggerOptions>(z => z.LogToStandardErrorThreshold = LogLevel.Trace);
         }
 
         public void Dispose()
@@ -118,7 +123,8 @@ namespace OmniSharp.LanguageServerProtocol
             try
             {
                 _cancellationTokenSource.Cancel();
-            } catch (ObjectDisposedException){}
+            }
+            catch (ObjectDisposedException) { }
         }
 
         public async Task Start()
@@ -291,7 +297,7 @@ namespace OmniSharp.LanguageServerProtocol
             // and not loose any functionality.
             server.Register(r =>
             {
-                var defaultOptions = new JsonRpcHandlerOptions() {RequestProcessType = RequestProcessType.Parallel};
+                var defaultOptions = new JsonRpcHandlerOptions() { RequestProcessType = RequestProcessType.Parallel };
                 var interop = InitializeInterop(compositionHost);
                 foreach (var osHandler in interop)
                 {


### PR DESCRIPTION
* Upgraded extension dependencies to 3.1.
* Enabled console logging over stderr instead of stdout to ensure console logs don't cause issues for lsp functionality
+semver:minor