### PR TITLE
OmniSharpDocumentSymbolHandler.cs: a fix for a crash in 'textDocument/documentSymbol` LSP request

### DIFF
--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpDocumentSymbolHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpDocumentSymbolHandler.cs
@@ -41,7 +41,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
 
             var omnisharpResponse = await _codeStructureHandler.Handle(omnisharpRequest);
 
-            return omnisharpResponse.Elements?.Select(ToDocumentSymbolInformationOrDocumentSymbol).ToArray() ??
+            return omnisharpResponse?.Elements?.Select(ToDocumentSymbolInformationOrDocumentSymbol).ToArray() ??
                 Array.Empty<SymbolInformationOrDocumentSymbol>();
         }
 


### PR DESCRIPTION
The NRE may happen when OS.R.CS.Services.Structure.CodeStructureService
returns a null during the time when projects are still being loaded but
LSP client already sends queries for symbol info under cursor.

Reported in and should fix https://github.com/OmniSharp/omnisharp-roslyn/issues/2141