### PR TITLE
Add support for GoToDefinition on source-generated files

### DIFF
--- a/src/OmniSharp.Abstractions/Models/v1/GotoDefinition/GotoDefinitionResponse.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/GotoDefinition/GotoDefinitionResponse.cs
@@ -1,16 +1,20 @@
+#nullable enable
+
 using Newtonsoft.Json;
 using OmniSharp.Models.Metadata;
+using OmniSharp.Models.v1.SourceGeneratedFile;
 
 namespace OmniSharp.Models.GotoDefinition
 {
     public class GotoDefinitionResponse : ICanBeEmptyResponse
     {
-        public string FileName { get; set; }
+        public string? FileName { get; set; }
         [JsonConverter(typeof(ZeroBasedIndexConverter))]
         public int Line { get; set; }
         [JsonConverter(typeof(ZeroBasedIndexConverter))]
         public int Column { get; set; }
-        public MetadataSource MetadataSource { get; set; }
+        public MetadataSource? MetadataSource { get; set; }
+        public SourceGeneratedFileInfo? SourceGeneratedInfo { get; set; }
         public bool IsEmpty => string.IsNullOrWhiteSpace(FileName) && MetadataSource == null;
     }
 }

--- a/src/OmniSharp.Abstractions/Models/v1/GotoDefinition/GotoDefinitionResponse.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/GotoDefinition/GotoDefinitionResponse.cs
@@ -15,6 +15,6 @@ namespace OmniSharp.Models.GotoDefinition
         public int Column { get; set; }
         public MetadataSource? MetadataSource { get; set; }
         public SourceGeneratedFileInfo? SourceGeneratedInfo { get; set; }
-        public bool IsEmpty => string.IsNullOrWhiteSpace(FileName) && MetadataSource == null;
+        public bool IsEmpty => string.IsNullOrWhiteSpace(FileName) && MetadataSource == null && SourceGeneratedInfo == null;
     }
 }

--- a/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/SourceGeneratedFileClosedRequest.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/SourceGeneratedFileClosedRequest.cs
@@ -1,0 +1,11 @@
+﻿#nullable enable
+
+using OmniSharp.Mef;
+
+namespace OmniSharp.Models.v1.SourceGeneratedFile
+{
+    [OmniSharpEndpoint(OmniSharpEndpoints.SourceGeneratedFileClosed, typeof(SourceGeneratedFileClosedRequest), typeof(SourceGeneratedFileClosedResponse))]
+    public sealed record SourceGeneratedFileClosedRequest : SourceGeneratedFileInfo, IRequest
+    {
+    }
+}

--- a/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/SourceGeneratedFileClosedResponse.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/SourceGeneratedFileClosedResponse.cs
@@ -1,0 +1,10 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+
+namespace OmniSharp.Models.v1.SourceGeneratedFile
+{
+    public sealed class SourceGeneratedFileClosedResponse
+    {
+        public static readonly Task<SourceGeneratedFileClosedResponse> Instance = Task.FromResult(new SourceGeneratedFileClosedResponse());
+    }
+}

--- a/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/SourceGeneratedFileInfo.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/SourceGeneratedFileInfo.cs
@@ -1,0 +1,12 @@
+﻿#nullable enable
+
+using System;
+
+namespace OmniSharp.Models.v1.SourceGeneratedFile
+{
+    public record SourceGeneratedFileInfo
+    {
+        public Guid ProjectGuid { get; init; }
+        public Guid DocumentGuid { get; init; }
+    }
+}

--- a/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/SourceGeneratedFileRequest.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/SourceGeneratedFileRequest.cs
@@ -1,0 +1,12 @@
+﻿#nullable enable
+
+using OmniSharp.Mef;
+using System;
+
+namespace OmniSharp.Models.v1.SourceGeneratedFile
+{
+    [OmniSharpEndpoint(OmniSharpEndpoints.SourceGeneratedFile, typeof(SourceGeneratedFileRequest), typeof(SourceGeneratedFileResponse))]
+    public sealed record SourceGeneratedFileRequest : SourceGeneratedFileInfo, IRequest
+    {
+    }
+}

--- a/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/SourceGeneratedFileResponse.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/SourceGeneratedFileResponse.cs
@@ -1,0 +1,10 @@
+﻿#nullable enable
+
+namespace OmniSharp.Models.v1.SourceGeneratedFile
+{
+    public sealed record SourceGeneratedFileResponse
+    {
+        public string? SourceName { get; init; }
+        public string? Source { get; init; }
+    }
+}

--- a/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/UpdateSourceGeneratedFileRequest.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/UpdateSourceGeneratedFileRequest.cs
@@ -1,0 +1,10 @@
+﻿#nullable enable
+using OmniSharp.Mef;
+
+namespace OmniSharp.Models.v1.SourceGeneratedFile
+{
+    [OmniSharpEndpoint(OmniSharpEndpoints.UpdateSourceGeneratedFile, typeof(UpdateSourceGeneratedFileRequest), typeof(UpdateSourceGeneratedFileResponse))]
+    public sealed record UpdateSourceGeneratedFileRequest : SourceGeneratedFileInfo, IRequest
+    {
+    }
+}

--- a/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/UpdateSourceGeneratedFileResponse.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/SourceGeneratedFile/UpdateSourceGeneratedFileResponse.cs
@@ -1,0 +1,17 @@
+﻿#nullable enable
+
+namespace OmniSharp.Models.v1.SourceGeneratedFile
+{
+    public record UpdateSourceGeneratedFileResponse
+    {
+        public UpdateType UpdateType { get; init; }
+        public string? Source { get; init; }
+    }
+
+    public enum UpdateType
+    {
+        Unchanged,
+        Deleted,
+        Modified
+    }
+}

--- a/src/OmniSharp.Abstractions/Models/v2/GotoDefinition/GotoDefinitionResponse.cs
+++ b/src/OmniSharp.Abstractions/Models/v2/GotoDefinition/GotoDefinitionResponse.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using OmniSharp.Models.Metadata;
+using OmniSharp.Models.v1.SourceGeneratedFile;
 using System.Collections.Generic;
 
 namespace OmniSharp.Models.V2.GotoDefinition
@@ -14,5 +15,6 @@ namespace OmniSharp.Models.V2.GotoDefinition
     {
         public Location Location { get; init; } = null!;
         public MetadataSource? MetadataSource { get; init; }
+        public SourceGeneratedFileInfo? SourceGeneratedFileInfo { get; init; }
     }
 }

--- a/src/OmniSharp.Abstractions/OmniSharpEndpoints.cs
+++ b/src/OmniSharp.Abstractions/OmniSharpEndpoints.cs
@@ -51,6 +51,10 @@ namespace OmniSharp
         public const string CompletionResolve = "/completion/resolve";
         public const string CompletionAfterInsert = "/completion/afterinsert";
 
+        public const string SourceGeneratedFile = "/sourcegeneratedfile";
+        public const string UpdateSourceGeneratedFile = "/updatesourcegeneratedfile";
+        public const string SourceGeneratedFileClosed = "/sourcegeneratedfileclosed";
+
         public static class V2
         {
             public const string GetCodeActions = "/v2/getcodeactions";

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GoToDefinitionHelpers.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GoToDefinitionHelpers.cs
@@ -3,6 +3,8 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
 using OmniSharp.Extensions;
+using OmniSharp.Models.v1.SourceGeneratedFile;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -41,6 +43,22 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
             }
 
             return null;
+        }
+
+        internal static SourceGeneratedFileInfo? GetSourceGeneratedFileInfo(OmniSharpWorkspace workspace, Location location)
+        {
+            Debug.Assert(location.IsInSource);
+            var document = workspace.CurrentSolution.GetDocument(location.SourceTree);
+            if (document is not SourceGeneratedDocument)
+            {
+                return null;
+            }
+
+            return new SourceGeneratedFileInfo
+            {
+                ProjectGuid = document.Project.Id.Id,
+                DocumentGuid = document.Id.Id
+            };
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionService.cs
@@ -50,7 +50,8 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                 {
                     FileName = lineSpan.Path,
                     Line = lineSpan.StartLinePosition.Line,
-                    Column = lineSpan.StartLinePosition.Character
+                    Column = lineSpan.StartLinePosition.Character,
+                    SourceGeneratedInfo = GoToDefinitionHelpers.GetSourceGeneratedFileInfo(_workspace, location)
                 };
             }
             else if (location.IsInMetadata && request.WantMetadata)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionServiceV2.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionServiceV2.cs
@@ -49,7 +49,11 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                 return new GotoDefinitionResponse()
                 {
                     Definitions = symbol.Locations
-                        .Select(location => new Definition { Location = location.GetMappedLineSpan().GetLocationFromFileLinePositionSpan() })
+                        .Select(location => new Definition
+                        {
+                            Location = location.GetMappedLineSpan().GetLocationFromFileLinePositionSpan(),
+                            SourceGeneratedFileInfo = GoToDefinitionHelpers.GetSourceGeneratedFileInfo(_workspace, location)
+                        })
                         .ToList()
                 };
             }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/SourceGeneratedFileService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/SourceGeneratedFileService.cs
@@ -1,0 +1,105 @@
+﻿#nullable enable
+
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Mef;
+using OmniSharp.Models.v1.SourceGeneratedFile;
+using System.Collections.Generic;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OmniSharp.Roslyn.CSharp.Services.Navigation
+{
+    [Shared]
+    [OmniSharpHandler(OmniSharpEndpoints.SourceGeneratedFile, LanguageNames.CSharp)]
+    [OmniSharpHandler(OmniSharpEndpoints.UpdateSourceGeneratedFile, LanguageNames.CSharp)]
+    [OmniSharpHandler(OmniSharpEndpoints.SourceGeneratedFileClosed, LanguageNames.CSharp)]
+    public class SourceGeneratedFileService :
+        IRequestHandler<SourceGeneratedFileRequest, SourceGeneratedFileResponse>,
+        IRequestHandler<UpdateSourceGeneratedFileRequest, UpdateSourceGeneratedFileResponse>,
+        IRequestHandler<SourceGeneratedFileClosedRequest, SourceGeneratedFileClosedResponse>
+    {
+        private readonly OmniSharpWorkspace _workspace;
+        private readonly ILogger _logger;
+        private readonly Dictionary<DocumentId, VersionStamp> _lastSentVerisons = new();
+        private readonly object _lock = new();
+
+        [ImportingConstructor]
+        public SourceGeneratedFileService(OmniSharpWorkspace workspace, ILoggerFactory loggerFactory)
+        {
+            _workspace = workspace;
+            _logger = loggerFactory.CreateLogger<SourceGeneratedFileService>();
+        }
+
+        public async Task<SourceGeneratedFileResponse> Handle(SourceGeneratedFileRequest request)
+        {
+            var documentId = GetId(request);
+
+            var document = await _workspace.CurrentSolution.GetSourceGeneratedDocumentAsync(documentId, CancellationToken.None);
+
+            if (document is null)
+            {
+                _logger.LogError("Document with ID {0}:{1} was not found or not a source generated file", request.ProjectGuid, request.DocumentGuid);
+                return new SourceGeneratedFileResponse();
+            }
+
+            var text = await document.GetTextAsync();
+
+            var documentVerison = await document.GetTextVersionAsync();
+            lock (_lock)
+            {
+                _lastSentVerisons[documentId] = documentVerison;
+            }
+
+            return new SourceGeneratedFileResponse
+            {
+                Source = text.ToString(),
+                SourceName = document.FilePath
+            };
+        }
+
+        public async Task<UpdateSourceGeneratedFileResponse> Handle(UpdateSourceGeneratedFileRequest request)
+        {
+            var documentId = GetId(request);
+            var document = await _workspace.CurrentSolution.GetSourceGeneratedDocumentAsync(documentId, CancellationToken.None);
+            if (document == null)
+            {
+                lock (_lock)
+                {
+                    _ = _lastSentVerisons.Remove(documentId);
+                }
+                return new UpdateSourceGeneratedFileResponse() { UpdateType = UpdateType.Deleted };
+            }
+
+            var docVersion = await document.GetTextVersionAsync();
+            lock (_lock)
+            {
+                if (_lastSentVerisons.TryGetValue(documentId, out var lastVersion) && lastVersion == docVersion)
+                {
+                    return new UpdateSourceGeneratedFileResponse() { UpdateType = UpdateType.Unchanged };
+                }
+
+                _lastSentVerisons[documentId] = docVersion;
+            }
+
+            return new UpdateSourceGeneratedFileResponse()
+            {
+                UpdateType = UpdateType.Modified,
+                Source = (await document.GetTextAsync()).ToString()
+            };
+        }
+
+        public Task<SourceGeneratedFileClosedResponse> Handle(SourceGeneratedFileClosedRequest request)
+        {
+            lock (_lock)
+            {
+                _ = _lastSentVerisons.Remove(GetId(request));
+            }
+
+            return SourceGeneratedFileClosedResponse.Instance;
+        }
+
+        private DocumentId GetId(SourceGeneratedFileInfo info) => DocumentId.CreateFromSerialized(ProjectId.CreateFromSerialized(info.ProjectGuid), info.DocumentGuid);
+    }
+}

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/AbstractGoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/AbstractGoToDefinitionFacts.cs
@@ -526,6 +526,7 @@ class C
     public void M(Generated g)
     {
         _ = g.P$$roperty;
+    }
 }
 ");
 
@@ -534,7 +535,7 @@ class C
                 new[] { "netcoreapp3.1" },
                 new[] { testFile },
                 analyzerRefs: ImmutableArray.Create<AnalyzerReference>(new TestGeneratorReference(
-                    context => context.AddSource("GeneratedFile", Source))));
+                    context => context.AddSource("GeneratedFile", generatedTestFile.Content.Code))));
 
             var point = testFile.Content.GetPointFromPosition();
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/AbstractGoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/AbstractGoToDefinitionFacts.cs
@@ -562,7 +562,7 @@ class C
             var sourceGeneratedFileResponse = await sourceGeneratedFileHandler.Handle(sourceGeneratedRequest);
             Assert.NotNull(sourceGeneratedFileResponse);
             Assert.Equal(generatedTestFile.Content.Code, sourceGeneratedFileResponse.Source);
-            Assert.Equal(@"OmniSharp.Roslyn.CSharp.Tests\OmniSharp.Roslyn.CSharp.Tests.TestSourceGenerator\GeneratedFile.cs", sourceGeneratedFileResponse.SourceName);
+            Assert.Equal(@"OmniSharp.Roslyn.CSharp.Tests\OmniSharp.Roslyn.CSharp.Tests.TestSourceGenerator\GeneratedFile.cs", sourceGeneratedFileResponse.SourceName.Replace("/", @"\"));
         }
 
         protected async Task TestGoToSourceAsync(params TestFile[] testFiles)

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionFacts.cs
@@ -4,6 +4,7 @@ using OmniSharp.Models.Metadata;
 using TestUtility;
 using Xunit.Abstractions;
 using System.Collections.Generic;
+using OmniSharp.Models.v1.SourceGeneratedFile;
 
 namespace OmniSharp.Roslyn.CSharp.Tests
 {
@@ -26,14 +27,14 @@ namespace OmniSharp.Roslyn.CSharp.Tests
                 Timeout = timeout
             };
 
-        protected override IEnumerable<(int Line, int Column, string FileName)> GetInfo(GotoDefinitionResponse response)
+        protected override IEnumerable<(int Line, int Column, string FileName, SourceGeneratedFileInfo SourceGeneratorInfo)> GetInfo(GotoDefinitionResponse response)
         {
             if (response.IsEmpty)
             {
                 yield break;
             }
 
-            yield return (response.Line, response.Column, response.FileName);
+            yield return (response.Line, response.Column, response.FileName, response.SourceGeneratedInfo);
         }
 
         protected override MetadataSource GetMetadataSource(GotoDefinitionResponse response)

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionV2Facts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/GoToDefinitionV2Facts.cs
@@ -6,6 +6,7 @@ using Xunit;
 using Xunit.Abstractions;
 using System.Collections.Generic;
 using OmniSharp.Models.V2.GotoDefinition;
+using OmniSharp.Models.v1.SourceGeneratedFile;
 
 namespace OmniSharp.Roslyn.CSharp.Tests
 {
@@ -63,24 +64,20 @@ partial class {|def:Class|}
                 Timeout = timeout
             };
 
-        protected override IEnumerable<(int Line, int Column, string FileName)> GetInfo(GotoDefinitionResponse response)
+        protected override IEnumerable<(int Line, int Column, string FileName, SourceGeneratedFileInfo SourceGeneratorInfo)> GetInfo(GotoDefinitionResponse response)
         {
             if (response.Definitions is null)
                 yield break;
 
             foreach (var definition in response.Definitions)
             {
-                yield return (definition.Location.Range.Start.Line, definition.Location.Range.Start.Column, definition.Location.FileName);
+                yield return (definition.Location.Range.Start.Line, definition.Location.Range.Start.Column, definition.Location.FileName, definition.SourceGeneratedFileInfo);
             }
         }
 
         protected override MetadataSource GetMetadataSource(GotoDefinitionResponse response)
         {
-            if (response.Definitions?.Count != 1)
-            {
-                return null;
-            }
-
+            Assert.Single(response.Definitions);
             return response.Definitions[0].MetadataSource;
         }
     }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SourceGeneratorFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SourceGeneratorFacts.cs
@@ -1,0 +1,102 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using OmniSharp.Models.v1.SourceGeneratedFile;
+using OmniSharp.Models.V2.GotoDefinition;
+using OmniSharp.Roslyn.CSharp.Services.Buffer;
+using OmniSharp.Roslyn.CSharp.Services.Navigation;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using TestUtility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OmniSharp.Roslyn.CSharp.Tests
+{
+    public class SourceGeneratorFacts : AbstractTestFixture
+    {
+        public SourceGeneratorFacts(ITestOutputHelper output, SharedOmniSharpHostFixture sharedOmniSharpHostFixture) : base(output, sharedOmniSharpHostFixture)
+        {
+        }
+
+        [Fact]
+        public async Task UpdateReturnsChanges()
+        {
+            const string Code = @"
+_ = GeneratedCode.$$S;
+_ = ""Hello world!""";
+            const string Path = @"Test.cs";
+            var reference = new TestGeneratorReference(context =>
+            {
+                // NOTE: Don't actually do this in a real generator. This is just for test
+                // code. Do not use this as an example of what to do in production.
+
+                var syntax = context.Compilation.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().SingleOrDefault();
+                if (syntax != null)
+                {
+                    context.AddSource("GeneratedSource", @"
+class GeneratedCode
+{
+    public static string S = " + syntax.ToString() + @";
+}");
+                }
+            });
+
+            TestFile testFile = new TestFile(Path, Code);
+            TestHelpers.AddProjectToWorkspace(SharedOmniSharpTestHost.Workspace,
+                "project.csproj",
+                new[] { "netcoreapp3.1" },
+                new[] { testFile },
+                ImmutableArray.Create<AnalyzerReference>(reference));
+
+            var point = testFile.Content.GetPointFromPosition();
+
+            var gotoDefRequest = new GotoDefinitionRequest { FileName = Path, Line = point.Line, Column = point.Offset };
+            var gotoDefResponse = (await SharedOmniSharpTestHost
+                .GetRequestHandler<GotoDefinitionServiceV2>(OmniSharpEndpoints.V2.GotoDefinition)
+                .Handle(gotoDefRequest)).Definitions.Single();
+
+            var initialContent = await SharedOmniSharpTestHost
+                .GetRequestHandler<SourceGeneratedFileService>(OmniSharpEndpoints.SourceGeneratedFile)
+                .Handle(new SourceGeneratedFileRequest()
+                {
+                    ProjectGuid = gotoDefResponse.SourceGeneratedFileInfo.ProjectGuid,
+                    DocumentGuid = gotoDefResponse.SourceGeneratedFileInfo.DocumentGuid
+                });
+
+            Assert.Contains("Hello world!", initialContent.Source);
+
+            var updateRequest = new UpdateSourceGeneratedFileRequest
+            {
+                DocumentGuid = gotoDefResponse.SourceGeneratedFileInfo.DocumentGuid,
+                ProjectGuid = gotoDefResponse.SourceGeneratedFileInfo.ProjectGuid
+            };
+            var updateHandler = SharedOmniSharpTestHost.GetRequestHandler<SourceGeneratedFileService>(OmniSharpEndpoints.UpdateSourceGeneratedFile);
+            var updatedResponse = await updateHandler.Handle(updateRequest);
+            Assert.Null(updatedResponse.Source);
+            Assert.Equal(UpdateType.Unchanged, updatedResponse.UpdateType);
+
+            var updateBufferHandler = SharedOmniSharpTestHost.GetRequestHandler<UpdateBufferService>(OmniSharpEndpoints.UpdateBuffer);
+            _ = await updateBufferHandler.Handle(new()
+            {
+                FileName = Path,
+                Buffer = Code.Replace("Hello world!", "Goodbye!")
+            });
+
+            updatedResponse = await updateHandler.Handle(updateRequest);
+            Assert.Equal(UpdateType.Modified, updatedResponse.UpdateType);
+            Assert.Contains("Goodbye!", updatedResponse.Source);
+            Assert.DoesNotContain("Hello world!", updatedResponse.Source);
+
+            _ = await updateBufferHandler.Handle(new()
+            {
+                FileName = Path,
+                Buffer = @"_ = GeneratedCode.S;"
+            });
+
+            updatedResponse = await updateHandler.Handle(updateRequest);
+            Assert.Equal(UpdateType.Deleted, updatedResponse.UpdateType);
+            Assert.Null(updatedResponse.Source);
+        }
+    }
+}

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/TestSourceGenerator.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/TestSourceGenerator.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+
+namespace OmniSharp.Roslyn.CSharp.Tests
+{
+    public class TestSourceGenerator : ISourceGenerator
+    {
+
+        public TestSourceGenerator(Action<GeneratorExecutionContext> execute)
+        {
+            _execute = execute;
+        }
+
+        private readonly Action<GeneratorExecutionContext> _execute;
+
+        public void Execute(GeneratorExecutionContext context)
+        {
+            _execute(context);
+        }
+
+        public void Initialize(GeneratorInitializationContext context)
+        {
+        }
+    }
+
+    public class TestGeneratorReference : AnalyzerReference
+    {
+        private readonly bool _isEnabledByDefault;
+        private readonly Action<GeneratorExecutionContext> _execute;
+
+        public TestGeneratorReference(Action<GeneratorExecutionContext> execute, [CallerMemberName] string testId = "", bool isEnabledByDefault = true)
+        {
+            Id = testId;
+            _isEnabledByDefault = isEnabledByDefault;
+            _execute = execute;
+        }
+
+        public override ImmutableArray<ISourceGenerator> GetGenerators(string language)
+            => ImmutableArray.Create<ISourceGenerator>(new TestSourceGenerator(_execute));
+
+        public override ImmutableArray<ISourceGenerator> GetGeneratorsForAllLanguages()
+            => ImmutableArray.Create<ISourceGenerator>(new TestSourceGenerator(_execute));
+
+        public override string FullPath => null;
+        public override object Id { get; }
+        public override string Display => $"{nameof(TestGeneratorReference)}_{Id}";
+
+        public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language) => ImmutableArray<DiagnosticAnalyzer>.Empty;
+        public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages() => ImmutableArray<DiagnosticAnalyzer>.Empty;
+    }
+}


### PR DESCRIPTION
This adds a new response element to gotodefinition responses: SourceGeneratedFileInfo. This is similar to MetadataSource, except that unlike MetadataSource it's not tracked on a type/project basis, but rather as a document/project basis. Retrieving info about a source generated file can be done through the SourceGeneratedFileService endpoints:

* SourceGeneratedFileInfo - Gets the file content of a source generated file.
* UpdateSourceGeneratedFileInfo - Gets the updated content of a source generated file, if it has changed since the last time information was returned.
* SourceGeneratedFileClosed - Sent to the server to inform it that the editor has closed the generated file and it can stop tracking Document version info for that file.

Currently, the only way to get the info needed to open a source-generated file is via the gotodefinition endpoint. We'll want to add info to find-usages as well, but that's a job for another day. Contributes to https://github.com/OmniSharp/omnisharp-roslyn/issues/1934.
