### PR TITLE
Only subscribe to AppDomain.AssemblyResolve once

### DIFF
--- a/src/OmniSharp.Host/Services/AnalyzerAssemblyLoader.cs
+++ b/src/OmniSharp.Host/Services/AnalyzerAssemblyLoader.cs
@@ -231,7 +231,7 @@ namespace OmniSharp.Host.Services
             string assemblyDirectory = CreateUniqueDirectoryForAssembly();
             string shadowCopyPath = CopyFileAndResources(originalPath, assemblyDirectory);
 
-            if (Interlocked.CompareExchange(ref _hookedAssemblyResolve, 0, 1) == 0)
+            if (Interlocked.CompareExchange(ref _hookedAssemblyResolve, value: 1, comparand: 0) == 0)
             {
                 AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
             }


### PR DESCRIPTION
This is a port of https://github.com/dotnet/roslyn/pull/53166. There's a bigger question here about how to reuse this code better, but this caused a bunch of confusion while debugging an issue.