### PR TITLE
Rework completion resolution

### DIFF
--- a/OmniSharp.sln
+++ b/OmniSharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31129.286
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2C348365-A9D8-459E-9276-56FC46AAEE31}"
 EndProject
@@ -67,9 +67,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.Stdio.Driver", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.Script.Tests", "tests\OmniSharp.Script.Tests\OmniSharp.Script.Tests.csproj", "{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OmniSharp.Shared", "src\OmniSharp.Shared\OmniSharp.Shared.csproj", "{9571E3FE-E742-44AC-9E1F-64156815B8E1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.Shared", "src\OmniSharp.Shared\OmniSharp.Shared.csproj", "{9571E3FE-E742-44AC-9E1F-64156815B8E1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OmniSharp.Lsp.Tests", "tests\OmniSharp.Lsp.Tests\OmniSharp.Lsp.Tests.csproj", "{D67AA10B-8DB6-408D-A4C5-0B1DDCF5B3CC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.Lsp.Tests", "tests\OmniSharp.Lsp.Tests\OmniSharp.Lsp.Tests.csproj", "{D67AA10B-8DB6-408D-A4C5-0B1DDCF5B3CC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmniSharp.Benchmarks", "src\OmniSharp.Benchmarks\OmniSharp.Benchmarks.csproj", "{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -369,6 +371,18 @@ Global
 		{D67AA10B-8DB6-408D-A4C5-0B1DDCF5B3CC}.Release|x64.Build.0 = Release|Any CPU
 		{D67AA10B-8DB6-408D-A4C5-0B1DDCF5B3CC}.Release|x86.ActiveCfg = Release|Any CPU
 		{D67AA10B-8DB6-408D-A4C5-0B1DDCF5B3CC}.Release|x86.Build.0 = Release|Any CPU
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}.Debug|x64.Build.0 = Debug|Any CPU
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}.Debug|x86.Build.0 = Debug|Any CPU
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}.Release|x64.ActiveCfg = Release|Any CPU
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}.Release|x64.Build.0 = Release|Any CPU
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}.Release|x86.ActiveCfg = Release|Any CPU
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -398,6 +412,7 @@ Global
 		{9E4BA68C-7F4B-429A-A0C7-8CE7D41D610F} = {35E025BF-BBB2-4FAC-9F4B-37CBA083EE47}
 		{9571E3FE-E742-44AC-9E1F-64156815B8E1} = {2C348365-A9D8-459E-9276-56FC46AAEE31}
 		{D67AA10B-8DB6-408D-A4C5-0B1DDCF5B3CC} = {35E025BF-BBB2-4FAC-9F4B-37CBA083EE47}
+		{6F5B209E-8DD3-4E90-A1F3-D85E7AF56588} = {2C348365-A9D8-459E-9276-56FC46AAEE31}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4DD725CE-B49A-4151-8B77-BB33FE88E46E}

--- a/src/OmniSharp.Benchmarks/.gitignore
+++ b/src/OmniSharp.Benchmarks/.gitignore
@@ -1,0 +1,1 @@
+BenchmarkDotNet.Artifacts/*

--- a/src/OmniSharp.Benchmarks/ImportCompletionBenchmarks.cs
+++ b/src/OmniSharp.Benchmarks/ImportCompletionBenchmarks.cs
@@ -1,0 +1,63 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnostics.Windows.Configs;
+using OmniSharp.Models.v1.Completion;
+using OmniSharp.Roslyn.CSharp.Services.Completion;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TestUtility;
+
+namespace OmniSharp.Benchmarks
+{
+    [EtwProfiler]
+    public class ImportCompletionBenchmarks : HostBase
+    {
+        public CompletionRequest Request { get; set; } = null!;
+
+        [GlobalSetup]
+        public async Task SetupAsync()
+        {
+            Setup(new KeyValuePair<string, string>("RoslynExtensionsOptions:EnableImportCompletion", "true"));
+
+            var builder = new StringBuilder();
+
+            builder.AppendLine("class Base");
+            builder.AppendLine("{");
+            builder.AppendLine("    void M()");
+            builder.AppendLine("    {");
+            builder.AppendLine("        $$");
+            builder.AppendLine("    }");
+            builder.AppendLine("}");
+
+            const string FileName = "ImportCompletionTest.cs";
+            var file = new TestFile(FileName, builder.ToString());
+            OmniSharpTestHost.AddFilesToWorkspace(file);
+
+            var point = file.Content.GetPointFromPosition();
+
+            Request = new()
+            {
+                CompletionTrigger = CompletionTriggerKind.Invoked,
+                Line = point.Line,
+                Column = point.Offset,
+                FileName = FileName
+            };
+
+            // Trigger completion once to ensure that all the runs have a warmed-up server, with full completions loaded
+            CompletionResponse completions;
+            do
+            {
+                completions = await ImportCompletionListAsync();
+            } while (!completions.Items.Any(i => i.Label == "Console"));
+
+        }
+
+        [Benchmark]
+        public async Task<CompletionResponse> ImportCompletionListAsync()
+        {
+            var handler = OmniSharpTestHost.GetRequestHandler<CompletionService>(OmniSharpEndpoints.Completion);
+            return await handler.Handle(Request);
+        }
+    }
+}

--- a/src/OmniSharp.Benchmarks/OmniSharp.Benchmarks.csproj
+++ b/src/OmniSharp.Benchmarks/OmniSharp.Benchmarks.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OmniSharp.Roslyn.CSharp\OmniSharp.Roslyn.CSharp.csproj" />
+    <ProjectReference Include="..\..\tests\TestUtility\TestUtility.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/OmniSharp.Benchmarks/OverrideCompletionBenchmarks.cs
+++ b/src/OmniSharp.Benchmarks/OverrideCompletionBenchmarks.cs
@@ -1,0 +1,71 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnostics.Windows.Configs;
+using OmniSharp.Models.v1.Completion;
+using OmniSharp.Roslyn.CSharp.Services.Completion;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using TestUtility;
+
+namespace OmniSharp.Benchmarks
+{
+    [EtwProfiler]
+    public class OverrideCompletionBenchmarks : HostBase
+    {
+        [Params(10, 100, 250, 500)]
+        public int NumOverrides { get; set; }
+
+        public CompletionRequest Request { get; set; } = null!;
+
+        [GlobalSetup]
+        public async Task SetupAsync()
+        {
+            Setup(new KeyValuePair<string, string>( "RoslynExtensionsOptions:EnableImportCompletion", "true" ));
+
+            var builder = new StringBuilder();
+
+            builder.AppendLine("namespace N1");
+            builder.AppendLine("{");
+            builder.AppendLine("    using System.Collections.Generic;");
+            builder.AppendLine("    class Base");
+            builder.AppendLine("    {");
+            for (int i = 0; i < NumOverrides; i++)
+            {
+                builder.AppendLine($"        public virtual Dictionary<string, string> M{i}(List<string> s) {{ return null; }}");
+            }
+            builder.AppendLine("    }");
+            builder.AppendLine("}");
+            builder.AppendLine("namespace N2 : N1.Base");
+            builder.AppendLine("{");
+            builder.AppendLine("    class Derived");
+            builder.AppendLine("    {");
+            builder.AppendLine("        override $$");
+            builder.AppendLine("    }");
+            builder.AppendLine("}");
+
+            const string FileName = "OverrideTest.cs";
+            var file = new TestFile(FileName, builder.ToString());
+            OmniSharpTestHost.AddFilesToWorkspace(file);
+
+            var point = file.Content.GetPointFromPosition();
+
+            Request = new()
+            {
+                CompletionTrigger = OmniSharp.Models.v1.Completion.CompletionTriggerKind.Invoked,
+                Line = point.Line,
+                Column = point.Offset,
+                FileName = FileName
+            };
+
+            // Trigger completion once to ensure that all the runs have a warmed-up server
+            await OverrideCompletionAsync();
+        }
+
+        [Benchmark]
+        public async Task<CompletionResponse> OverrideCompletionAsync()
+        {
+            var handler = OmniSharpTestHost.GetRequestHandler<CompletionService>(OmniSharpEndpoints.Completion);
+            return await handler.Handle(Request);
+        }
+    }
+}

--- a/src/OmniSharp.Benchmarks/Program.cs
+++ b/src/OmniSharp.Benchmarks/Program.cs
@@ -1,0 +1,27 @@
+﻿using BenchmarkDotNet.Running;
+using Microsoft.Extensions.Configuration;
+using OmniSharp.Benchmarks;
+using OmniSharp.Utilities;
+using System.Collections.Generic;
+using TestUtility;
+
+BenchmarkRunner.Run(typeof(OverrideCompletionBenchmarks).Assembly);
+
+namespace OmniSharp.Benchmarks
+{
+    public abstract class HostBase : DisposableObject
+    {
+        protected OmniSharpTestHost OmniSharpTestHost { get; set; } = null!;
+
+        protected override void DisposeCore(bool disposing)
+        {
+            OmniSharpTestHost.Dispose();
+        }
+
+        public void Setup(params KeyValuePair<string, string>[]? configuration)
+        {
+            var builder = new Microsoft.Extensions.Configuration.ConfigurationBuilder().AddInMemoryCollection(configuration);
+            OmniSharpTestHost = OmniSharpTestHost.Create(configurationData: builder.Build());
+        }
+    }
+}

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpCompletionHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpCompletionHandler.cs
@@ -112,7 +112,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
             Debug.Assert(lspValues.Length == modelValues.Length);
             for (int i = 0; i < lspValues.Length; i++)
             {
-                Debug.Assert((int?)lspValues.GetValue(i) == (int?)modelValues.GetValue(i));
+                Debug.Assert((int)lspValues.GetValue(i) == (int)modelValues.GetValue(i));
             }
         }
 

--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
@@ -9,8 +9,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
@@ -36,7 +34,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
         IRequestHandler<CompletionRequest, CompletionResponse>,
         IRequestHandler<CompletionResolveRequest, CompletionResolveResponse>
     {
-        private static readonly Dictionary<string, CompletionItemKind> s_roslynTagToCompletionItemKind = new Dictionary<string, CompletionItemKind>()
+        private static readonly Dictionary<string, CompletionItemKind> s_roslynTagToCompletionItemKind = new()
         {
             { WellKnownTags.Public, CompletionItemKind.Keyword },
             { WellKnownTags.Protected, CompletionItemKind.Keyword },
@@ -78,7 +76,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
         private readonly FormattingOptions _formattingOptions;
         private readonly ILogger _logger;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
         private (CSharpCompletionList Completions, string FileName, int position)? _lastCompletion = null;
 
         [ImportingConstructor]
@@ -110,19 +108,23 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             var completionService = CSharpCompletionService.GetService(document);
             Debug.Assert(request.TriggerCharacter != null || request.CompletionTrigger != CompletionTriggerKind.TriggerCharacter);
 
+            CompletionTrigger trigger = request.CompletionTrigger switch
+            {
+                CompletionTriggerKind.Invoked => CompletionTrigger.Invoke,
+                CompletionTriggerKind.TriggerCharacter when request.TriggerCharacter is char c => CompletionTrigger.CreateInsertionTrigger(c),
+                _ => CompletionTrigger.Invoke,
+            };
+
             if (request.CompletionTrigger == CompletionTriggerKind.TriggerCharacter &&
-                !completionService.ShouldTriggerCompletion(sourceText, position, getCompletionTrigger(includeTriggerCharacter: true)))
+                !completionService.ShouldTriggerCompletion(sourceText, position, trigger))
             {
                 _logger.LogTrace("Should not insert completions here.");
                 return new CompletionResponse { Items = ImmutableArray<CompletionItem>.Empty };
             }
 
-            var (completions, expandedItemsAvailable) = await completionService.GetCompletionsInternalAsync(
-                document,
-                position,
-                getCompletionTrigger(includeTriggerCharacter: false));
+            var (completions, expandedItemsAvailable) = await completionService.GetCompletionsInternalAsync(document, position, trigger);
             _logger.LogTrace("Found {0} completions for {1}:{2},{3}",
-                             completions?.Items.IsDefaultOrEmpty != true ? 0 : completions.Items.Length,
+                             completions?.Items.IsDefaultOrEmpty != false ? 0 : completions.Items.Length,
                              request.FileName,
                              request.Line,
                              request.Column);
@@ -135,9 +137,9 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             if (request.TriggerCharacter == ' ' && !completions.Items.Any(c =>
             {
                 var providerName = c.GetProviderName();
-                return providerName == CompletionItemExtensions.OverrideCompletionProvider ||
-                       providerName == CompletionItemExtensions.PartialMethodCompletionProvider ||
-                       providerName == CompletionItemExtensions.ObjectCreationCompletionProvider;
+                return providerName is CompletionItemExtensions.OverrideCompletionProvider or
+                                       CompletionItemExtensions.PartialMethodCompletionProvider or
+                                       CompletionItemExtensions.ObjectCreationCompletionProvider;
             }))
             {
                 // Only trigger on space if there is an object creation completion
@@ -146,10 +148,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
 
             var typedSpan = completionService.GetDefaultCompletionListSpan(sourceText, position);
             string typedText = sourceText.GetSubText(typedSpan).ToString();
-
-            ImmutableArray<string> filteredItems = typedText != string.Empty
-                ? completionService.FilterItems(document, completions.Items, typedText).SelectAsArray(i => i.DisplayText)
-                : ImmutableArray<string>.Empty;
             _logger.LogTrace("Completions filled in");
 
             lock (_lock)
@@ -173,167 +171,134 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
 
             for (int i = 0; i < completions.Items.Length; i++)
             {
+                TextSpan changeSpan = typedSpan;
                 var completion = completions.Items[i];
                 var insertTextFormat = InsertTextFormat.PlainText;
-                IReadOnlyList<LinePositionSpanTextChange>? additionalTextEdits = null;
-                char sortTextPrepend = '0';
-
-                if (!completion.TryGetInsertionText(out string insertText))
+                string labelText = completion.DisplayTextPrefix + completion.DisplayText + completion.DisplayTextSuffix;
+                List<LinePositionSpanTextChange>? additionalTextEdits = null;
+                string? insertText = null;
+                string? filterText = null;
+                string? sortText = null;
+                switch (completion.GetProviderName())
                 {
-                    string providerName = completion.GetProviderName();
-                    switch (providerName)
-                    {
-                        case CompletionItemExtensions.EmeddedLanguageCompletionProvider:
-                            // The Regex completion provider can change escapes based on whether
-                            // we're in a verbatim string or not
+                    case CompletionItemExtensions.TypeImportCompletionProvider or CompletionItemExtensions.ExtensionMethodImportCompletionProvider:
+                        changeSpan = typedSpan;
+                        insertText = completion.DisplayText;
+                        seenUnimportedCompletions = true;
+                        sortText = '1' + completion.SortText;
+                        filterText = null;
+                        break;
+
+                    case CompletionItemExtensions.InternalsVisibleToCompletionProvider:
+                        // if the completion is for the hidden Misc files project, skip it
+                        if (completion.DisplayText == Configuration.OmniSharpMiscProjectName) continue;
+                        goto default;
+
+                    default:
+                        {
+                            // Except for import completion, we just resolve the change up front in the sync version. It's only expensive
+                            // for override completion, but there's not a heck of a lot we can do about that for the sync scenario
+                            var change = await completionService.GetChangeAsync(document, completion);
+
+                            // Roslyn will give us the position to move the cursor after the completion is entered.
+                            // However, this is in the _new_ document, after changes have been applied. In order to
+                            // snippetize the insertion text, we need to calculate the offset as we move along the
+                            // edits, subtracting or adding the difference for edits that do not insersect the current
+                            // span.
+                            var adjustedNewPosition = change.NewPosition;
+
+                            // There must be at least one change that affects the current location, or something is seriously wrong
+                            Debug.Assert(change.TextChanges.Any(change => change.Span.IntersectsWith(position)));
+
+                            foreach (var textChange in change.TextChanges)
                             {
-                                CompletionChange change = await completionService.GetChangeAsync(document, completion);
-                                Debug.Assert(typedSpan == change.TextChange.Span);
-                                insertText = change.TextChange.NewText!;
-                            }
-                            break;
-
-                        case CompletionItemExtensions.InternalsVisibleToCompletionProvider:
-                            // The IVT completer doesn't add extra things before the completion
-                            // span, only assembly keys at the end if they exist.
-                            {
-                                // if the completion is for the hidden Misc files project, skip it
-                                if (completion.DisplayText == Configuration.OmniSharpMiscProjectName) continue;
-                                CompletionChange change = await completionService.GetChangeAsync(document, completion);
-                                Debug.Assert(typedSpan == change.TextChange.Span);
-                                insertText = change.TextChange.NewText!;
-                            }
-                            break;
-
-                        case CompletionItemExtensions.XmlDocCommentCompletionProvider:
-                            {
-                                // The doc comment completion might compensate for the < before
-                                // the current word, if one exists. For these cases, if the token
-                                // before the current location is a < and the text it's replacing starts
-                                // with a <, erase the < from the given insertion text.
-                                var change = await completionService.GetChangeAsync(document, completion);
-
-                                bool trimFront = change.TextChange.NewText![0] == '<'
-                                                 && sourceText[change.TextChange.Span.Start] == '<';
-
-                                Debug.Assert(!trimFront || change.TextChange.Span.Start + 1 == typedSpan.Start);
-
-                                (insertText, insertTextFormat) = getAdjustedInsertTextWithPosition(change, position, newOffset: trimFront ? 1 : 0);
-                            }
-                            break;
-
-                        case CompletionItemExtensions.OverrideCompletionProvider:
-                        case CompletionItemExtensions.PartialMethodCompletionProvider:
-                            {
-                                // For these two, we potentially need to use additionalTextEdits. It's possible
-                                // that override (or C# expanded partials) will cause the word or words before
-                                // the cursor to be adjusted. For example:
-                                //
-                                // public class C {
-                                //     override $0
-                                // }
-                                //
-                                // Invoking completion and selecting, say Equals, wants to cause the line to be
-                                // rewritten as this:
-                                //
-                                // public class C {
-                                //     public override bool Equals(object other)
-                                //     {
-                                //         return base.Equals(other);$0
-                                //     }
-                                // }
-                                //
-                                // In order to handle this, we need to chop off the section of the completion
-                                // before the cursor and bundle that into an additionalTextEdit. Then, we adjust
-                                // the remaining bit of the change to put the cursor in the expected spot via
-                                // snippets. We could leave the additionalTextEdit bit for resolve, but we already
-                                // have the data do the change and we basically have to compute the whole thing now
-                                // anyway, so it doesn't really save us anything.
-
-                                var change = await completionService.GetChangeAsync(document, completion);
-
-                                if (typedSpan == change.TextChange.Span)
+                                if (!textChange.Span.IntersectsWith(position))
                                 {
-                                    // If the span we're using to key the completion off is the same as the replacement
-                                    // span, then we don't need to do anything special, just snippitize the text and
-                                    // exit
-                                    (insertText, insertTextFormat) = getAdjustedInsertTextWithPosition(change, position, newOffset: 0);
-                                    break;
-                                }
+                                    additionalTextEdits ??= new();
+                                    additionalTextEdits.Add(GetChangeForTextAndSpan(textChange.NewText!, textChange.Span, sourceText));
 
-                                if (change.TextChange.Span.Start > typedSpan.Start)
+                                    if (adjustedNewPosition is int newPosition)
+                                    {
+                                        // Find the diff between the original text length and the new text length.
+                                        var diff = (textChange.NewText?.Length ?? 0) - textChange.Span.Length;
+
+                                        // If the new text is longer than the replaced text, we want to subtract that
+                                        // length from the current new position to find the adjusted position in the old
+                                        // document. If the new text was shorter, diff will be negative, and subtracting
+                                        // will result in increasing the adjusted position as expected
+                                        adjustedNewPosition = newPosition - diff;
+                                    }
+                                }
+                                else
                                 {
-                                    // If the span we're using to key the replacement span is within the original typed span
-                                    // span, we want to prepend the missing text from the original typed text to here. The
-                                    // reason is that some lsp clients, such as vscode, use the range from the text edit as
-                                    // the selector for what filter text to use. This can lead to odd scenarios where invoking
-                                    // completion and typing `EQ` will bring up the Equals override, but then dismissing and
-                                    // reinvoking completion will have a range that just replaces the Q. Vscode will then consider
-                                    // that capital Q to be the start of the filter text, and filter out the Equals overload
-                                    // leaving the user with no completion and no explanation
-                                    Debug.Assert(change.TextChange.Span.End == typedSpan.End);
-                                    var prefix = typedText.Substring(0, change.TextChange.Span.Start - typedSpan.Start);
+                                    // Either there should be no new position, or it should be within the text that is being added
+                                    // by this change.
+                                    Debug.Assert(adjustedNewPosition is null ||
+                                        (adjustedNewPosition.Value <= textChange.Span.Start + textChange.NewText!.Length) &&
+                                        (adjustedNewPosition.Value >= textChange.Span.Start));
 
-                                    (insertText, insertTextFormat) = getAdjustedInsertTextWithPosition(change, position, newOffset: 0, prefix);
-                                    break;
+                                    changeSpan = textChange.Span;
+                                    (insertText, insertTextFormat) = getPossiblySnippitizedInsertText(textChange, adjustedNewPosition);
+
+                                    // If we're expecting there to be unimported types, put in an explicit sort text to put things already in scope first.
+                                    // Otherwise, omit the sort text if it's the same as the label to save on space.
+                                    sortText = expectingImportedItems
+                                        ? '0' + completion.SortText
+                                        : labelText == completion.SortText ? null : completion.SortText;
+
+                                    // If the completion is replacing a bigger range than the previously-typed word, we need to have the filter
+                                    // text compensate. Clients will use the range of the text edit to determine the thing that is being filtered
+                                    // against. For example, override completion:
+                                    //
+                                    //    override $$
+                                    //    |--------| Range that is being changed by the completion
+                                    //
+                                    // That means vscode will consider "override <additional user input>" when looking to see whether the item
+                                    // still matches. To compensate, we add the start of the replacing range, up to the start of the current word,
+                                    // to ensure the item isn't silently filtered out.
+
+                                    if (changeSpan != typedSpan)
+                                    {
+                                        if (typedSpan.Start < changeSpan.Start)
+                                        {
+                                            // This means that some part of the currently-typed text is an exact match for the start of the
+                                            // change, so chop off changeSpan.Start - typedSpan.Start from the filter text to get it to match
+                                            // up with the range
+                                            int prefixMatchElement = changeSpan.Start - typedSpan.Start;
+                                            Debug.Assert(completion.FilterText.StartsWith(sourceText.GetSubText(new TextSpan(typedSpan.Start, prefixMatchElement)).ToString()));
+                                            filterText = completion.FilterText.Substring(prefixMatchElement);
+                                        }
+                                        else
+                                        {
+                                            var prefix = sourceText.GetSubText(TextSpan.FromBounds(changeSpan.Start, typedSpan.Start)).ToString();
+                                            filterText = prefix + completion.FilterText;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        filterText = labelText == completion.FilterText ? null : completion.FilterText;
+                                    }
                                 }
-
-                                int additionalEditEndOffset;
-                                (additionalTextEdits, additionalEditEndOffset) = GetAdditionalTextEdits(change, sourceText, (CSharpParseOptions)syntax!.Options, typedSpan, completion.DisplayText, providerName);
-
-                                if (additionalEditEndOffset < 0)
-                                {
-                                    // We couldn't find the position of the change in the new text. This shouldn't happen in normal cases,
-                                    // but handle as best we can in release
-                                    Debug.Fail("Couldn't find the new cursor position in the replacement text!");
-                                    additionalTextEdits = null;
-                                    insertText = completion.DisplayText;
-                                    break;
-                                }
-
-                                // Now that we have the additional edit, adjust the rest of the new text
-                                (insertText, insertTextFormat) = getAdjustedInsertTextWithPosition(change, position, additionalEditEndOffset);
                             }
-                            break;
 
-                        case CompletionItemExtensions.TypeImportCompletionProvider:
-                        case CompletionItemExtensions.ExtensionMethodImportCompletionProvider:
-                            // We did indeed find unimported types, the completion list can be considered complete.
-                            // This is technically slightly incorrect: extension method completion can provide
-                            // partial results. However, this should only affect the first completion session or
-                            // two and isn't a big problem in practice.
-                            seenUnimportedCompletions = true;
-                            sortTextPrepend = '1';
-                            goto default;
-
-                        default:
-                            insertText = completion.DisplayText;
                             break;
-                    }
+                        }
                 }
 
                 var commitCharacters = buildCommitCharacters(completions, completion.Rules.CommitCharacterRules, triggerCharactersBuilder);
 
                 completionsBuilder.Add(new CompletionItem
                 {
-                    Label = completion.DisplayTextPrefix + completion.DisplayText + completion.DisplayTextSuffix,
-                    TextEdit = new LinePositionSpanTextChange
-                    {
-                        NewText = insertText,
-                        StartLine = replacingSpanStartPosition.Line,
-                        StartColumn = replacingSpanStartPosition.Character,
-                        EndLine = replacingSpanEndPosition.Line,
-                        EndColumn = replacingSpanEndPosition.Character
-                    },
+                    Label = labelText,
+                    TextEdit = GetChangeForTextAndSpan(insertText!, changeSpan, sourceText),
                     InsertTextFormat = insertTextFormat,
                     AdditionalTextEdits = additionalTextEdits,
-                    // Ensure that unimported items are sorted after things already imported.
-                    SortText = expectingImportedItems ? sortTextPrepend + completion.SortText : completion.SortText,
-                    FilterText = completion.FilterText,
+                    SortText = sortText,
+                    FilterText = filterText,
                     Kind = getCompletionItemKind(completion.Tags),
                     Detail = completion.InlineDescription,
                     Data = i,
-                    Preselect = completion.Rules.MatchPriority == MatchPriority.Preselect || filteredItems.Contains(completion.DisplayText),
+                    Preselect = completion.Rules.SelectionBehavior == CompletionItemSelectionBehavior.HardSelection,
                     CommitCharacters = commitCharacters,
                 });
             }
@@ -344,15 +309,22 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
                 Items = completionsBuilder.Capacity == completionsBuilder.Count ? completionsBuilder.MoveToImmutable() : completionsBuilder.ToImmutable()
             };
 
-            CompletionTrigger getCompletionTrigger(bool includeTriggerCharacter)
-                => request.CompletionTrigger switch
+            static (string?, InsertTextFormat) getPossiblySnippitizedInsertText(TextChange change, int? adjustedNewPosition)
+            {
+                if (adjustedNewPosition is not int newPosition || change.NewText is null || newPosition == change.Span.Start + change.NewText.Length)
                 {
-                    CompletionTriggerKind.Invoked => CompletionTrigger.Invoke,
-                    // https://github.com/dotnet/roslyn/issues/42982: Passing a trigger character
-                    // to GetCompletionsAsync causes a null ref currently.
-                    CompletionTriggerKind.TriggerCharacter when includeTriggerCharacter => CompletionTrigger.CreateInsertionTrigger((char)request.TriggerCharacter!),
-                    _ => CompletionTrigger.Invoke,
-                };
+                    return (change.NewText, InsertTextFormat.PlainText);
+                }
+
+                // Roslyn wants to move the cursor somewhere inside the result. Substring from the
+                // requested start to the new position, and from the new position to the end of the
+                // string.
+                int midpoint = newPosition - change.Span.Start;
+                var beforeText = LspSnippetHelpers.Escape(change.NewText.Substring(0, midpoint));
+                var afterText = LspSnippetHelpers.Escape(change.NewText.Substring(midpoint));
+
+                return ($"{beforeText}$0{afterText}", InsertTextFormat.Snippet);
+            }
 
             static CompletionItemKind getCompletionItemKind(ImmutableArray<string> tags)
             {
@@ -408,39 +380,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
 
                 return triggerCharactersBuilder.ToImmutableAndClear();
             }
-
-            static (string, InsertTextFormat) getAdjustedInsertTextWithPosition(
-                CompletionChange change,
-                int originalPosition,
-                int newOffset,
-                string? prependText = null)
-            {
-                // We often have to trim part of the given change off the front, but we
-                // still want to turn the resulting change into a snippet and control
-                // the cursor location in the insertion text. We therefore need to compensate
-                // by cutting off the requested portion of the text, finding the adjusted
-                // position in the requested string, and snippetizing it.
-
-                // NewText is annotated as nullable, but this is a misannotation that will be fixed.
-                string newText = change.TextChange.NewText!;
-
-                // Easy-out, either Roslyn doesn't have an opinion on adjustment, or the adjustment is after the
-                // end of the new text. Just return a substring from the requested offset to the end
-                if (!(change.NewPosition is int newPosition)
-                    || newPosition >= (change.TextChange.Span.Start + newText.Length))
-                {
-                    return (prependText + newText.Substring(newOffset), InsertTextFormat.PlainText);
-                }
-
-                // Roslyn wants to move the cursor somewhere inside the result. Substring from the
-                // requested start to the new position, and from the new position to the end of the
-                // string.
-                int midpoint = newPosition - change.TextChange.Span.Start;
-                var beforeText = LspSnippetHelpers.Escape(prependText + newText.Substring(newOffset, midpoint - newOffset));
-                var afterText = LspSnippetHelpers.Escape(newText.Substring(midpoint));
-
-                return (beforeText + "$0" + afterText, InsertTextFormat.Snippet);
-            }
         }
 
         public async Task<CompletionResolveResponse> Handle(CompletionResolveRequest request)
@@ -490,16 +429,23 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             {
                 case CompletionItemExtensions.ExtensionMethodImportCompletionProvider:
                 case CompletionItemExtensions.TypeImportCompletionProvider:
-                    var syntax = await document.GetSyntaxTreeAsync();
                     var sourceText = await document.GetTextAsync();
                     var typedSpan = completionService.GetDefaultCompletionListSpan(sourceText, position);
                     var change = await completionService.GetChangeAsync(document, lastCompletionItem, typedSpan);
-                    var (additionalTextEdits, offset) = GetAdditionalTextEdits(change, sourceText, (CSharpParseOptions)syntax!.Options, typedSpan, lastCompletionItem.DisplayText, providerName);
-                    if (offset > 0)
+
+                    var additionalChanges = new List<LinePositionSpanTextChange>();
+                    foreach (var textChange in change.TextChanges)
                     {
-                        Debug.Assert(additionalTextEdits is object);
-                        request.Item.AdditionalTextEdits = additionalTextEdits;
+                        if (textChange.NewText == request.Item.TextEdit!.NewText)
+                        {
+                            continue;
+                        }
+
+                        additionalChanges.Add(GetChangeForTextAndSpan(textChange.NewText, textChange.Span, sourceText));
                     }
+
+                    request.Item.AdditionalTextEdits = additionalChanges;
+
                     break;
             }
 
@@ -509,86 +455,17 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             };
         }
 
-        private (IReadOnlyList<LinePositionSpanTextChange>? edits, int endOffset) GetAdditionalTextEdits(
-            CompletionChange change,
-            SourceText sourceText,
-            CSharpParseOptions parseOptions,
-            TextSpan typedSpan,
-            string completionDisplayText,
-            string providerName)
+        private static LinePositionSpanTextChange GetChangeForTextAndSpan(string? insertText, TextSpan changeSpan, SourceText sourceText)
         {
-            // We know the span starts before the text we're keying off of. So, break that
-            // out into a separate edit. We need to cut out the space before the current word,
-            // as the additional edit is not allowed to overlap with the insertion point.
-            var additionalEditStartPosition = sourceText.Lines.GetLinePosition(change.TextChange.Span.Start);
-            var additionalEditEndPosition = sourceText.Lines.GetLinePosition(typedSpan.Start - 1);
-            int additionalEditEndOffset = getAdditionalTextEditEndOffset(change, sourceText, parseOptions, completionDisplayText, providerName);
-            if (additionalEditEndOffset < 1)
+            var changeLinePositionSpan = sourceText.Lines.GetLinePositionSpan(changeSpan);
+            return new()
             {
-                // The first index of this was either 0 and the edit span was wrong,
-                // or it wasn't found at all. In this case, just do the best we can:
-                // send the whole string wtih no additional edits and log a warning.
-                _logger.LogWarning("Could not find the first index of the display text.\nDisplay text: {0}.\nCompletion Text: {1}",
-                    completionDisplayText, change.TextChange.NewText);
-                return (null, -1);
-            }
-
-            return (ImmutableArray.Create(new LinePositionSpanTextChange
-            {
-                // Again, we cut off the space at the end of the offset
-                NewText = change.TextChange.NewText!.Substring(0, additionalEditEndOffset - 1),
-                StartLine = additionalEditStartPosition.Line,
-                StartColumn = additionalEditStartPosition.Character,
-                EndLine = additionalEditEndPosition.Line,
-                EndColumn = additionalEditEndPosition.Character,
-            }), additionalEditEndOffset);
-
-            static int getAdditionalTextEditEndOffset(CompletionChange change, SourceText sourceText, CSharpParseOptions parseOptions, string completionDisplayText, string providerName)
-            {
-                if (providerName == CompletionItemExtensions.ExtensionMethodImportCompletionProvider ||
-                    providerName == CompletionItemExtensions.TypeImportCompletionProvider)
-                {
-                    return change.TextChange.NewText!.LastIndexOf(completionDisplayText);
-                }
-
-                // The DisplayText wasn't in the final string. This can happen in a few cases:
-                //  * The override or partial method completion is involving types that need
-                //    to have a using added in the final version, and won't be fully qualified
-                //    as they were in the DisplayText
-                //  * Nullable context differences, such as if the thing you're overriding is
-                //    annotated but the final context being generated into does not have
-                //    annotations enabled.
-                // For these cases, we currently should only be seeing override or partial
-                // completions, as import completions don't have nullable annotations or
-                // fully-qualified types in their DisplayTexts. If that ever changes, we'll have
-                // to adjust the API here.
-                //
-                // In order to find the correct location here, we parse the change. The location
-                // of the method or property that contains the new cursor position is the location
-                // of the new changes
-                Debug.Assert(providerName == CompletionItemExtensions.OverrideCompletionProvider ||
-                             providerName == CompletionItemExtensions.PartialMethodCompletionProvider);
-                Debug.Assert(change.NewPosition.HasValue);
-
-                var parsedTree = CSharpSyntaxTree.ParseText(sourceText.WithChanges(change.TextChange).ToString(), parseOptions);
-
-                var tokenOfNewPosition = parsedTree.GetRoot().FindToken(change.NewPosition!.Value);
-                var finalNode = tokenOfNewPosition.Parent;
-                while (finalNode != null)
-                {
-                    switch (finalNode)
-                    {
-                        case MethodDeclarationSyntax decl:
-                            return decl.Identifier.SpanStart - change.TextChange.Span.Start;
-                        case PropertyDeclarationSyntax prop:
-                            return prop.Identifier.SpanStart - change.TextChange.Span.Start;
-                    }
-
-                    finalNode = finalNode.Parent;
-                }
-
-                return -1;
-            }
+                NewText = insertText ?? "",
+                StartLine = changeLinePositionSpan.Start.Line,
+                StartColumn = changeLinePositionSpan.Start.Character,
+                EndLine = changeLinePositionSpan.End.Line,
+                EndColumn = changeLinePositionSpan.End.Character
+            };
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
@@ -371,7 +371,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
                 if (characterRules.IsEmpty)
                 {
                     // Use defaults
-                    return isSuggestionMode ? DefaultRulesWithoutSpace : null;
+                    return isSuggestionMode ? DefaultRulesWithoutSpace : CompletionRules.Default.DefaultCommitCharacters;
                 }
 
                 if (commitCharacterRulesCache.TryGetValue(characterRules, out var cachedRules))

--- a/src/OmniSharp.Shared/Utilities/ImmutableArrayExtensions.cs
+++ b/src/OmniSharp.Shared/Utilities/ImmutableArrayExtensions.cs
@@ -36,6 +36,22 @@ namespace OmniSharp.Utilities
             return builder.MoveToImmutable();
         }
 
+        public static ImmutableArray<TOut> SelectAsArray<TIn, TArg, TOut>(this ImmutableArray<TIn> array, TArg arg, Func<TIn, TArg, TOut> mapper)
+        {
+            if (array.IsDefaultOrEmpty)
+            {
+                return ImmutableArray<TOut>.Empty;
+            }
+
+            var builder = ImmutableArray.CreateBuilder<TOut>(array.Length);
+            foreach (var e in array)
+            {
+                builder.Add(mapper(e, arg));
+            }
+
+            return builder.MoveToImmutable();
+        }
+
         public static ImmutableArray<T> ToImmutableAndClear<T>(this ImmutableArray<T>.Builder builder)
         {
             if (builder.Capacity == builder.Count)

--- a/tests/OmniSharp.Cake.Tests/CompletionFacts.cs
+++ b/tests/OmniSharp.Cake.Tests/CompletionFacts.cs
@@ -75,7 +75,7 @@ namespace OmniSharp.Cake.Tests
             {
                 var fileName = Path.Combine(testProject.Directory, "build.cake");
                 var completion = (await FindCompletionsAsync(fileName, input, host))
-                    .Items.First(x => x.Preselect && x.TextEdit.NewText == "Information");
+                    .Items.First(x => x.TextEdit.NewText == "Information");
 
                 var resolved = await ResolveCompletionAsync(completion, host);
 
@@ -155,31 +155,33 @@ class FooChild : Foo
                     completions.Items.Select(c => c.Label));
                 Assert.Equal(new[]
                     {
-                        "Equals(object obj)\n    {\n        return base.Equals(obj);$0\n    \\}",
-                        "GetHashCode()\n    {\n        return base.GetHashCode();$0\n    \\}",
-                        "Test(string text)\n    {\n        base.Test(text);$0\n    \\}",
-                        "Test(string text, string moreText)\n    {\n        base.Test(text, moreText);$0\n    \\}",
-                        "ToString()\n    {\n        return base.ToString();$0\n    \\}"
+                        "public override bool Equals(object obj)\n    {\n        return base.Equals(obj);$0\n    \\}",
+                        "public override int GetHashCode()\n    {\n        return base.GetHashCode();$0\n    \\}",
+                        "public override void Test(string text)\n    {\n        base.Test(text);$0\n    \\}",
+                        "public override void Test(string text, string moreText)\n    {\n        base.Test(text, moreText);$0\n    \\}",
+                        "public override string ToString()\n    {\n        return base.ToString();$0\n    \\}"
                     },
-                    completions.Items.Select<CompletionItem, string>(c => c.TextEdit.NewText));
+                    completions.Items.Select(c => c.TextEdit.NewText));
 
                 Assert.Equal(new[]
                     {
-                        "public override bool",
-                        "public override int",
-                        "public override void",
-                        "public override void",
-                        "public override string"
+                        "override Equals",
+                        "override GetHashCode",
+                        "override Test",
+                        "override Test",
+                        "override ToString"
                     },
-                    completions.Items.Select(c => c.AdditionalTextEdits.Single().NewText));
+                    completions.Items.Select(c => c.FilterText));
 
-                Assert.All(completions.Items.Select(c => c.AdditionalTextEdits.Single()),
+                Assert.All(completions.Items, c => Assert.Null(c.AdditionalTextEdits));
+
+                Assert.All(completions.Items.Select(c => c.TextEdit),
                     r =>
                     {
                         Assert.Equal(9, r.StartLine);
                         Assert.Equal(4, r.StartColumn);
                         Assert.Equal(9, r.EndLine);
-                        Assert.Equal(12, r.EndColumn);
+                        Assert.Equal(13, r.EndColumn);
                     });
 
                 Assert.All(completions.Items, c => Assert.Equal(InsertTextFormat.Snippet, c.InsertTextFormat));

--- a/tests/TestUtility/Logging/TestLogger.cs
+++ b/tests/TestUtility/Logging/TestLogger.cs
@@ -16,7 +16,7 @@ namespace TestUtility.Logging
 
         protected override void WriteMessage(LogLevel logLevel, string message)
         {
-            _output.WriteLine(message);
+            _output?.WriteLine(message);
         }
     }
 }


### PR DESCRIPTION
Recently, Roslyn undeprecated the CompletionChange.TextChanges API. This API gives changes in a significantly simpler manner for us to deal with, as it splits up things like imports and the actual main change element, so we can remove a whole bunch of code dedicated to finding the changed elements and mapping original source locations to the new document. The new pattern is much simpler: except for import completion, we always resolve the change up front. For most providers, this is an extremely quick call, as most providers just return the label, and for the ones that don't we can't do much about it anyway. We can then loop through the individual changes, putting changes that are not touching the current cursor location into AdditionalTextChanges. This shrinks the completion payload pretty significantly for many scenarios, and gets rid of a bunch of special handling around it. The only remaining special handling is adjusting the filter texts and snippitizing completions that want to move the cursor. I've also aligned the behavior of the Preselect flag with Roslyn's completion handler, and removed additional filtering of completion items so that they can be filtered by the client instead.

Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/2123 as well.
