### PR TITLE
Update versions to match .NET SDK 6 RC1 (fix test)

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -256,7 +256,6 @@ Task("CreateMSBuildFolder")
         "NuGet.Common",
         "NuGet.Configuration",
         "NuGet.DependencyResolver.Core",
-        "NuGet.Frameworks",
         "NuGet.LibraryModel",
         "NuGet.Packaging",
         "NuGet.ProjectModel",
@@ -461,7 +460,8 @@ Task("CreateMSBuildFolder")
     var nugetPackages = new []
     {
         "NuGet.Commands",
-        "NuGet.Credentials"
+        "NuGet.Credentials",
+        "NuGet.Frameworks"
     };
 
     foreach (var nugetPackage in nugetPackages)

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -9,46 +9,46 @@
     <!--
         The version for these packages can be found in the dotnet/installer eng/Versions.props file in
         the branch that corresponds with the SDK Toolset being modeled.
-        ex. https://github.com/dotnet/installer/blob/release/6.0.1xx-preview6/eng/Versions.props
+        ex. https://github.com/dotnet/installer/blob/release/6.0.1xx-rc1/eng/Versions.props
     -->
 
     <!-- These packages should match the "MicrosoftNETSdkPackageVersion" property-->
-    <package id="Microsoft.NET.Sdk" version="6.0.100-preview.7.21376.11" />
-    <package id="Microsoft.DotNet.MSBuildSdkResolver" version="6.0.100-preview.7.21376.11" />
+    <package id="Microsoft.NET.Sdk" version="6.0.100-rc.1.21427.66" />
+    <package id="Microsoft.DotNet.MSBuildSdkResolver" version="6.0.100-rc.1.21427.66" />
 
     <!-- These packages should match the "MicrosoftNETCoreDotNetHostResolverPackageVersion" property -->
-    <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="6.0.0-preview.7.21373.17" />
-    <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="6.0.0-preview.7.21373.17" />
-    <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="6.0.0-preview.7.21373.17" />
-    <package id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" version="6.0.0-preview.7.21373.17" />
-    <package id="runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver" version="6.0.0-preview.7.21373.17" />
+    <package id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" version="6.0.0-rc.1.21426.17" />
+    <package id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" version="6.0.0-rc.1.21426.17" />
+    <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="6.0.0-rc.1.21426.17" />
+    <package id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" version="6.0.0-rc.1.21426.17" />
+    <package id="runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver" version="6.0.0-rc.1.21426.17" />
 
     <!--
         The version for these packages can be found in the dotnet/sdk eng/Versions.props file in
         the branch that corresponds with the "Microsoft.NET.Sdk package" being referenced.
-        ex. https://github.com/dotnet/sdk/blob/release/6.0.1xx-preview6/eng/Versions.props
+        ex. https://github.com/dotnet/sdk/blob/release/6.0.1xx-rc1/eng/Versions.props
     -->
 
     <!-- These packages should match the "MicrosoftBuildPackageVersion" property -->
-    <package id="Microsoft.Build" version="17.0.0-preview-21376-04" />
-    <package id="Microsoft.Build.Framework" version="17.0.0-preview-21376-04" />
-    <package id="Microsoft.Build.Runtime" version="17.0.0-preview-21376-04" />
-    <package id="Microsoft.Build.Tasks.Core" version="17.0.0-preview-21376-04" />
-    <package id="Microsoft.Build.Utilities.Core" version="17.0.0-preview-21376-04" />
+    <package id="Microsoft.Build" version="17.0.0-preview-21426-01" />
+    <package id="Microsoft.Build.Framework" version="17.0.0-preview-21426-01" />
+    <package id="Microsoft.Build.Runtime" version="17.0.0-preview-21426-01" />
+    <package id="Microsoft.Build.Tasks.Core" version="17.0.0-preview-21426-01" />
+    <package id="Microsoft.Build.Utilities.Core" version="17.0.0-preview-21426-01" />
     <!-- This package should match as well except the Major & Minor version are set to 1.0 -->
-    <package id="Microsoft.NET.StringTools" version="1.0.0-preview-21376-04" />
+    <package id="Microsoft.NET.StringTools" version="1.0.0-preview-21426-01" />
 
     <!-- This package should match the "MicrosoftNetCompilersToolsetPackageVersion" property-->
-    <package id="Microsoft.Net.Compilers.Toolset" version="4.0.0-3.21373.8" />
+    <package id="Microsoft.Net.Compilers.Toolset" version="4.0.0-4.21427.11" />
 
     <!-- These packages should match the "NuGetBuildTasksPackageVersion" property -->
-    <package id="Microsoft.Build.NuGetSdkResolver" version="6.0.0-preview.3.158" />
-    <package id="NuGet.Build.Tasks" version="6.0.0-preview.3.158" />
-    <package id="NuGet.Commands" version="6.0.0-preview.3.158" />
-    <package id="NuGet.Credentials" version="6.0.0-preview.3.158" />
+    <package id="Microsoft.Build.NuGetSdkResolver" version="6.0.0-preview.4.220" />
+    <package id="NuGet.Build.Tasks" version="6.0.0-preview.4.220" />
+    <package id="NuGet.Commands" version="6.0.0-preview.4.220" />
+    <package id="NuGet.Credentials" version="6.0.0-preview.4.220" />
 
     <!-- This package should match the "NewtonsoftJsonPackageVersion" property-->
-    <package id="Newtonsoft.Json" version="12.0.3" />
+    <package id="Newtonsoft.Json" version="13.0.1" />
 
     <!-- This package should match the "DeploymentReleasesVersion" property-->
     <package id="Microsoft.Deployment.DotNet.Releases" version="1.0.0-preview1.1.21112.1" />

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -46,6 +46,7 @@
     <package id="NuGet.Build.Tasks" version="6.0.0-preview.4.220" />
     <package id="NuGet.Commands" version="6.0.0-preview.4.220" />
     <package id="NuGet.Credentials" version="6.0.0-preview.4.220" />
+    <package id="NuGet.Frameworks" version="6.0.0-preview.4.220" />
 
     <!-- This package should match the "NewtonsoftJsonPackageVersion" property-->
     <package id="Newtonsoft.Json" version="13.0.1" />


### PR DESCRIPTION
Attempt to fix test failure in https://github.com/OmniSharp/omnisharp-roslyn/pull/2217