### PR TITLE
[vnext] do not throw null reference when no MSBuild was registered

### DIFF
--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -72,7 +72,7 @@ namespace OmniSharp.MSBuild
         {
             _environment = environment;
             _workspace = workspace;
-            _propertyOverrides = msbuildLocator.RegisteredInstance.PropertyOverrides;
+            _propertyOverrides = msbuildLocator.RegisteredInstance?.PropertyOverrides ?? ImmutableDictionary.Create<string, string>();
             _dotNetCli = dotNetCliService;
             _sdksPathResolver = sdksPathResolver;
             _metadataFileReferenceCache = metadataFileReferenceCache;


### PR DESCRIPTION
At the moment when no MSBuild was found the server would hard crash with a null reference exception.

This way we allow it continue further - it would still not work, but at least moves into a more appropriate failure state, where the log shows that 0 MSBuild instances are found, and then some errors about missing MSBuild dlls are written.