### PR TITLE
Fix incorrect signature help trigger characters

### DIFF
--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs
@@ -73,7 +73,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
             return new SignatureHelpRegistrationOptions()
             {
                 DocumentSelector = _documentSelector,
-                TriggerCharacters = new[] {".", "?", "["}
+                TriggerCharacters = new[] { "(", ",", "<", "{", "[" }
             };
         }
     }


### PR DESCRIPTION
Fixes signature help UI in https://github.com/OmniSharp/omnisharp-roslyn/issues/2071 (sublime text) and https://github.com/ray-x/lsp_signature.nvim/issues/50 (neovim).

The VS Code plugin also currently ignores the incorrect signature help trigger characters delivered by this plugin and manually overrides them to `,` and `(`.

Fixing this will give a better out-of-the-box experience to all language-server supporting editors.

You can see here in the vs code's plugin where it's manually setting its own trigger characters:

https://github.com/OmniSharp/omnisharp-vscode/blob/master/src/omnisharp/extension.ts#L96