### PR TITLE
Correctly set compilation platform of the project

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
@@ -151,7 +151,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 Guid guid, string name,
                 string assemblyName, string targetPath, string outputPath, string intermediateOutputPath,
                 string projectAssetsFile,
-                string configuration, string platform,
+                string configuration, string platform, string platformTarget,
                 FrameworkName targetFramework,
                 ImmutableArray<string> targetFrameworks,
                 OutputKind outputKind,
@@ -182,7 +182,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 ImmutableDictionary<string, string> projectReferenceAliases,
                 ImmutableArray<IMSBuildGlob> fileInclusionGlobs)
                 : this(guid, name, assemblyName, targetPath, outputPath, intermediateOutputPath, projectAssetsFile,
-                      configuration, platform, targetFramework, targetFrameworks, outputKind, languageVersion, nullableContextOptions, allowUnsafeCode, checkForOverflowUnderflow,
+                      configuration, platform, platformTarget, targetFramework, targetFrameworks, outputKind, languageVersion, nullableContextOptions, allowUnsafeCode, checkForOverflowUnderflow,
                       documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, warningsAsErrors, warningsNotAsErrors, signAssembly, assemblyOriginatorKeyFile, treatWarningsAsErrors, defaultNamespace, runAnalyzers, runAnalyzersDuringLiveAnalysis, ruleset)
             {
                 SourceFiles = sourceFiles.EmptyIfDefault();
@@ -208,6 +208,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 var projectAssetsFile = project.GetPropertyValue(PropertyNames.ProjectAssetsFile);
                 var configuration = project.GetPropertyValue(PropertyNames.Configuration);
                 var platform = project.GetPropertyValue(PropertyNames.Platform);
+                var platformTarget = project.GetPropertyValue(PropertyNames.PlatformTarget);
                 var defaultNamespace = project.GetPropertyValue(PropertyNames.RootNamespace);
 
                 var targetFramework = new FrameworkName(project.GetPropertyValue(PropertyNames.TargetFrameworkMoniker));
@@ -238,7 +239,7 @@ namespace OmniSharp.MSBuild.ProjectFile
 
                 return new ProjectData(
                     guid, name, assemblyName, targetPath, outputPath, intermediateOutputPath, projectAssetsFile,
-                    configuration, platform, targetFramework, targetFrameworks, outputKind, languageVersion, nullableContextOptions, allowUnsafeCode, checkForOverflowUnderflow,
+                    configuration, platform, platformTarget, targetFramework, targetFrameworks, outputKind, languageVersion, nullableContextOptions, allowUnsafeCode, checkForOverflowUnderflow,
                     documentationFile, preprocessorSymbolNames, suppressedDiagnosticIds, warningsAsErrors, warningsNotAsErrors, signAssembly, assemblyOriginatorKeyFile, treatWarningsAsErrors, defaultNamespace, runAnalyzers, runAnalyzersDuringLiveAnalysis, ruleset: null);
             }
 

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.ProjectData.cs
@@ -30,6 +30,7 @@ namespace OmniSharp.MSBuild.ProjectFile
 
             public string Configuration { get; }
             public string Platform { get; }
+            public string PlatformTarget { get; }
             public FrameworkName TargetFramework { get; }
             public ImmutableArray<string> TargetFrameworks { get; }
 
@@ -88,7 +89,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 Guid guid, string name,
                 string assemblyName, string targetPath, string outputPath, string intermediateOutputPath,
                 string projectAssetsFile,
-                string configuration, string platform,
+                string configuration, string platform, string platformTarget,
                 FrameworkName targetFramework,
                 ImmutableArray<string> targetFrameworks,
                 OutputKind outputKind,
@@ -121,6 +122,7 @@ namespace OmniSharp.MSBuild.ProjectFile
 
                 Configuration = configuration;
                 Platform = platform;
+                PlatformTarget = platformTarget;
                 TargetFramework = targetFramework;
                 TargetFrameworks = targetFrameworks.EmptyIfDefault();
 
@@ -253,6 +255,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                 var projectAssetsFile = projectInstance.GetPropertyValue(PropertyNames.ProjectAssetsFile);
                 var configuration = projectInstance.GetPropertyValue(PropertyNames.Configuration);
                 var platform = projectInstance.GetPropertyValue(PropertyNames.Platform);
+                var platformTarget = projectInstance.GetPropertyValue(PropertyNames.PlatformTarget);
                 var defaultNamespace = projectInstance.GetPropertyValue(PropertyNames.RootNamespace);
 
                 var targetFramework = new FrameworkName(projectInstance.GetPropertyValue(PropertyNames.TargetFrameworkMoniker));
@@ -346,6 +349,7 @@ namespace OmniSharp.MSBuild.ProjectFile
                     projectAssetsFile,
                     configuration,
                     platform,
+                    platformTarget,
                     targetFramework,
                     targetFrameworks,
                     outputKind,

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -34,6 +34,7 @@ namespace OmniSharp.MSBuild.ProjectFile
 
         public string Configuration => _data.Configuration;
         public string Platform => _data.Platform;
+        public string PlatformTarget => _data.PlatformTarget;
         public FrameworkName TargetFramework => _data.TargetFramework;
         public ImmutableArray<string> TargetFrameworks => _data.TargetFrameworks;
 

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
@@ -24,6 +24,12 @@ namespace OmniSharp.MSBuild.ProjectFile
                         .WithSpecificDiagnosticOptions(projectFileInfo.GetDiagnosticOptions())
                         .WithOverflowChecks(projectFileInfo.CheckForOverflowUnderflow);
 
+            var platformTarget = ParsePlatform(projectFileInfo.PlatformTarget);
+            if (platformTarget != compilationOptions.Platform)
+            {
+                compilationOptions = compilationOptions.WithPlatform(platformTarget);
+            }
+
             if (projectFileInfo.AllowUnsafeCode != compilationOptions.AllowUnsafe)
             {
                 compilationOptions = compilationOptions.WithAllowUnsafe(projectFileInfo.AllowUnsafeCode);
@@ -111,5 +117,17 @@ namespace OmniSharp.MSBuild.ProjectFile
 
             return projectFileInfo.Analyzers.Select(analyzerCandicatePath => new AnalyzerFileReference(analyzerCandicatePath, analyzerAssemblyLoader)).ToImmutableArray();
         }
+
+        private static Platform ParsePlatform(string value) => (value.ToLowerInvariant()) switch
+        {
+            "x86" => Platform.X86,
+            "x64" => Platform.X64,
+            "itanium" => Platform.Itanium,
+            "anycpu" => Platform.AnyCpu,
+            "anycpu32bitpreferred" => Platform.AnyCpu32BitPreferred,
+            "arm" => Platform.Arm,
+            "arm64" => Platform.Arm64,
+            _ => Platform.AnyCpu,
+        };
     }
 }

--- a/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/ProjectFileInfoExtensions.cs
@@ -118,7 +118,7 @@ namespace OmniSharp.MSBuild.ProjectFile
             return projectFileInfo.Analyzers.Select(analyzerCandicatePath => new AnalyzerFileReference(analyzerCandicatePath, analyzerAssemblyLoader)).ToImmutableArray();
         }
 
-        private static Platform ParsePlatform(string value) => (value.ToLowerInvariant()) switch
+        private static Platform ParsePlatform(string value) => (value?.ToLowerInvariant()) switch
         {
             "x86" => Platform.X86,
             "x64" => Platform.X64,

--- a/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
+++ b/src/OmniSharp.MSBuild/ProjectFile/PropertyNames.cs
@@ -25,6 +25,7 @@
         public const string Nullable = nameof(Nullable);
         public const string OutputPath = nameof(OutputPath);
         public const string Platform = nameof(Platform);
+        public const string PlatformTarget = nameof(PlatformTarget);
         public const string ProjectAssetsFile = nameof(ProjectAssetsFile);
         public const string ProvideCommandLineArgs = nameof(ProvideCommandLineArgs);
         public const string ProjectGuid = nameof(ProjectGuid);

--- a/test-assets/test-projects/HelloWorld/HelloWorld.csproj
+++ b/test-assets/test-projects/HelloWorld/HelloWorld.csproj
@@ -6,6 +6,7 @@
     <LangVersion>7.1</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
 </Project>

--- a/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/ProjectFileInfoTests.cs
@@ -17,11 +17,13 @@ namespace OmniSharp.MSBuild.Tests
     public class ProjectFileInfoTests : AbstractTestFixture
     {
         private readonly TestAssets _testAssets;
+        private readonly SharedOmniSharpHostFixture _sharedOmniSharpHostFixture;
 
-        public ProjectFileInfoTests(ITestOutputHelper output)
-            : base(output)
+        public ProjectFileInfoTests(ITestOutputHelper output, SharedOmniSharpHostFixture sharedOmniSharpHostFixture)
+            : base(output, sharedOmniSharpHostFixture)
         {
-            this._testAssets = TestAssets.Instance;
+            _testAssets = TestAssets.Instance;
+            _sharedOmniSharpHostFixture = sharedOmniSharpHostFixture;
         }
 
         private ProjectFileInfo CreateProjectFileInfo(OmniSharpTestHost host, ITestProject testProject, string projectFilePath)
@@ -45,12 +47,11 @@ namespace OmniSharp.MSBuild.Tests
         [Fact]
         public async Task HelloWorld_has_correct_property_values()
         {
-            using (var host = CreateOmniSharpHost())
             using (var testProject = await _testAssets.GetTestProjectAsync("HelloWorld"))
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "HelloWorld.csproj");
 
-                var projectFileInfo = CreateProjectFileInfo(host, testProject, projectFilePath);
+                var projectFileInfo = CreateProjectFileInfo(_sharedOmniSharpHostFixture.OmniSharpTestHost, testProject, projectFilePath);
 
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
@@ -63,9 +64,11 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.True(projectFileInfo.TreatWarningsAsErrors);
                 Assert.Equal("Debug", projectFileInfo.Configuration);
                 Assert.Equal("AnyCPU", projectFileInfo.Platform);
+                Assert.Equal("x64", projectFileInfo.PlatformTarget);
 
                 var compilationOptions = projectFileInfo.CreateCompilationOptions();
                 Assert.Equal(ReportDiagnostic.Error, compilationOptions.GeneralDiagnosticOption);
+                Assert.Equal(Platform.X64, compilationOptions.Platform);
                 Assert.True(compilationOptions.CheckOverflow);
             }
         }
@@ -73,12 +76,11 @@ namespace OmniSharp.MSBuild.Tests
         [Fact]
         public async Task HelloWorldSlim_has_correct_property_values()
         {
-            using (var host = CreateOmniSharpHost())
             using (var testProject = await _testAssets.GetTestProjectAsync("HelloWorldSlim"))
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "HelloWorldSlim.csproj");
 
-                var projectFileInfo = CreateProjectFileInfo(host, testProject, projectFilePath);
+                var projectFileInfo = CreateProjectFileInfo(_sharedOmniSharpHostFixture.OmniSharpTestHost, testProject, projectFilePath);
 
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
@@ -89,9 +91,11 @@ namespace OmniSharp.MSBuild.Tests
                 Assert.Equal(3, projectFileInfo.SourceFiles.Length); // Program.cs, AssemblyInfo.cs, AssemblyAttributes.cs
                 Assert.Equal("Debug", projectFileInfo.Configuration);
                 Assert.Equal("AnyCPU", projectFileInfo.Platform);
+                Assert.Equal("", projectFileInfo.PlatformTarget);
 
                 var compilationOptions = projectFileInfo.CreateCompilationOptions();
                 Assert.Equal(ReportDiagnostic.Default, compilationOptions.GeneralDiagnosticOption);
+                Assert.Equal(Platform.AnyCpu, compilationOptions.Platform);
                 Assert.False(compilationOptions.CheckOverflow);
             }
         }
@@ -99,12 +103,11 @@ namespace OmniSharp.MSBuild.Tests
         [Fact]
         public async Task NetStandardAndNetCoreApp_has_correct_property_values()
         {
-            using (var host = CreateOmniSharpHost())
             using (var testProject = await _testAssets.GetTestProjectAsync("NetStandardAndNetCoreApp"))
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "NetStandardAndNetCoreApp.csproj");
 
-                var projectFileInfo = CreateProjectFileInfo(host, testProject, projectFilePath);
+                var projectFileInfo = CreateProjectFileInfo(_sharedOmniSharpHostFixture.OmniSharpTestHost, testProject, projectFilePath);
 
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
@@ -122,12 +125,11 @@ namespace OmniSharp.MSBuild.Tests
         [Fact]
         public async Task CSharp8AndNullableContext_has_correct_property_values()
         {
-            using (var host = CreateOmniSharpHost())
             using (var testProject = await _testAssets.GetTestProjectAsync("CSharp8AndNullableContext"))
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "CSharp8AndNullableContext.csproj");
 
-                var projectFileInfo = CreateProjectFileInfo(host, testProject, projectFilePath);
+                var projectFileInfo = CreateProjectFileInfo(_sharedOmniSharpHostFixture.OmniSharpTestHost, testProject, projectFilePath);
 
                 Assert.NotNull(projectFileInfo);
                 Assert.Equal(projectFilePath, projectFileInfo.FilePath);
@@ -146,11 +148,10 @@ namespace OmniSharp.MSBuild.Tests
         [Fact]
         public async Task ExternAliasWithReference()
         {
-            using (var host = CreateOmniSharpHost())
             using (var testProject = await _testAssets.GetTestProjectAsync("ExternAlias"))
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "ExternAlias.App", "ExternAlias.App.csproj");
-                var projectFileInfo = CreateProjectFileInfo(host, testProject, projectFilePath);
+                var projectFileInfo = CreateProjectFileInfo(_sharedOmniSharpHostFixture.OmniSharpTestHost, testProject, projectFilePath);
                 Assert.Single(projectFileInfo.ReferenceAliases);
                 foreach (var kv in projectFileInfo.ReferenceAliases)
                 {
@@ -166,11 +167,10 @@ namespace OmniSharp.MSBuild.Tests
         [Fact]
         public async Task ExternAliasWithProjectReference()
         {
-            using (var host = CreateOmniSharpHost())
             using (var testProject = await _testAssets.GetTestProjectAsync("ExternAlias"))
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "ExternAlias.App2", "ExternAlias.App2.csproj");
-                var projectFileInfo = CreateProjectFileInfo(host, testProject, projectFilePath);
+                var projectFileInfo = CreateProjectFileInfo(_sharedOmniSharpHostFixture.OmniSharpTestHost, testProject, projectFilePath);
                 Assert.Single(projectFileInfo.ProjectReferenceAliases);
                 foreach (var kv in projectFileInfo.ProjectReferenceAliases)
                 {
@@ -186,11 +186,10 @@ namespace OmniSharp.MSBuild.Tests
         [Fact]
         public async Task AllowUnsafe()
         {
-            using (var host = CreateOmniSharpHost())
             using (var testProject = await _testAssets.GetTestProjectAsync("AllowUnsafe"))
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "AllowUnsafe.csproj");
-                var projectFileInfo = CreateProjectFileInfo(host, testProject, projectFilePath);
+                var projectFileInfo = CreateProjectFileInfo(_sharedOmniSharpHostFixture.OmniSharpTestHost, testProject, projectFilePath);
                 Assert.True(projectFileInfo.AllowUnsafeCode);
 
                 var compilationOptions = projectFileInfo.CreateCompilationOptions();
@@ -202,11 +201,10 @@ namespace OmniSharp.MSBuild.Tests
         [Fact]
         public async Task WarningsAsErrors()
         {
-            using (var host = CreateOmniSharpHost())
             using (var testProject = await _testAssets.GetTestProjectAsync("WarningsAsErrors"))
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "WarningsAsErrors.csproj");
-                var projectFileInfo = CreateProjectFileInfo(host, testProject, projectFilePath);
+                var projectFileInfo = CreateProjectFileInfo(_sharedOmniSharpHostFixture.OmniSharpTestHost, testProject, projectFilePath);
                 Assert.NotEmpty(projectFileInfo.WarningsAsErrors);
                 Assert.Contains("CS1998", projectFileInfo.WarningsAsErrors);
                 Assert.Contains("CS7080", projectFileInfo.WarningsAsErrors);
@@ -233,11 +231,10 @@ namespace OmniSharp.MSBuild.Tests
         [Fact]
         public async Task ProjectReferenceProducingAnalyzerItems()
         {
-            using (var host = CreateOmniSharpHost())
             using (var testProject = await _testAssets.GetTestProjectAsync("ProjectWithAnalyzersFromReference"))
             {
                 var projectFilePath = Path.Combine(testProject.Directory, "ConsumingProject", "ConsumingProject.csproj");
-                var projectFileInfo = CreateProjectFileInfo(host, testProject, projectFilePath);
+                var projectFileInfo = CreateProjectFileInfo(_sharedOmniSharpHostFixture.OmniSharpTestHost, testProject, projectFilePath);
                 Assert.Empty(projectFileInfo.ProjectReferences);
                 var analyzerFileReference = Assert.Single(projectFileInfo.Analyzers);
                 Assert.EndsWith("Analyzer.dll", analyzerFileReference);


### PR DESCRIPTION
`Platform` property of the compilation options should be [based on](https://github.com/dotnet/roslyn/issues/29369#issuecomment-414354632) the `PlatformTarget` MSBuild property.