### PR TITLE
Do not return nulls when getting documents by path

### DIFF
--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -543,8 +543,13 @@ namespace OmniSharp
 
         public void AddAdditionalDocument(ProjectId projectId, string filePath)
         {
-            var documentId = DocumentId.CreateNewId(projectId);
             var loader = new OmniSharpTextLoader(filePath);
+            AddAdditionalDocument(projectId, filePath, loader);
+        }
+
+        public void AddAdditionalDocument(ProjectId projectId, string filePath, TextLoader loader)
+        {
+            var documentId = DocumentId.CreateNewId(projectId);
             var documentInfo = DocumentInfo.Create(documentId, Path.GetFileName(filePath), filePath: filePath, loader: loader);
             OnAdditionalDocumentAdded(documentInfo);
         }

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -62,12 +62,12 @@ namespace OmniSharp
 
         private void OnDirectoryRemoved(string path, FileChangeType changeType)
         {
-            if(changeType == FileChangeType.DirectoryDelete)
+            if (changeType == FileChangeType.DirectoryDelete)
             {
                 var docs = CurrentSolution.Projects.SelectMany(x => x.Documents)
                     .Where(x => x.FilePath.StartsWith(path + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase));
 
-                foreach(var doc in docs)
+                foreach (var doc in docs)
                 {
                     OnDocumentRemoved(doc.Id);
                 }
@@ -340,7 +340,8 @@ namespace OmniSharp
         {
             return CurrentSolution
                 .GetDocumentIdsWithFilePath(filePath)
-                .Select(id => CurrentSolution.GetDocument(id));
+                .Select(id => CurrentSolution.GetDocument(id))
+                .OfType<Document>();
         }
 
         public Document GetDocument(string filePath)

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SourceGeneratorFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SourceGeneratorFacts.cs
@@ -47,6 +47,7 @@ class GeneratedCode
                 "project.csproj",
                 new[] { "netcoreapp3.1" },
                 new[] { testFile },
+                otherFiles: null,
                 ImmutableArray.Create<AnalyzerReference>(reference));
 
             var point = testFile.Content.GetPointFromPosition();

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -144,7 +144,8 @@ namespace TestUtility
                 Workspace,
                 Path.Combine(folderPath, "project.csproj"),
                 new[] { "net472" },
-                testFiles.Where(f => f.FileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)).ToArray());
+                testFiles.Where(f => f.FileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)).ToArray(),
+                testFiles.Where(f => !f.FileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) && !f.FileName.EndsWith(".csx", StringComparison.OrdinalIgnoreCase)).ToArray());
 
             foreach (var csxFile in testFiles.Where(f => f.FileName.EndsWith(".csx", StringComparison.OrdinalIgnoreCase)))
             {

--- a/tests/TestUtility/OmniSharpTestHost.cs
+++ b/tests/TestUtility/OmniSharpTestHost.cs
@@ -145,7 +145,9 @@ namespace TestUtility
                 Path.Combine(folderPath, "project.csproj"),
                 new[] { "net472" },
                 testFiles.Where(f => f.FileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)).ToArray(),
-                testFiles.Where(f => !f.FileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) && !f.FileName.EndsWith(".csx", StringComparison.OrdinalIgnoreCase)).ToArray());
+                testFiles.Where(f => !f.FileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+                    && !f.FileName.EndsWith(".csx", StringComparison.OrdinalIgnoreCase)
+                    && !f.FileName.EndsWith(".cake", StringComparison.OrdinalIgnoreCase)).ToArray());
 
             foreach (var csxFile in testFiles.Where(f => f.FileName.EndsWith(".csx", StringComparison.OrdinalIgnoreCase)))
             {

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -46,8 +46,10 @@ namespace TestUtility
             workspace.AddDocument(documentInfo);
         }
 
-        public static IEnumerable<ProjectId> AddProjectToWorkspace(OmniSharpWorkspace workspace, string filePath, string[] frameworks, TestFile[] testFiles, ImmutableArray<AnalyzerReference> analyzerRefs = default)
+        public static IEnumerable<ProjectId> AddProjectToWorkspace(OmniSharpWorkspace workspace, string filePath, string[] frameworks, TestFile[] testFiles, TestFile[] otherFiles = null, ImmutableArray<AnalyzerReference> analyzerRefs = default)
         {
+            otherFiles ??= Array.Empty<TestFile>();
+
             var versionStamp = VersionStamp.Create();
             var references = GetReferences();
             frameworks = frameworks ?? new[] { string.Empty };
@@ -82,6 +84,11 @@ namespace TestUtility
                 foreach (var testFile in testFiles)
                 {
                     workspace.AddDocument(projectInfo.Id, testFile.FileName, TextLoader.From(TextAndVersion.Create(testFile.Content.Text, versionStamp)), SourceCodeKind.Regular);
+                }
+
+                foreach (var otherFile in otherFiles)
+                {
+                    workspace.AddAdditionalDocument(projectInfo.Id, otherFile.FileName, TextLoader.From(TextAndVersion.Create(otherFile.Content.Text, versionStamp)));
                 }
 
                 projectsIds.Add(projectInfo.Id);


### PR DESCRIPTION
Resolves https://github.com/OmniSharp/omnisharp-roslyn/issues/2125

The IEnumerable returned by `workspace.GetDocuments(string filePath)` can contain `null`s if the filepath isn't present in any Project.Documents. In this case .cshtml files are not part of the compilation and are AdditionalDocuments in the workspace. The added `OfType<>()` will filter out the `null` values and allow an empty enumerable to be returned.

Using the repro provided at https://github.com/jsheely/dotnet6-omni-bug1, we get results instead of an NRE.

![image](https://user-images.githubusercontent.com/611219/132599703-bb85305d-69b3-4d32-85be-27f8b45f33ce.png)