### PR TITLE
Check diagnostic analyzer's configured severity before running it

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/RunFixAllCodeActionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/RunFixAllCodeActionService.cs
@@ -192,13 +192,13 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring
             }
 
             public override async Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
-                => await _diagnosticWorker.AnalyzeProjectsAsync(project, cancellationToken);
+                => await _diagnosticWorker.AnalyzeProjectAsync(project, cancellationToken);
 
             public override async Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
                 => await _diagnosticWorker.AnalyzeDocumentAsync(document, cancellationToken);
 
             public override async Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
-                => await _diagnosticWorker.AnalyzeProjectsAsync(project, cancellationToken);
+                => await _diagnosticWorker.AnalyzeProjectAsync(project, cancellationToken);
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/AnalyzerOptionExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/AnalyzerOptionExtensions.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
+{
+    internal static class AnalyzerOptionsExtensions
+    {
+        internal const string DotnetDiagnosticPrefix = "dotnet_diagnostic";
+        internal const string DotnetAnalyzerDiagnosticPrefix = "dotnet_analyzer_diagnostic";
+        internal const string CategoryPrefix = "category";
+        internal const string SeveritySuffix = "severity";
+
+        internal const string DotnetAnalyzerDiagnosticSeverityKey = DotnetAnalyzerDiagnosticPrefix + "." + SeveritySuffix;
+
+        internal static string GetDiagnosticIdBasedDotnetAnalyzerDiagnosticSeverityKey(string diagnosticId)
+            => $"{DotnetDiagnosticPrefix}.{diagnosticId}.{SeveritySuffix}";
+        internal static string GetCategoryBasedDotnetAnalyzerDiagnosticSeverityKey(string category)
+            => $"{DotnetAnalyzerDiagnosticPrefix}.{CategoryPrefix}-{category}.{SeveritySuffix}";
+
+        /// <summary>
+        /// Tries to get configured severity for the given <paramref name="descriptor"/>
+        /// for the given <paramref name="tree"/> from analyzer config options, i.e.
+        ///     'dotnet_diagnostic.%descriptor.Id%.severity = %severity%',
+        ///     'dotnet_analyzer_diagnostic.category-%RuleCategory%.severity = %severity%',
+        ///         or
+        ///     'dotnet_analyzer_diagnostic.severity = %severity%'
+        /// </summary>
+        public static bool TryGetSeverityFromConfiguration(
+            this AnalyzerOptions analyzerOptions,
+            SyntaxTree tree,
+            Compilation compilation,
+            DiagnosticDescriptor descriptor,
+            out ReportDiagnostic severity)
+        {
+            // If user has explicitly configured severity for this diagnostic ID, that should be respected.
+            if (compilation.Options.SpecificDiagnosticOptions.TryGetValue(descriptor.Id, out severity))
+            {
+                return true;
+            }
+
+            // If user has explicitly configured severity for this diagnostic ID, that should be respected.
+            // For example, 'dotnet_diagnostic.CA1000.severity = error'
+            if (compilation.Options.SyntaxTreeOptionsProvider?.TryGetDiagnosticValue(tree, descriptor.Id, CancellationToken.None, out severity) == true)
+            {
+                return true;
+            }
+
+            // Analyzer bulk configuration does not apply to:
+            //  1. Disabled by default diagnostics
+            //  2. Compiler diagnostics
+            //  3. Non-configurable diagnostics
+            if (analyzerOptions == null ||
+                !descriptor.IsEnabledByDefault ||
+                descriptor.CustomTags.Any(tag => tag == WellKnownDiagnosticTags.Compiler || tag == WellKnownDiagnosticTags.NotConfigurable))
+            {
+                severity = default;
+                return false;
+            }
+
+            var analyzerConfigOptions = analyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(tree);
+
+            // If user has explicitly configured default severity for the diagnostic category, that should be respected.
+            // For example, 'dotnet_analyzer_diagnostic.category-security.severity = error'
+            var categoryBasedKey = GetCategoryBasedDotnetAnalyzerDiagnosticSeverityKey(descriptor.Category);
+            if (analyzerConfigOptions.TryGetValue(categoryBasedKey, out var value) &&
+                TryParseSeverity(value, out severity))
+            {
+                return true;
+            }
+
+            // Otherwise, if user has explicitly configured default severity for all analyzer diagnostics, that should be respected.
+            // For example, 'dotnet_analyzer_diagnostic.severity = error'
+            if (analyzerConfigOptions.TryGetValue(DotnetAnalyzerDiagnosticSeverityKey, out value) &&
+                TryParseSeverity(value, out severity))
+            {
+                return true;
+            }
+
+            severity = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether a diagnostic is configured in the <paramref name="analyzerConfigOptions" />.
+        /// </summary>
+        public static bool IsDiagnosticSeverityConfigured(this AnalyzerConfigOptions analyzerConfigOptions, Project project, SyntaxTree tree, string diagnosticId, string diagnosticCategory)
+        {
+            var optionsProvider = project.CompilationOptions?.SyntaxTreeOptionsProvider;
+            return (optionsProvider != null && optionsProvider.TryGetDiagnosticValue(tree, diagnosticId, CancellationToken.None, out _))
+                || (diagnosticCategory != null && analyzerConfigOptions.TryGetValue(GetCategoryBasedDotnetAnalyzerDiagnosticSeverityKey(diagnosticCategory), out _))
+                || analyzerConfigOptions.TryGetValue(DotnetAnalyzerDiagnosticSeverityKey, out _);
+        }
+
+        /// <summary>
+        /// Get the configured severity for a diagnostic analyzer from the <paramref name="analyzerConfigOptions" />.
+        /// </summary>
+        public static ReportDiagnostic GetDiagnosticSeverity(this AnalyzerConfigOptions analyzerConfigOptions, Project project, SyntaxTree tree, string diagnosticId, string diagnosticCategory)
+        {
+            return analyzerConfigOptions.TryGetSeverityFromConfiguration(project, tree, diagnosticId, diagnosticCategory, out var reportSeverity)
+                ? reportSeverity
+                : ReportDiagnostic.Suppress;
+        }
+
+        /// <summary>
+        /// Tries to get configured severity for the given <paramref name="diagnosticId"/>
+        /// for the given <paramref name="tree"/> from analyzer config options, i.e.
+        ///     'dotnet_diagnostic.%descriptor.Id%.severity = %severity%',
+        ///     'dotnet_analyzer_diagnostic.category-%RuleCategory%.severity = %severity%',
+        ///         or
+        ///     'dotnet_analyzer_diagnostic.severity = %severity%'
+        /// </summary>
+        public static bool TryGetSeverityFromConfiguration(
+            this AnalyzerConfigOptions analyzerConfigOptions,
+            Project project,
+            SyntaxTree tree,
+            string diagnosticId,
+            string diagnosticCategory,
+            out ReportDiagnostic severity)
+        {
+            if (analyzerConfigOptions is null)
+            {
+                severity = default;
+                return false;
+            }
+
+            // If user has explicitly configured severity for this diagnostic ID, that should be respected.
+            // For example, 'dotnet_diagnostic.CA1000.severity = error'
+            var optionsProvider = project.CompilationOptions?.SyntaxTreeOptionsProvider;
+            if (optionsProvider != null &&
+                optionsProvider.TryGetDiagnosticValue(tree, diagnosticId, CancellationToken.None, out severity))
+            {
+                return true;
+            }
+
+            string value;
+            if (diagnosticCategory != null)
+            {
+                // If user has explicitly configured default severity for the diagnostic category, that should be respected.
+                // For example, 'dotnet_analyzer_diagnostic.category-security.severity = error'
+                var categoryBasedKey = GetCategoryBasedDotnetAnalyzerDiagnosticSeverityKey(diagnosticCategory);
+                if (analyzerConfigOptions.TryGetValue(categoryBasedKey, out value) &&
+                    TryParseSeverity(value, out severity))
+                {
+                    return true;
+                }
+            }
+
+            // Otherwise, if user has explicitly configured default severity for all analyzer diagnostics, that should be respected.
+            // For example, 'dotnet_analyzer_diagnostic.severity = error'
+            if (analyzerConfigOptions.TryGetValue(DotnetAnalyzerDiagnosticSeverityKey, out value) &&
+                TryParseSeverity(value, out severity))
+            {
+                return true;
+            }
+
+            severity = default;
+            return false;
+        }
+
+        internal static bool TryParseSeverity(string value, out ReportDiagnostic severity)
+        {
+            var comparer = StringComparer.OrdinalIgnoreCase;
+            if (comparer.Equals(value, "default"))
+            {
+                severity = ReportDiagnostic.Default;
+                return true;
+            }
+            else if (comparer.Equals(value, "error"))
+            {
+                severity = ReportDiagnostic.Error;
+                return true;
+            }
+            else if (comparer.Equals(value, "warning"))
+            {
+                severity = ReportDiagnostic.Warn;
+                return true;
+            }
+            else if (comparer.Equals(value, "suggestion"))
+            {
+                severity = ReportDiagnostic.Info;
+                return true;
+            }
+            else if (comparer.Equals(value, "silent") || comparer.Equals(value, "refactoring"))
+            {
+                severity = ReportDiagnostic.Hidden;
+                return true;
+            }
+            else if (comparer.Equals(value, "none"))
+            {
+                severity = ReportDiagnostic.Suppress;
+                return true;
+            }
+
+            severity = default;
+            return false;
+        }
+    }
+}

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorker.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorker.cs
@@ -17,7 +17,7 @@ using OmniSharp.Roslyn.CSharp.Services.Diagnostics;
 
 namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
 {
-    public class CSharpDiagnosticWorker: ICsDiagnosticWorker, IDisposable
+    public class CSharpDiagnosticWorker : ICsDiagnosticWorker, IDisposable
     {
         private readonly ILogger _logger;
         private readonly OmniSharpWorkspace _workspace;
@@ -68,7 +68,7 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
             {
                 var newDocument = changeEvent.NewSolution.GetDocument(changeEvent.DocumentId);
 
-                EmitDiagnostics(new [] {newDocument.Id}.Union(_workspace.GetOpenDocumentIds()).Select(x => _workspace.CurrentSolution.GetDocument(x).FilePath).ToArray());
+                EmitDiagnostics(new[] { newDocument.Id }.Union(_workspace.GetOpenDocumentIds()).Select(x => _workspace.CurrentSolution.GetDocument(x).FilePath).ToArray());
             }
             else if (changeEvent.Kind == WorkspaceChangeKind.ProjectAdded || changeEvent.Kind == WorkspaceChangeKind.ProjectReloaded)
             {
@@ -148,7 +148,7 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
 
             foreach (var document in documents)
             {
-                if(document?.Project?.Name == null)
+                if (document?.Project?.Name == null)
                     continue;
 
                 var projectName = document.Project.Name;
@@ -209,7 +209,7 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
             return await GetDiagnosticsForDocument(document, document.Project.Name);
         }
 
-        public async Task<IEnumerable<Diagnostic>> AnalyzeProjectsAsync(Project project, CancellationToken cancellationToken)
+        public async Task<IEnumerable<Diagnostic>> AnalyzeProjectAsync(Project project, CancellationToken cancellationToken)
         {
             var diagnostics = new List<Diagnostic>();
             foreach (var document in project.Documents)

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
@@ -320,7 +320,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
                     var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, new CompilationWithAnalyzersOptions(
                         workspaceAnalyzerOptions,
                         onAnalyzerException: OnAnalyzerException,
-                        concurrentAnalysis: false,
+                        concurrentAnalysis: true,
                         logAnalyzerExecutionTime: false,
                         reportSuppressedDiagnostics: false));
 
@@ -367,7 +367,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
                     var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, new CompilationWithAnalyzersOptions(
                         workspaceAnalyzerOptions,
                         onAnalyzerException: OnAnalyzerException,
-                        concurrentAnalysis: false,
+                        concurrentAnalysis: true,
                         logAnalyzerExecutionTime: false,
                         reportSuppressedDiagnostics: false));
 

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
@@ -320,7 +320,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
                     var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, new CompilationWithAnalyzersOptions(
                         workspaceAnalyzerOptions,
                         onAnalyzerException: OnAnalyzerException,
-                        concurrentAnalysis: true,
+                        concurrentAnalysis: false,
                         logAnalyzerExecutionTime: false,
                         reportSuppressedDiagnostics: false));
 
@@ -367,7 +367,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
                     var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, new CompilationWithAnalyzersOptions(
                         workspaceAnalyzerOptions,
                         onAnalyzerException: OnAnalyzerException,
-                        concurrentAnalysis: true,
+                        concurrentAnalysis: false,
                         logAnalyzerExecutionTime: false,
                         reportSuppressedDiagnostics: false));
 

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CSharpDiagnosticWorkerWithAnalyzers.cs
@@ -130,7 +130,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
 
                         EventIfBackgroundWork(workType, projectPath, ProjectDiagnosticStatus.Started);
 
-                        await AnalyzeProject(solution, projectGroup);
+                        await AnalyzeAndReport(solution, projectGroup);
 
                         EventIfBackgroundWork(workType, projectPath, ProjectDiagnosticStatus.Ready);
                     }
@@ -188,7 +188,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
                 case WorkspaceChangeKind.SolutionReloaded:
                     QueueDocumentsForDiagnostics();
                     break;
-
             }
         }
 
@@ -203,11 +202,16 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
             var compilation = await project.GetCompilationAsync();
             var workspaceAnalyzerOptions = (AnalyzerOptions)_workspaceAnalyzerOptionsConstructor.Invoke(new object[] { project.AnalyzerOptions, project.Solution });
 
+            var documentOptions = await document.GetOptionsAsync();
+            var filteredAnalyzers = allAnalyzers
+                .Where(analyzer => analyzer is DiagnosticSuppressor || analyzer.GetSeverity(document, workspaceAnalyzerOptions, documentOptions, compilation) != ReportDiagnostic.Suppress)
+                .ToImmutableArray();
+
             cancellationToken.ThrowIfCancellationRequested();
-            return await AnalyzeDocument(project, allAnalyzers, compilation, workspaceAnalyzerOptions, document);
+            return await AnalyzeDocumentAsync(project, filteredAnalyzers, compilation, workspaceAnalyzerOptions, document);
         }
 
-        public async Task<IEnumerable<Diagnostic>> AnalyzeProjectsAsync(Project project, CancellationToken cancellationToken)
+        public async Task<IEnumerable<Diagnostic>> AnalyzeProjectAsync(Project project, CancellationToken cancellationToken)
         {
             var diagnostics = new List<Diagnostic>();
             var allAnalyzers = _providers
@@ -218,16 +222,27 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
             var compilation = await project.GetCompilationAsync();
             var workspaceAnalyzerOptions = (AnalyzerOptions)_workspaceAnalyzerOptionsConstructor.Invoke(new object[] { project.AnalyzerOptions, project.Solution });
 
-            foreach (var document in project.Documents)
+            var filteredAnalyzersBuilder = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
+            foreach (var analyzer in allAnalyzers)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                diagnostics.AddRange(await AnalyzeDocument(project, allAnalyzers, compilation, workspaceAnalyzerOptions, document));
+                if (analyzer is DiagnosticSuppressor)
+                {
+                    filteredAnalyzersBuilder.Add(analyzer);
+                }
+
+                var severity = await analyzer.GetSeverityAsync(project, compilation, cancellationToken);
+                if (severity != ReportDiagnostic.Suppress)
+                {
+                    filteredAnalyzersBuilder.Add(analyzer);
+                }
             }
 
-            return diagnostics;
+            var filteredAnalyzers = filteredAnalyzersBuilder.ToImmutable();
+
+            return await AnalyzeProjectAsync(project, filteredAnalyzers, compilation, workspaceAnalyzerOptions);
         }
 
-        private async Task AnalyzeProject(Solution solution, IGrouping<ProjectId, DocumentId> documentsGroupedByProject)
+        private async Task AnalyzeAndReport(Solution solution, IGrouping<ProjectId, DocumentId> documentsGroupedByProject)
         {
             try
             {
@@ -242,11 +257,39 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
 
                 var workspaceAnalyzerOptions = (AnalyzerOptions)_workspaceAnalyzerOptionsConstructor.Invoke(new object[] { project.AnalyzerOptions, project.Solution });
 
+                var filteredAnalyzersBuilder = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
+                foreach (var analyzer in allAnalyzers)
+                {
+                    if (analyzer is DiagnosticSuppressor)
+                    {
+                        filteredAnalyzersBuilder.Add(analyzer);
+                    }
+
+                    var severity = await analyzer.GetSeverityAsync(project, compilation, CancellationToken.None);
+                    if (severity != ReportDiagnostic.Suppress)
+                    {
+                        filteredAnalyzersBuilder.Add(analyzer);
+                    }
+                }
+
+                var filteredAnalyzers = filteredAnalyzersBuilder.ToImmutable();
+
+                var diagnostics = await AnalyzeProjectAsync(project, filteredAnalyzers, compilation, workspaceAnalyzerOptions);
+                var diagnosticsByFilePath = diagnostics
+                    .GroupBy(diagnostic => diagnostic.Location.SourceTree.FilePath)
+                    .ToDictionary(group => group.Key, group => group.ToImmutableArray());
+
                 foreach (var documentId in documentsGroupedByProject)
                 {
                     var document = project.GetDocument(documentId);
-                    var diagnostics = await AnalyzeDocument(project, allAnalyzers, compilation, workspaceAnalyzerOptions, document);
-                    UpdateCurrentDiagnostics(project, document, diagnostics);
+                    if (diagnosticsByFilePath.TryGetValue(document.FilePath, out var documentDiagnostics))
+                    {
+                        UpdateCurrentDiagnostics(project, document, documentDiagnostics);
+                    }
+                    else
+                    {
+                        UpdateCurrentDiagnostics(project, document, ImmutableArray<Diagnostic>.Empty);
+                    }
                 }
             }
             catch (Exception ex)
@@ -255,7 +298,48 @@ namespace OmniSharp.Roslyn.CSharp.Services.Diagnostics
             }
         }
 
-        private async Task<ImmutableArray<Diagnostic>> AnalyzeDocument(Project project, ImmutableArray<DiagnosticAnalyzer> allAnalyzers, Compilation compilation, AnalyzerOptions workspaceAnalyzerOptions, Document document)
+        private async Task<ImmutableArray<Diagnostic>> AnalyzeProjectAsync(Project project, ImmutableArray<DiagnosticAnalyzer> allAnalyzers, Compilation compilation, AnalyzerOptions workspaceAnalyzerOptions)
+        {
+            try
+            {
+                // There's real possibility that bug in analyzer causes analysis hang at document.
+                var perDocumentTimeout =
+                    new CancellationTokenSource(_options.RoslynExtensionsOptions.DocumentAnalysisTimeoutMs);
+
+                var diagnostics = ImmutableArray<Diagnostic>.Empty;
+
+                // Only basic syntax check is available if file is miscellanous like orphan .cs file.
+                // Those projects are on hard coded virtual project
+                if (project.Name != $"{Configuration.OmniSharpMiscProjectName}.csproj" && allAnalyzers.Any())
+                {
+                    var compilationWithAnalyzers = compilation.WithAnalyzers(allAnalyzers, new CompilationWithAnalyzersOptions(
+                        workspaceAnalyzerOptions,
+                        onAnalyzerException: OnAnalyzerException,
+                        concurrentAnalysis: false,
+                        logAnalyzerExecutionTime: false,
+                        reportSuppressedDiagnostics: false));
+
+                    var allDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync();
+                    diagnostics = allDiagnostics
+                        .Where(d => !d.IsSuppressed && d.Location.IsInSource)
+                        .ToImmutableArray();
+                }
+                else
+                {
+                    diagnostics = compilation.GetDiagnostics();
+                }
+
+                return diagnostics;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Analysis of project {project.Name} failed or cancelled by timeout: {ex.Message}, analysers: {string.Join(", ", allAnalyzers)}");
+                return ImmutableArray<Diagnostic>.Empty;
+            }
+        }
+
+
+        private async Task<ImmutableArray<Diagnostic>> AnalyzeDocumentAsync(Project project, ImmutableArray<DiagnosticAnalyzer> allAnalyzers, Compilation compilation, AnalyzerOptions workspaceAnalyzerOptions, Document document)
         {
             try
             {

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CsharpDiagnosticWorkerComposer.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/CsharpDiagnosticWorkerComposer.cs
@@ -16,7 +16,7 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
     // Theres several implementation of worker currently based on configuration.
     // This will handle switching between them.
     [Export(typeof(ICsDiagnosticWorker)), Shared]
-    public class CsharpDiagnosticWorkerComposer: ICsDiagnosticWorker, IDisposable
+    public class CsharpDiagnosticWorkerComposer : ICsDiagnosticWorker, IDisposable
     {
         private readonly OmniSharpWorkspace _workspace;
         private readonly IEnumerable<ICodeActionProvider> _providers;
@@ -98,9 +98,9 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
             return _implementation.AnalyzeDocumentAsync(document, cancellationToken);
         }
 
-        public Task<IEnumerable<Diagnostic>> AnalyzeProjectsAsync(Project project, CancellationToken cancellationToken)
+        public Task<IEnumerable<Diagnostic>> AnalyzeProjectAsync(Project project, CancellationToken cancellationToken)
         {
-            return _implementation.AnalyzeProjectsAsync(project, cancellationToken);
+            return _implementation.AnalyzeProjectAsync(project, cancellationToken);
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/DiagnosticAnalyzerExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/DiagnosticAnalyzerExtensions.cs
@@ -1,23 +1,24 @@
+using System;
 using System.Collections;
-using System.Collections.Immutable;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
+using OmniSharp.Utilities;
 
 namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
 {
     public static class DiagnosticAnalyzerExtensions
     {
-        private static MethodInfo TryGetMappedOptionsMethod { get; }
+        private static Lazy<MethodInfo> TryGetMappedOptionsMethod { get; }
 
         static DiagnosticAnalyzerExtensions()
         {
-            TryGetMappedOptionsMethod = Assembly.Load(new AssemblyName("Microsoft.CodeAnalysis.Features"))
-                .GetType("Microsoft.CodeAnalysis.Diagnostics.IDEDiagnosticIdToOptionMappingHelper")
-                .GetMethod("TryGetMappedOptions", BindingFlags.Static | BindingFlags.Public);
+            TryGetMappedOptionsMethod = new Lazy<Assembly>(() => Assembly.Load(new AssemblyName("Microsoft.CodeAnalysis.Features")))
+                .LazyGetType("Microsoft.CodeAnalysis.Diagnostics.IDEDiagnosticIdToOptionMappingHelper")
+                .LazyGetMethod("TryGetMappedOptions", BindingFlags.Static | BindingFlags.Public);
         }
         /// <summary>
         /// Get the highest possible severity for any formattable document in the project.
@@ -136,7 +137,7 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
                 severity = ReportDiagnostic.Suppress;
 
                 var parameters = new object[] { descriptor.Id, compilation.Language, null };
-                var result = (bool)(TryGetMappedOptionsMethod.Invoke(null, parameters) ?? false);
+                var result = (bool)(TryGetMappedOptionsMethod.InvokeStatic(parameters) ?? false);
 
                 if (!result)
                 {

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/DiagnosticAnalyzerExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/DiagnosticAnalyzerExtensions.cs
@@ -1,0 +1,180 @@
+using System.Collections;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Options;
+
+namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
+{
+    public static class DiagnosticAnalyzerExtensions
+    {
+        private static MethodInfo TryGetMappedOptionsMethod { get; }
+
+        static DiagnosticAnalyzerExtensions()
+        {
+            TryGetMappedOptionsMethod = Assembly.Load(new AssemblyName("Microsoft.CodeAnalysis.Features"))
+                .GetType("Microsoft.CodeAnalysis.Diagnostics.IDEDiagnosticIdToOptionMappingHelper")
+                .GetMethod("TryGetMappedOptions", BindingFlags.Static | BindingFlags.Public);
+        }
+        /// <summary>
+        /// Get the highest possible severity for any formattable document in the project.
+        /// </summary>
+        public static async Task<ReportDiagnostic> GetSeverityAsync(
+            this DiagnosticAnalyzer analyzer,
+            Project project,
+            Compilation compilation,
+            CancellationToken cancellationToken)
+        {
+            var severity = ReportDiagnostic.Suppress;
+            if (compilation is null)
+            {
+                return severity;
+            }
+
+            foreach (var document in project.Documents)
+            {
+                // Is the document formattable?
+                if (document.FilePath is null)
+                {
+                    continue;
+                }
+
+                var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+
+                var documentSeverity = analyzer.GetSeverity(document, project.AnalyzerOptions, options, compilation);
+                if (documentSeverity < severity)
+                {
+                    severity = documentSeverity;
+                }
+            }
+
+            return severity;
+        }
+
+        public static ReportDiagnostic FromSeverity(this DiagnosticSeverity diagnosticSeverity)
+        {
+            return diagnosticSeverity switch
+            {
+                DiagnosticSeverity.Error => ReportDiagnostic.Error,
+                DiagnosticSeverity.Warning => ReportDiagnostic.Warn,
+                DiagnosticSeverity.Info => ReportDiagnostic.Info,
+                _ => ReportDiagnostic.Hidden,
+            };
+        }
+
+        public static DiagnosticSeverity ToSeverity(this ReportDiagnostic reportDiagnostic)
+        {
+            return reportDiagnostic switch
+            {
+                ReportDiagnostic.Error => DiagnosticSeverity.Error,
+                ReportDiagnostic.Warn => DiagnosticSeverity.Warning,
+                ReportDiagnostic.Info => DiagnosticSeverity.Info,
+                _ => DiagnosticSeverity.Hidden
+            };
+        }
+
+        public static ReportDiagnostic GetSeverity(
+            this DiagnosticAnalyzer analyzer,
+            Document document,
+            AnalyzerOptions analyzerOptions,
+            OptionSet options,
+            Compilation compilation)
+        {
+            var severity = ReportDiagnostic.Suppress;
+
+            if (!document.TryGetSyntaxTree(out var tree))
+            {
+                return severity;
+            }
+
+            foreach (var descriptor in analyzer.SupportedDiagnostics)
+            {
+                if (severity == ReportDiagnostic.Error)
+                {
+                    break;
+                }
+
+                if (analyzerOptions.TryGetSeverityFromConfiguration(tree, compilation, descriptor, out var reportDiagnostic))
+                {
+                    var configuredSeverity = reportDiagnostic;
+                    if (configuredSeverity < severity)
+                    {
+                        severity = configuredSeverity;
+                    }
+
+                    continue;
+                }
+
+                if (TryGetSeverityFromCodeStyleOption(descriptor, compilation, options, out var codeStyleSeverity))
+                {
+                    if (codeStyleSeverity < severity)
+                    {
+                        severity = codeStyleSeverity;
+                    }
+
+                    continue;
+                }
+
+                var defaultSeverity = FromSeverity(descriptor.DefaultSeverity);
+                if (defaultSeverity < severity)
+                {
+                    severity = defaultSeverity;
+                }
+            }
+
+            return severity;
+
+            static bool TryGetSeverityFromCodeStyleOption(
+                DiagnosticDescriptor descriptor,
+                Compilation compilation,
+                OptionSet options,
+                out ReportDiagnostic severity)
+            {
+                severity = ReportDiagnostic.Suppress;
+
+                var parameters = new object[] { descriptor.Id, compilation.Language, null };
+                var result = (bool)(TryGetMappedOptionsMethod.Invoke(null, parameters) ?? false);
+
+                if (!result)
+                {
+                    return false;
+                }
+
+                var codeStyleOptions = (IEnumerable)parameters[2]!;
+                foreach (var codeStyleOptionObj in codeStyleOptions)
+                {
+                    var codeStyleOption = (IOption)codeStyleOptionObj!;
+                    var option = options.GetOption(new OptionKey(codeStyleOption, codeStyleOption.IsPerLanguage ? compilation.Language : null));
+                    if (option is null)
+                    {
+                        continue;
+                    }
+
+                    var notificationProperty = option.GetType().GetProperty("Notification");
+                    if (notificationProperty is null)
+                    {
+                        continue;
+                    }
+
+                    var notification = notificationProperty.GetValue(option);
+                    var reportDiagnosticValue = notification?.GetType().GetProperty("Severity")?.GetValue(notification);
+                    if (reportDiagnosticValue is null)
+                    {
+                        continue;
+                    }
+
+                    var codeStyleSeverity = (ReportDiagnostic)reportDiagnosticValue;
+                    if (codeStyleSeverity < severity)
+                    {
+                        severity = codeStyleSeverity;
+                    }
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/ICsDiagnosticWorker.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Workers/Diagnostics/ICsDiagnosticWorker.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Roslyn.CSharp.Workers.Diagnostics
         Task<ImmutableArray<DocumentDiagnostics>> GetDiagnostics(ImmutableArray<string> documentPaths);
         Task<ImmutableArray<DocumentDiagnostics>> GetAllDiagnosticsAsync();
         Task<IEnumerable<Diagnostic>> AnalyzeDocumentAsync(Document document, CancellationToken cancellationToken);
-        Task<IEnumerable<Diagnostic>> AnalyzeProjectsAsync(Project project, CancellationToken cancellationToken);
+        Task<IEnumerable<Diagnostic>> AnalyzeProjectAsync(Project project, CancellationToken cancellationToken);
         ImmutableArray<DocumentId> QueueDocumentsForDiagnostics();
         ImmutableArray<DocumentId> QueueDocumentsForDiagnostics(ImmutableArray<ProjectId> projectId);
     }

--- a/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
+++ b/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs
@@ -556,8 +556,13 @@ namespace OmniSharp
 
         public void AddAnalyzerConfigDocument(ProjectId projectId, string filePath)
         {
-            var documentId = DocumentId.CreateNewId(projectId);
             var loader = new OmniSharpTextLoader(filePath);
+            AddAnalyzerConfigDocument(projectId, filePath, loader);
+        }
+
+        public void AddAnalyzerConfigDocument(ProjectId projectId, string filePath, TextLoader loader)
+        {
+            var documentId = DocumentId.CreateNewId(projectId);
             var documentInfo = DocumentInfo.Create(documentId, Path.GetFileName(filePath), filePath: filePath, loader: loader);
             OnAnalyzerConfigDocumentAdded(documentInfo);
         }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CSharpDiagnosticWorkerWithAnalyzersFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CSharpDiagnosticWorkerWithAnalyzersFacts.cs
@@ -1,0 +1,205 @@
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using OmniSharp.Roslyn.CSharp.Services.Diagnostics;
+using OmniSharp.Services;
+using TestUtility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OmniSharp.Roslyn.CSharp.Tests
+{
+    public class CSharpDiagnosticWorkerWithAnalyzersFacts : AbstractTestFixture
+    {
+        private const string TestFilename = "dummy.cs";
+        private const string TestFilename2 = "dummy2.cs";
+        private const string TestCode = @"
+public class Program
+{
+    public static void Main(string[] args)
+    {
+    }
+}";
+
+        public CSharpDiagnosticWorkerWithAnalyzersFacts(ITestOutputHelper output, SharedOmniSharpHostFixture sharedOmniSharpHostFixture)
+            : base(output, sharedOmniSharpHostFixture)
+        {
+        }
+
+        [Fact]
+        public async Task ProjectAnalyzers_NotFiltered_WhenSeverityIsDefault()
+        {
+            var editorconfigFile = CreateFile(".editorconfig", "root = true");
+            var testFile = CreateFile(TestFilename, TestCode);
+
+            var filteredAnalyzers = await GetFilteredProjectAnalyzersAsync(testFile, editorconfigFile);
+
+            Assert.NotEmpty(filteredAnalyzers);
+        }
+
+        [Fact]
+        public async Task ProjectAnalyzers_AllFiltered_WhenAnalyzerDiagnosticSeverityNone()
+        {
+            var editorconfigFile = CreateFile(".editorconfig", @"
+root = true
+
+[*.cs]
+# Disable all diagnostics
+dotnet_analyzer_diagnostic.severity = none
+");
+            var testFile = CreateFile(TestFilename, TestCode);
+
+            var filteredAnalyzers = await GetFilteredProjectAnalyzersAsync(testFile, editorconfigFile);
+
+            Assert.Empty(filteredAnalyzers);
+        }
+
+        [Fact]
+        public async Task ProjectAnalyzers_SingleAnalyzer_WhenSeverityIsSet()
+        {
+            var editorconfigFile = CreateFile(".editorconfig", @"
+root = true
+
+[*.cs]
+# Disable all diagnostics
+dotnet_analyzer_diagnostic.severity = none
+
+# Enable a single diagnostic
+dotnet_diagnostic.IDE0055.severity = error
+");
+            var testFile = CreateFile(TestFilename, TestCode);
+
+            var filteredAnalyzers = await GetFilteredProjectAnalyzersAsync(testFile, editorconfigFile);
+
+            Assert.Single(filteredAnalyzers);
+            Assert.Equal("IDE0055", filteredAnalyzers[0].SupportedDiagnostics[0].Id);
+        }
+
+        [Fact]
+        public async Task DocumentAnalyzers_NotFiltered_WhenSeverityIsDefault()
+        {
+            var editorconfigFile = CreateFile(".editorconfig", "root = true");
+            var testFile = CreateFile(TestFilename, TestCode);
+            var testFile2 = CreateFile(TestFilename2, TestCode);
+
+            var filteredAnalyzerMap = await GetFilteredDocumentAnalyzersAsync(testFile, testFile2, editorconfigFile);
+
+            var testFileAnalyzers = filteredAnalyzerMap[testFile];
+            Assert.NotEmpty(testFileAnalyzers);
+
+            var testFile2Analyzers = filteredAnalyzerMap[testFile2];
+            Assert.NotEmpty(testFile2Analyzers);
+
+            Assert.Equal(testFileAnalyzers.Length, testFile2Analyzers.Length);
+        }
+
+        [Fact]
+        public async Task DocumentAnalyzers_AllFiltered_WhenAnalyzerDiagnosticSeverityNone()
+        {
+            var editorconfigFile = CreateFile(".editorconfig", @"
+root = true
+
+[*.cs]
+# Disable all diagnostics
+dotnet_analyzer_diagnostic.severity = none
+");
+            var testFile = CreateFile(TestFilename, TestCode);
+            var testFile2 = CreateFile(TestFilename2, TestCode);
+
+            var filteredAnalyzerMap = await GetFilteredDocumentAnalyzersAsync(testFile, testFile2, editorconfigFile);
+
+            var testFileAnalyzers = filteredAnalyzerMap[testFile];
+            Assert.Empty(testFileAnalyzers);
+
+            var testFile2Analyzers = filteredAnalyzerMap[testFile2];
+            Assert.Empty(testFile2Analyzers);
+        }
+
+        [Fact]
+        public async Task DocumentAnalyzers_SingleAnalyzer_WhenSeverityIsSet()
+        {
+            var editorconfigFile = CreateFile(".editorconfig", $@"
+root = true
+
+[*.cs]
+# Disable all diagnostics
+dotnet_analyzer_diagnostic.severity = none
+
+[**\{TestFilename2}]
+# Enable a single diagnostic
+dotnet_diagnostic.IDE0055.severity = error
+");
+            var testFile = CreateFile(TestFilename, TestCode);
+            var testFile2 = CreateFile(TestFilename2, TestCode);
+
+            var filteredAnalyzerMap = await GetFilteredDocumentAnalyzersAsync(testFile, testFile2, editorconfigFile);
+
+            var testFileAnalyzers = filteredAnalyzerMap[testFile];
+            Assert.Empty(testFileAnalyzers);
+
+            var testFile2Analyzers = filteredAnalyzerMap[testFile2];
+            Assert.Single(testFile2Analyzers);
+            Assert.Equal("IDE0055", testFile2Analyzers[0].SupportedDiagnostics[0].Id);
+        }
+
+
+        private async Task<ImmutableArray<DiagnosticAnalyzer>> GetFilteredProjectAnalyzersAsync(TestFile codeFile, TestFile editorconfigFile)
+        {
+            using var host = CreateOmniSharpHost(new[] { codeFile, editorconfigFile });
+
+            var project = host.Workspace.CurrentSolution.Projects.Single();
+            var compilation = await project.GetCompilationAsync();
+
+            var allAnalyzers = GetConfigurableAnalyzers(host, project);
+
+            Assert.NotEmpty(allAnalyzers);
+
+            return await CSharpDiagnosticWorkerWithAnalyzers.FilterSuppressedAnalyzersAsync(allAnalyzers, project, compilation);
+        }
+
+        private async Task<ImmutableDictionary<TestFile, ImmutableArray<DiagnosticAnalyzer>>> GetFilteredDocumentAnalyzersAsync(TestFile codeFile, TestFile codeFile2, TestFile editorconfigFile)
+        {
+            using var host = CreateOmniSharpHost(new[] { codeFile, codeFile2, editorconfigFile });
+
+            var project = host.Workspace.CurrentSolution.Projects.Single();
+            var compilation = await project.GetCompilationAsync();
+
+            var allAnalyzers = GetConfigurableAnalyzers(host, project);
+
+            Assert.NotEmpty(allAnalyzers);
+
+            var analyzersMap = ImmutableDictionary.CreateBuilder<TestFile, ImmutableArray<DiagnosticAnalyzer>>();
+
+            foreach (var document in project.Documents)
+            {
+                var documentAnalyzers = await CSharpDiagnosticWorkerWithAnalyzers.FilterSuppressedAnalyzersAsync(allAnalyzers, document, project.AnalyzerOptions, compilation);
+
+                var testFile = document.FilePath == codeFile.FileName
+                    ? codeFile
+                    : codeFile2;
+                analyzersMap.Add(testFile, documentAnalyzers);
+            }
+
+            Assert.Equal(2, analyzersMap.Count);
+
+            return analyzersMap.ToImmutable();
+        }
+
+        private static TestFile CreateFile(string filename, string contents)
+            => new(Path.Combine(TestAssets.Instance.TestProjectsFolder, filename), contents);
+
+        private static ImmutableArray<DiagnosticAnalyzer> GetConfigurableAnalyzers(OmniSharpTestHost host, Project project)
+        {
+            var providers = host.CompositionHost.GetExports<ICodeActionProvider>().ToImmutableArray();
+            return providers
+                .SelectMany(x => x.CodeDiagnosticAnalyzerProviders)
+                .Concat(project.AnalyzerReferences.SelectMany(x => x.GetAnalyzers(project.Language)))
+                .Where(diagnostic => diagnostic is not DiagnosticSuppressor
+                    && !diagnostic.SupportedDiagnostics.Any(descriptor => descriptor.CustomTags.Contains(WellKnownDiagnosticTags.NotConfigurable)))
+                .ToImmutableArray();
+        }
+    }
+}

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CSharpDiagnosticWorkerWithAnalyzersFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CSharpDiagnosticWorkerWithAnalyzersFacts.cs
@@ -157,7 +157,7 @@ dotnet_diagnostic.IDE0055.severity = error
 
             Assert.NotEmpty(allAnalyzers);
 
-            return await CSharpDiagnosticWorkerWithAnalyzers.FilterSuppressedAnalyzersAsync(allAnalyzers, project, compilation);
+            return await CSharpDiagnosticWorkerWithAnalyzers.FilterAnalyzersBySeverityAsync(allAnalyzers, project, compilation, ReportDiagnostic.Hidden);
         }
 
         private async Task<ImmutableDictionary<TestFile, ImmutableArray<DiagnosticAnalyzer>>> GetFilteredDocumentAnalyzersAsync(TestFile codeFile, TestFile codeFile2, TestFile editorconfigFile)
@@ -175,7 +175,7 @@ dotnet_diagnostic.IDE0055.severity = error
 
             foreach (var document in project.Documents)
             {
-                var documentAnalyzers = await CSharpDiagnosticWorkerWithAnalyzers.FilterSuppressedAnalyzersAsync(allAnalyzers, document, project.AnalyzerOptions, compilation);
+                var documentAnalyzers = await CSharpDiagnosticWorkerWithAnalyzers.FilterAnalyzersBySeverityAsync(allAnalyzers, document, project.AnalyzerOptions, compilation, ReportDiagnostic.Hidden);
 
                 var testFile = document.FilePath == codeFile.FileName
                     ? codeFile

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SourceGeneratorFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SourceGeneratorFacts.cs
@@ -47,6 +47,7 @@ class GeneratedCode
                 "project.csproj",
                 new[] { "netcoreapp3.1" },
                 new[] { testFile },
+                analyzerConfigFiles: null,
                 otherFiles: null,
                 ImmutableArray.Create<AnalyzerReference>(reference));
 

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -56,6 +56,7 @@ namespace TestUtility
             TestFile[] otherFiles = null,
             ImmutableArray<AnalyzerReference> analyzerRefs = default)
         {
+            analyzerConfigFiles ??= Array.Empty<TestFile>();
             otherFiles ??= Array.Empty<TestFile>();
 
             var versionStamp = VersionStamp.Create();

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.ServiceModel.Configuration;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -46,7 +47,14 @@ namespace TestUtility
             workspace.AddDocument(documentInfo);
         }
 
-        public static IEnumerable<ProjectId> AddProjectToWorkspace(OmniSharpWorkspace workspace, string filePath, string[] frameworks, TestFile[] testFiles, TestFile[] otherFiles = null, ImmutableArray<AnalyzerReference> analyzerRefs = default)
+        public static IEnumerable<ProjectId> AddProjectToWorkspace(
+            OmniSharpWorkspace workspace,
+            string filePath,
+            string[] frameworks,
+            TestFile[] testFiles,
+            TestFile[] analyzerConfigFiles = null,
+            TestFile[] otherFiles = null,
+            ImmutableArray<AnalyzerReference> analyzerRefs = default)
         {
             otherFiles ??= Array.Empty<TestFile>();
 
@@ -84,6 +92,11 @@ namespace TestUtility
                 foreach (var testFile in testFiles)
                 {
                     workspace.AddDocument(projectInfo.Id, testFile.FileName, TextLoader.From(TextAndVersion.Create(testFile.Content.Text, versionStamp)), SourceCodeKind.Regular);
+                }
+
+                foreach (var analyzerConfigFile in analyzerConfigFiles)
+                {
+                    workspace.AddAnalyzerConfigDocument(projectInfo.Id, analyzerConfigFile.FileName, TextLoader.From(TextAndVersion.Create(analyzerConfigFile.Content.Text, versionStamp)));
                 }
 
                 foreach (var otherFile in otherFiles)


### PR DESCRIPTION
This change will filter the analyzers which are run by whether they can produce a meaningful diagnostic. If a diagnostic has been configured in the .editorconfig with a severity of `none`, then it should be filtered out.

Resolves https://github.com/OmniSharp/omnisharp-vscode/issues/4718