### PR TITLE
LSP: fix duplicate log messages

### DIFF
--- a/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
+++ b/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs
@@ -61,8 +61,6 @@ namespace OmniSharp.LanguageServerProtocol
             _options = new LanguageServerOptions()
                 .WithInput(input)
                 .WithOutput(output)
-                // initializeParams from the client won't be arriving yet, configure with app loglevel
-                .ConfigureLogging(GetLogBuilderAction(configureLogging, application.LogLevel))
                 .OnInitialize(Initialize)
                 .OnInitialized(Initialized)
                 .WithServices(ConfigureServices);
@@ -178,14 +176,6 @@ namespace OmniSharp.LanguageServerProtocol
             }
         }
 
-        private static Action<ILoggingBuilder> GetLogBuilderAction(Action<ILoggingBuilder> configureLogging, LogLevel loglevel) => builder =>
-        {
-            configureLogging?.Invoke(builder);
-            builder
-                .AddLanguageProtocolLogging()
-                .SetMinimumLevel(loglevel);
-        };
-
         private static (IServiceProvider serviceProvider, CompositionHost compositionHost) CreateCompositionHost(
             ILanguageServer server,
             InitializeParams initializeParams,
@@ -211,7 +201,12 @@ namespace OmniSharp.LanguageServerProtocol
 
             var serviceProvider =
                 CompositionHostBuilder.CreateDefaultServiceProvider(environment, configurationResult.Configuration, eventEmitter,
-                    services, GetLogBuilderAction(configureLogging, environment.LogLevel));
+                    services, builder => {
+                        configureLogging?.Invoke(builder);
+                        builder
+                            .AddLanguageProtocolLogging()
+                            .SetMinimumLevel(environment.LogLevel);
+                    });
 
             var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger<LanguageServerHost>();


### PR DESCRIPTION
This reverts commit 60c7b64d3fe0d9ee36b0c4e0c4cd32ea9ae48cb0.

Reverting fixes duplicate log messages on lsp log.