### PR TITLE
LSP: update OmniSharpCodeHandler so we support codeAction/resolve

### DIFF
--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -381,7 +381,7 @@ namespace OmniSharp.LanguageServerProtocol
                     .Concat(OmniSharpReferencesHandler.Enumerate(handlers))
                     .Concat(OmniSharpImplementationHandler.Enumerate(handlers))
                     .Concat(OmniSharpCodeLensHandler.Enumerate(handlers))
-                    .Concat(OmniSharpCodeActionHandler.Enumerate(handlers, serializer, server, documentVersions))
+                    .Concat(OmniSharpCodeActionHandler.Enumerate(handlers, server, documentVersions))
                     .Concat(OmniSharpDocumentFormattingHandler.Enumerate(handlers))
                     .Concat(OmniSharpDocumentFormatRangeHandler.Enumerate(handlers))
                     .Concat(OmniSharpDocumentOnTypeFormattingHandler.Enumerate(handlers)))


### PR DESCRIPTION
This feature was introduced in LSP
3.16.0 https://microsoft.github.io/language-server-protocol/specification#codeAction_resolve
and allows us to drop the hack where we were introducing a special
"omnisharp/executeCodeAction" command to delay the resolution of code
action changesets until user actually selets that code
action: see https://github.com/OmniSharp/omnisharp-roslyn/pull/1814.

Related to:
- https://github.com/OmniSharp/omnisharp-roslyn/issues/2068
- https://github.com/OmniSharp/omnisharp-roslyn/pull/1814