### PR TITLE
Report back the solution filter name in workspace updated event

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -135,14 +135,16 @@ namespace OmniSharp.MSBuild
             // If a solution was provided, use it.
             if (!string.IsNullOrEmpty(_environment.SolutionFilePath))
             {
-                return GetProjectPathsAndIdsFromSolutionOrFilter(_environment.SolutionFilePath, out _solutionFileOrRootPath);
+                _solutionFileOrRootPath = _environment.SolutionFilePath;
+                return GetProjectPathsAndIdsFromSolutionOrFilter(_environment.SolutionFilePath);
             }
 
             // Otherwise, assume that the path provided is a directory and look for a solution there.
             var solutionFilePath = FindSolutionFilePath(_environment.TargetDirectory, _logger);
             if (!string.IsNullOrEmpty(solutionFilePath))
             {
-                return GetProjectPathsAndIdsFromSolutionOrFilter(solutionFilePath, out _solutionFileOrRootPath);
+                _solutionFileOrRootPath = solutionFilePath;
+                return GetProjectPathsAndIdsFromSolutionOrFilter(solutionFilePath);
             }
 
             // Finally, if there isn't a single solution immediately available,
@@ -156,11 +158,11 @@ namespace OmniSharp.MSBuild
             });
         }
 
-        private IEnumerable<(string, ProjectIdInfo)> GetProjectPathsAndIdsFromSolutionOrFilter(string solutionOrFilterFilePath, out string solutionFilePath)
+        private IEnumerable<(string, ProjectIdInfo)> GetProjectPathsAndIdsFromSolutionOrFilter(string solutionOrFilterFilePath)
         {
             _logger.LogInformation($"Detecting projects in '{solutionOrFilterFilePath}'.");
 
-            solutionFilePath = solutionOrFilterFilePath;
+            var solutionFilePath = solutionOrFilterFilePath;
 
             var projectFilter = ImmutableHashSet<string>.Empty;
             if (SolutionFilterReader.IsSolutionFilterFilename(solutionOrFilterFilePath) &&

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -53,7 +53,7 @@ namespace OmniSharp.MSBuild.Tests
             {
                 var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
 
-                Assert.Equal("ProjectAndSolutionFilter.sln", Path.GetFileName(workspaceInfo.SolutionPath));
+                Assert.Equal("ProjectAndSolutionFilter.slnf", Path.GetFileName(workspaceInfo.SolutionPath));
                 Assert.NotNull(workspaceInfo.Projects);
                 var project = Assert.Single(workspaceInfo.Projects);
 


### PR DESCRIPTION
In https://github.com/OmniSharp/omnisharp-vscode/pull/4481 the solution file's name is reported in the project selector because we are settings the ProjectSystem _solutionName to be the parsed solution path from the solution filter.

This ensures the solution filter path is reported in Workspace Updated events.