### PR TITLE
Do not crash on startup when configuration is invalid

### DIFF
--- a/src/OmniSharp.Host/ConfigurationBuilder.cs
+++ b/src/OmniSharp.Host/ConfigurationBuilder.cs
@@ -19,30 +19,30 @@ namespace OmniSharp
 
         public ConfigurationResult Build(Action<IConfigurationBuilder> additionalSetup = null)
         {
-            var configBuilder = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
-                .SetBasePath(AppContext.BaseDirectory)
-                .AddEnvironmentVariables("OMNISHARP_");
-
-            if (_environment.AdditionalArguments?.Length > 0)
-            {
-                configBuilder.AddCommandLine(_environment.AdditionalArguments);
-            }
-
-            // Use the global omnisharp config if there's any in the shared path
-            configBuilder.CreateAndAddGlobalOptionsFile(_environment);
-
-            // Use the local omnisharp config if there's any in the root path
-            configBuilder.AddJsonFile(
-                new PhysicalFileProvider(_environment.TargetDirectory).WrapForPolling(),
-                Constants.OptionsFile,
-                optional: true,
-                reloadOnChange: true);
-
-            // bootstrap additional host configuration at the end
-            additionalSetup?.Invoke(configBuilder);
-
             try
             {
+                var configBuilder = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
+                    .SetBasePath(AppContext.BaseDirectory)
+                    .AddEnvironmentVariables("OMNISHARP_");
+
+                if (_environment.AdditionalArguments?.Length > 0)
+                {
+                    configBuilder.AddCommandLine(_environment.AdditionalArguments);
+                }
+
+                // Use the global omnisharp config if there's any in the shared path
+                configBuilder.CreateAndAddGlobalOptionsFile(_environment);
+
+                // Use the local omnisharp config if there's any in the root path
+                configBuilder.AddJsonFile(
+                    new PhysicalFileProvider(_environment.TargetDirectory).WrapForPolling(),
+                    Constants.OptionsFile,
+                    optional: true,
+                    reloadOnChange: true);
+
+                // bootstrap additional host configuration at the end
+                additionalSetup?.Invoke(configBuilder);
+
                 var config = configBuilder.Build();
                 return new ConfigurationResult(config);
             }

--- a/src/OmniSharp.Host/ConfigurationResult.cs
+++ b/src/OmniSharp.Host/ConfigurationResult.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.Extensions.Configuration;
+
+namespace OmniSharp
+{
+    public class ConfigurationResult
+    {
+        public ConfigurationResult(IConfigurationRoot configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public ConfigurationResult(Exception exception)
+        {
+            Exception = exception;
+            Configuration = new ConfigurationRoot(Array.Empty<IConfigurationProvider>());
+        }
+
+        public IConfigurationRoot Configuration { get; }
+
+        public Exception Exception { get; }
+
+        public bool HasError() => Exception != null;
+    }
+}

--- a/src/OmniSharp.Http/Startup.cs
+++ b/src/OmniSharp.Http/Startup.cs
@@ -32,8 +32,8 @@ namespace OmniSharp.Http
 
         public IServiceProvider ConfigureServices(IServiceCollection services)
         {
-            var configuration = new ConfigurationBuilder(_environment).Build();
-            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_environment, configuration, _eventEmitter, services,
+            var configurationResult = new ConfigurationBuilder(_environment).Build();
+            var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(_environment, configurationResult.Configuration, _eventEmitter, services,
                 configureLogging: builder =>
                 {
                     builder.AddConsole();
@@ -56,6 +56,12 @@ namespace OmniSharp.Http
 
             var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger<Startup>();
+
+            if (configurationResult.HasError())
+            {
+                logger.LogError(configurationResult.Exception, "There was an error when reading the OmniSharp configuration, starting with the default options.");
+            }
+
             var assemblyLoader = serviceProvider.GetRequiredService<IAssemblyLoader>();
             _compositionHost = new CompositionHostBuilder(serviceProvider)
                 .WithOmniSharpAssemblies()

--- a/src/OmniSharp.Stdio.Driver/Program.cs
+++ b/src/OmniSharp.Stdio.Driver/Program.cs
@@ -51,9 +51,9 @@ namespace OmniSharp.Stdio.Driver
 
                     var environment = application.CreateEnvironment();
                     Configuration.ZeroBasedIndices = application.ZeroBasedIndices;
-                    var configuration = new ConfigurationBuilder(environment).Build();
+                    var configurationResult = new ConfigurationBuilder(environment).Build();
                     var writer = new SharedTextWriter(output);
-                    var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(environment, configuration, new StdioEventEmitter(writer),
+                    var serviceProvider = CompositionHostBuilder.CreateDefaultServiceProvider(environment, configurationResult.Configuration, new StdioEventEmitter(writer),
                         configureLogging: builder => builder.AddStdio(writer));
 
                     var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
@@ -63,6 +63,10 @@ namespace OmniSharp.Stdio.Driver
                     var plugins = application.CreatePluginAssemblies(options.CurrentValue, environment);
 
                     var logger = loggerFactory.CreateLogger<Program>();
+                    if (configurationResult.HasError())
+                    {
+                        logger.LogError(configurationResult.Exception, "There was an error when reading the OmniSharp configuration, starting with the default options.");
+                    }
                     var compositionHostBuilder = new CompositionHostBuilder(serviceProvider)
                         .WithOmniSharpAssemblies()
                         .WithAssemblies(assemblyLoader.LoadByAssemblyNameOrPath(logger, plugins.AssemblyNames).ToArray());

--- a/tests/OmniSharp.Tests/ConfigurationBuilderFacts.cs
+++ b/tests/OmniSharp.Tests/ConfigurationBuilderFacts.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using OmniSharp.Services;
+using Xunit;
+
+namespace OmniSharp.Tests
+{
+    public class ConfigurationBuilderFacts
+    {
+        [Fact]
+        public void CustomConfigCanBeAdded()
+        {
+            var env = new OmniSharpEnvironment();
+            var builder = new ConfigurationBuilder(env);
+            var result = builder.Build(c => c.AddInMemoryCollection(new Dictionary<string, string> { { "key", "value" } }));
+
+            Assert.False(result.HasError());
+            Assert.Equal("value", result.Configuration["key"]);
+        }
+
+        [Fact]
+        public void EnvironmentVariableCanBeRead()
+        {
+            var tempValue = Guid.NewGuid().ToString("d");
+            try
+            {
+                Environment.SetEnvironmentVariable("OMNISHARP_testValue", tempValue);
+                var env = new OmniSharpEnvironment();
+                var builder = new ConfigurationBuilder(env);
+                var result = builder.Build(c => c.AddInMemoryCollection());
+
+                Assert.False(result.HasError());
+                Assert.Equal(tempValue, result.Configuration["testValue"]);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("OMNISHARP_testValue", null);
+            }
+        }
+
+        [Fact]
+        public void FileArgsCanBeRead()
+        {
+            var env = new OmniSharpEnvironment(additionalArguments: new string[] { "key:nestedKey=value" });
+            var builder = new ConfigurationBuilder(env);
+            var result = builder.Build();
+
+            Assert.False(result.HasError());
+            Assert.Equal("value", result.Configuration["key:nestedKey"]);
+        }
+
+        [Fact]
+        public void DoesNotCrashOnException()
+        {
+            var env = new OmniSharpEnvironment();
+            var builder = new ConfigurationBuilder(env);
+            var result = builder.Build(c => throw new Exception("bad thing happened"));
+
+            Assert.True(result.HasError());
+            Assert.NotNull(result.Configuration);
+            Assert.Empty(result.Configuration.AsEnumerable());
+        }
+    }
+}


### PR DESCRIPTION
At the moment when bootstrapping configuration, if anything invalid is found (e.g. JSON structure is bad) we have an unhandled exception and failure to start.

Since the config is really optional I think it is better to swallow the exception, log an error and start with default config. This has been source of several issues already (got closed after the user fixed the config on their side).

since when the config is bootstrapped, the DI container is not yet initialized, logging of the possible error is deferred until the logger is available.