### PR TITLE
handle RecordStructName in semantic highlighting classification

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/SemanticHighlight/SemanticHighlightService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/SemanticHighlight/SemanticHighlightService.cs
@@ -82,13 +82,16 @@ namespace OmniSharp.Roslyn.CSharp.Services.SemanticHighlight
 
             var linePos = lines.GetLinePositionSpan(span.TextSpan);
 
+            var type = SemanticHighlightClassification.Text;
+            _classificationMap.TryGetValue(span.ClassificationType, out type);
+
             return new SemanticHighlightSpan
             {
                 StartLine = linePos.Start.Line,
                 EndLine = linePos.End.Line,
                 StartColumn = linePos.Start.Character,
                 EndColumn = linePos.End.Character,
-                Type = _classificationMap[span.ClassificationType],
+                Type = type,
                 Modifiers = modifiers
             };
         }
@@ -100,7 +103,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.SemanticHighlight
         }
 
         private static readonly Dictionary<string, SemanticHighlightClassification> _classificationMap =
-            new Dictionary<string, SemanticHighlightClassification>
+            new()
             {
                 [ClassificationTypeNames.Comment] = SemanticHighlightClassification.Comment,
                 [ClassificationTypeNames.ExcludedCode] = SemanticHighlightClassification.ExcludedCode,
@@ -126,6 +129,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.SemanticHighlight
                 [ClassificationTypeNames.InterfaceName] = SemanticHighlightClassification.InterfaceName,
                 [ClassificationTypeNames.ModuleName] = SemanticHighlightClassification.ModuleName,
                 [ClassificationTypeNames.StructName] = SemanticHighlightClassification.StructName,
+                [ClassificationTypeNames.RecordStructName] = SemanticHighlightClassification.StructName,
                 [ClassificationTypeNames.TypeParameterName] = SemanticHighlightClassification.TypeParameterName,
                 [ClassificationTypeNames.FieldName] = SemanticHighlightClassification.FieldName,
                 [ClassificationTypeNames.EnumMemberName] = SemanticHighlightClassification.EnumMemberName,
@@ -171,7 +175,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.SemanticHighlight
             };
 
         private static readonly Dictionary<string, SemanticHighlightModifier> _modifierMap =
-            new Dictionary<string, SemanticHighlightModifier>
+            new()
             {
                 [ClassificationTypeNames.StaticSymbol] = SemanticHighlightModifier.Static,
             };

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SemanticHighlightFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SemanticHighlightFacts.cs
@@ -275,6 +275,45 @@ record R1(string S, int I);
             );
         }
 
+        [Fact]
+        public async Task SemanticHighlightRecordStructName()
+        {
+            var testFile = new TestFile("a.cs", @"
+R1 r1 = new R1(string.Empty, 1);
+record struct R1(string S, int I);
+");
+
+            var highlights = await GetSemanticHighlightsForFileAsync(testFile);
+
+            AssertSyntax(highlights, testFile.Content.Code, 0,
+                StructName("R1"),
+                Local("r1"),
+                Operator("="),
+                Keyword("new"),
+                StructName("R1"),
+                Punctuation("("),
+                Keyword("string"),
+                Operator("."),
+                Field("Empty", SemanticHighlightModifier.Static),
+                Punctuation(","),
+                Number("1"),
+                Punctuation(")"),
+                Punctuation(";"),
+
+                Keyword("record"),
+                Keyword("struct"),
+                StructName("R1"),
+                Punctuation("("),
+                Keyword("string"),
+                Parameter("S"),
+                Punctuation(","),
+                Keyword("int"),
+                Parameter("I"),
+                Punctuation(")"),
+                Punctuation(";")
+            );
+        }
+
         private Task<SemanticHighlightSpan[]> GetSemanticHighlightsForFileAsync(TestFile testFile)
         {
             return GetSemanticHighlightsAsync(testFile, range: null);
@@ -352,6 +391,7 @@ record R1(string S, int I);
         private static (SemanticHighlightClassification type, string text, SemanticHighlightModifier[] modifiers) Method(string text, params SemanticHighlightModifier[] modifiers) => (SemanticHighlightClassification.MethodName, text, modifiers);
         private static (SemanticHighlightClassification type, string text, SemanticHighlightModifier[] modifiers) Local(string text, params SemanticHighlightModifier[] modifiers) => (SemanticHighlightClassification.LocalName, text, modifiers);
         private static (SemanticHighlightClassification type, string text, SemanticHighlightModifier[] modifiers) ClassName(string text, params SemanticHighlightModifier[] modifiers) => (SemanticHighlightClassification.ClassName, text, modifiers);
+        private static (SemanticHighlightClassification type, string text, SemanticHighlightModifier[] modifiers) StructName(string text, params SemanticHighlightModifier[] modifiers) => (SemanticHighlightClassification.StructName, text, modifiers);
         private static (SemanticHighlightClassification type, string text, SemanticHighlightModifier[] modifiers) Field(string text, params SemanticHighlightModifier[] modifiers) => (SemanticHighlightClassification.FieldName, text, modifiers);
         private static (SemanticHighlightClassification type, string text, SemanticHighlightModifier[] modifiers) Identifier(string text, params SemanticHighlightModifier[] modifiers) => (SemanticHighlightClassification.Identifier, text, modifiers);
         private static (SemanticHighlightClassification type, string text, SemanticHighlightModifier[] modifiers) Parameter(string text, params SemanticHighlightModifier[] modifiers) => (SemanticHighlightClassification.ParameterName, text, modifiers);


### PR DESCRIPTION
Additionally, to avoid the key not found exceptions, which happened twice now, we will default to semantic highlighting classification as text in case a given span's classification cannot be mapped.

Fixes #2228 