### PR TITLE
Include timing info in logged responses

### DIFF
--- a/src/OmniSharp.Stdio/Host.cs
+++ b/src/OmniSharp.Stdio/Host.cs
@@ -31,6 +31,7 @@ namespace OmniSharp.Stdio
         private readonly IOmniSharpEnvironment _environment;
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly CachedStringBuilder _cachedStringBuilder;
+        private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
 
         public Host(
             TextReader input, ISharedTextWriter writer, IOmniSharpEnvironment environment,
@@ -193,8 +194,6 @@ namespace OmniSharp.Stdio
                 }
             }
         }
-
-        private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
 
         private async Task HandleRequest(string json, ILogger logger)
         {


### PR DESCRIPTION
If we log responses, we now do it with duration information.

For example:

```
        ************  Response (50.2536ms) ************ 
{
  "Request_seq": 6,
  "Command": "/codecheck",
  "Running": true,
  "Success": true,
  "Message": null,
  "Body": {
    "QuickFixes": []
  },
  "Seq": 416,
  "Type": "response"
}
```

or  

```
        ************  Response (4.0503ms) ************ 
{
  "Request_seq": 125,
  "Command": "/completion/resolve",
  "Running": true,
  "Success": true,
  "Message": null,
  "Body": {
    "Item": {
      "Label": "Console",
      "Kind": 7,
      "Tags": null,
      "Detail": "",
      "Documentation": "```csharp\nclass System.Console\n```\n\nRepresents the standard input, output, and error streams for console applications\\. This class cannot be inherited\\.",
      "Preselect": false,
      "SortText": null,
      "FilterText": null,
      "InsertTextFormat": 1,
      "TextEdit": {
        "NewText": "Console",
        "StartLine": 10,
        "StartColumn": 12,
        "EndLine": 10,
        "EndColumn": 13
      },
      "CommitCharacters": [
        " ",
        "{",
        "}",
        "[",
        "]",
        "(",
        ")",
        ".",
        ",",
        ":",
        ";",
        "+",
        "-",
        "*",
        "/",
        "%",
        "&",
        "|",
        "^",
        "!",
        "~",
        "=",
        "<",
        ">",
        "?",
        "@",
        "#",
        "'",
        "\"",
        "\\"
      ],
      "AdditionalTextEdits": null,
      "Data": {
        "Item1": 2,
        "Item2": 44
      },
      "HasAfterInsertStep": false
    }
  },
  "Seq": 831,
  "Type": "response"
}
```