### PR TITLE
Do not return null responses from BlockStructureService and CodeStructureService

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Structure/BlockStructureService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Structure/BlockStructureService.cs
@@ -56,7 +56,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
             var document = await _workspace.GetDocumentFromFullProjectModelAsync(request.FileName);
             if (document == null)
             {
-                return null;
+                return new BlockStructureResponse();
             }
 
             var text = await document.GetTextAsync();

--- a/src/OmniSharp.Roslyn.CSharp/Services/Structure/BlockStructureService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Structure/BlockStructureService.cs
@@ -56,7 +56,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
             var document = await _workspace.GetDocumentFromFullProjectModelAsync(request.FileName);
             if (document == null)
             {
-                return new BlockStructureResponse();
+                return new BlockStructureResponse { Spans = Array.Empty<CodeFoldingBlock>() };
             }
 
             var text = await document.GetTextAsync();

--- a/src/OmniSharp.Roslyn.CSharp/Services/Structure/CodeStructureService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Structure/CodeStructureService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading.Tasks;
@@ -36,7 +37,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
             var document = await _workspace.GetDocumentFromFullProjectModelAsync(request.FileName);
             if (document == null)
             {
-                return new CodeStructureResponse();
+                return new CodeStructureResponse { Elements = Array.Empty<CodeElement>() };
             }
 
             var elements = await GetCodeElementsAsync(document);

--- a/src/OmniSharp.Roslyn.CSharp/Services/Structure/CodeStructureService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Structure/CodeStructureService.cs
@@ -36,7 +36,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Structure
             var document = await _workspace.GetDocumentFromFullProjectModelAsync(request.FileName);
             if (document == null)
             {
-                return null;
+                return new CodeStructureResponse();
             }
 
             var elements = await GetCodeElementsAsync(document);

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/BlockStructureFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/BlockStructureFacts.cs
@@ -42,6 +42,21 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         }
 
         [Fact]
+        public async Task NonExistingFile()
+        {
+            var request = new BlockStructureRequest
+            {
+                FileName = "foo.cs"
+            };
+
+            var requestHandler = GetRequestHandler(SharedOmniSharpTestHost);
+            var response = await requestHandler.Handle(request);
+
+            Assert.NotNull(response);
+            Assert.Null(response.Spans);
+        }
+
+        [Fact]
         public async Task SupportsRegionBlocks()
         {
             var testFile = new TestFile("foo.cs", @"

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/BlockStructureFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/BlockStructureFacts.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using OmniSharp.Models.V2;
@@ -46,14 +47,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         {
             var request = new BlockStructureRequest
             {
-                FileName = "foo.cs"
+                FileName = $"{Guid.NewGuid().ToString("N")}.cs"
             };
 
             var requestHandler = GetRequestHandler(SharedOmniSharpTestHost);
             var response = await requestHandler.Handle(request);
 
             Assert.NotNull(response);
-            Assert.Null(response.Spans);
+            Assert.Empty(response.Spans);
         }
 
         [Fact]

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CodeStructureFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CodeStructureFacts.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using OmniSharp.Mef;
@@ -418,14 +419,14 @@ class C
         {
             var request = new CodeStructureRequest
             {
-                FileName = "foo.cs"
+                FileName = $"{Guid.NewGuid().ToString("N")}.cs"
             };
 
             var requestHandler = GetRequestHandler(SharedOmniSharpTestHost);
             var response = await requestHandler.Handle(request);
 
             Assert.NotNull(response);
-            Assert.Null(response.Elements);
+            Assert.Empty(response.Elements);
         }
 
         private static void AssertRange(CodeElement elementC, TestContent content, string contentSpanName, string elementRangeName)

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CodeStructureFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CodeStructureFacts.cs
@@ -413,6 +413,21 @@ class C
             AssertRange(elementC.Children[15], testFile.Content, "nameThis", "name");
         }
 
+        [Fact]
+        public async Task NonExistingFile()
+        {
+            var request = new CodeStructureRequest
+            {
+                FileName = "foo.cs"
+            };
+
+            var requestHandler = GetRequestHandler(SharedOmniSharpTestHost);
+            var response = await requestHandler.Handle(request);
+
+            Assert.NotNull(response);
+            Assert.Null(response.Elements);
+        }
+
         private static void AssertRange(CodeElement elementC, TestContent content, string contentSpanName, string elementRangeName)
         {
             var span = Assert.Single(content.GetSpans(contentSpanName));


### PR DESCRIPTION
We have a convention where we don't return `null` from services but an empty response instead - e.g. https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Roslyn.CSharp/Services/Navigation/FindSymbolsService.cs#L28 or https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs#L107

This simplifies client integration. Adapted `BlockStructureService` and `CodeStructureService` accordingly.