### PR TITLE
improved Cake/CSX info messages

### DIFF
--- a/src/OmniSharp.Cake/CakeProjectSystem.cs
+++ b/src/OmniSharp.Cake/CakeProjectSystem.cs
@@ -84,7 +84,7 @@ namespace OmniSharp.Cake
             var allCakeFiles = _fileSystemHelper.GetFiles("**/*.cake").ToArray();
             if (allCakeFiles.Length == 0)
             {
-                _logger.LogInformation("Could not find any Cake files");
+                _logger.LogInformation("Did not find any Cake files");
                 return;
             }
 

--- a/src/OmniSharp.Script/ScriptProjectSystem.cs
+++ b/src/OmniSharp.Script/ScriptProjectSystem.cs
@@ -67,7 +67,7 @@ namespace OmniSharp.Script
 
             if (allCsxFiles.Length == 0)
             {
-                _logger.LogInformation("Could not find any CSX files");
+                _logger.LogInformation("Did not find any CSX files");
                 Initialized = true;
 
                 // Watch CSX files in order to add/remove them in workspace


### PR DESCRIPTION
The current messages pritned when no Cake/CSX files are present in the working directory could be interpreted that something went wrong at start up (in fact, it has been asked in some issues).