### PR TITLE
long paths fix - add app.manifest to stdio driver

### DIFF
--- a/src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj
+++ b/src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj
@@ -7,6 +7,7 @@
         <OutputType>Exe</OutputType>
         <PreserveCompilationContext>true</PreserveCompilationContext>
         <RuntimeIdentifiers>win7-x64;win7-x86;win10-arm64</RuntimeIdentifiers>
+        <ApplicationManifest>app.manifest</ApplicationManifest>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/OmniSharp.Stdio.Driver/app.manifest
+++ b/src/OmniSharp.Stdio.Driver/app.manifest
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <application>
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
This is to fix "Could not find a part of the path" issue (#2261)

The manifest was adapted from the manifest that is in v1.37.17 executable