### PR TITLE
Updated IL Spy to 7.0.0 stable

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -15,7 +15,7 @@
 
         <PackageReference Update="Dotnet.Script.DependencyModel" Version="1.0.2" />
         <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="1.0.1" />
-        <PackageReference Update="ICSharpCode.Decompiler" Version="7.0.0.6372-preview3" />
+        <PackageReference Update="ICSharpCode.Decompiler" Version="7.0.0.6488" />
         <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
 
         <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="$(AspNetCorePackageVersion)" />

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
@@ -483,7 +483,7 @@ class Bar {
             // second comment should indicate we have decompiled
             var comments = compilationUnit.DescendantTrivia().Where(t => t.Kind() == SyntaxKind.SingleLineCommentTrivia).ToArray();
             Assert.NotNull(comments);
-            Assert.Equal("// Decompiled with ICSharpCode.Decompiler 7.0.0.6372", comments[1].ToString());
+            Assert.Equal("// Decompiled with ICSharpCode.Decompiler 7.0.0.6488", comments[1].ToString());
 
             // contrary to regular metadata, we should have methods with full bodies
             // this condition would fail if decompilation wouldn't work


### PR DESCRIPTION
IL Spy 7 was released this week - since we are on a preview, it makes sense for us to update to it as well.