### PR TITLE
Exclude diagnostics suppressed by DiagnosticSuppressor

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
@@ -291,6 +291,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
 
                     diagnostics = semanticDiagnosticsWithAnalyzers
                         .Concat(syntaxDiagnosticsWithAnalyzers)
+                        .Where(x => !x.IsSuppressed)
                         .Concat(documentSemanticModel.GetDiagnostics())
                         .ToImmutableArray();
                 }


### PR DESCRIPTION
Fixes: #1711

DiagnosticSuppressor is a subclass of DiagnosticAnalyzer, so its instances are already imported from assemblies and excuted. However, they just mark diagnostics as suppressed, not exclude them directly. So the suppressors will take effect just by excluding suppressed diagnostics.

I tested this with VSCode and [Microsoft's Unity analyzers](https://github.com/microsoft/Microsoft.Unity.Analyzers/).