### PR TITLE
Update run script in mono packages when building

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -172,6 +172,11 @@ Task("InstallMonoAssets")
     DownloadFileAndUnzip($"{buildPlan.DownloadURL}/{buildPlan.MonoRuntimeLinux32}", env.Folders.MonoRuntimeLinux32);
     DownloadFileAndUnzip($"{buildPlan.DownloadURL}/{buildPlan.MonoRuntimeLinux64}", env.Folders.MonoRuntimeLinux64);
 
+    var runScriptFile = CombinePaths(env.Folders.MonoPackaging, "run");
+    FileHelper.Copy(runScriptFile, CombinePaths(env.Folders.MonoRuntimeMacOS, "run"), overwrite: true);
+    FileHelper.Copy(runScriptFile, CombinePaths(env.Folders.MonoRuntimeLinux32, "run"), overwrite: true);
+    FileHelper.Copy(runScriptFile, CombinePaths(env.Folders.MonoRuntimeLinux64, "run"), overwrite: true);
+
     var monoInstallFolder = env.CurrentMonoRuntime.InstallFolder;
     var monoRuntimeFile = env.CurrentMonoRuntime.RuntimeFile;
 

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -140,6 +140,7 @@ public class Folders
     public string Source { get; }
     public string Tests { get; }
     public string TestAssets { get; }
+    public string MonoPackaging { get; }
 
     public string Artifacts { get; }
     public string ArtifactsPublish { get; }
@@ -165,6 +166,7 @@ public class Folders
         this.Source = PathHelper.Combine(workingDirectory, "src");
         this.Tests = PathHelper.Combine(workingDirectory, "tests");
         this.TestAssets = PathHelper.Combine(workingDirectory, "test-assets");
+        this.MonoPackaging = PathHelper.Combine(workingDirectory, "mono-packaging");
 
         this.Artifacts = PathHelper.Combine(workingDirectory, "artifacts");
         this.ArtifactsPublish = PathHelper.Combine(this.Artifacts, "publish");


### PR DESCRIPTION
Ensures the run script we ship with our mono packages are up to date. See comment https://github.com/OmniSharp/omnisharp-roslyn/pull/1979#issuecomment-951901436