### PR TITLE
updated to IL Spy 7.0.0.6372

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -15,7 +15,7 @@
 
         <PackageReference Update="Dotnet.Script.DependencyModel" Version="1.0.2" />
         <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="1.0.1" />
-        <PackageReference Update="ICSharpCode.Decompiler" Version="6.1.0.5902" />
+        <PackageReference Update="ICSharpCode.Decompiler" Version="7.0.0.6372-preview3" />
         <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
 
         <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="$(AspNetCorePackageVersion)" />

--- a/src/OmniSharp.Roslyn.CSharp/Services/Decompilation/AssemblyResolver.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Decompilation/AssemblyResolver.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
 
 namespace OmniSharp.Roslyn.CSharp.Services.Decompilation
 {
@@ -124,6 +125,16 @@ namespace OmniSharp.Roslyn.CSharp.Services.Decompilation
 
             Log("Loading from {0}", moduleFileName);
             return new PEFile(moduleFileName, PEStreamOptions.PrefetchMetadata);
+        }
+
+        public Task<PEFile> ResolveAsync(IAssemblyReference name)
+        {
+            return Task.Run(() => Resolve(name));
+        }
+
+        public Task<PEFile> ResolveModuleAsync(PEFile mainModule, string moduleName)
+        {
+            return Task.Run(() => ResolveModule(mainModule, moduleName));
         }
 
         private void Log(string format, params object[] args)

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
@@ -483,7 +483,7 @@ class Bar {
             // second comment should indicate we have decompiled
             var comments = compilationUnit.DescendantTrivia().Where(t => t.Kind() == SyntaxKind.SingleLineCommentTrivia).ToArray();
             Assert.NotNull(comments);
-            Assert.Equal("// Decompiled with ICSharpCode.Decompiler 6.1.0.5902", comments[1].ToString());
+            Assert.Equal("// Decompiled with ICSharpCode.Decompiler 7.0.0.6372", comments[1].ToString());
 
             // contrary to regular metadata, we should have methods with full bodies
             // this condition would fail if decompilation wouldn't work


### PR DESCRIPTION
This gives us, among other things, support for

- C# 9.0 records
- C# 9.0 with expressions
- C# 9.0 primary constructors

It is a preview release, but then, most of our dependencies are preview already anyway 🙂