### PR TITLE
Require a known good version of .NET SDK be installed.

### DIFF
--- a/src/OmniSharp.Host/HostHelpers.cs
+++ b/src/OmniSharp.Host/HostHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Extensions.Logging;
+using OmniSharp.MSBuild.Discovery;
 using OmniSharp.Roslyn;
 using OmniSharp.Utilities;
 
@@ -27,6 +28,11 @@ namespace OmniSharp
                 }
 
                 return action();
+            }
+            catch (MSBuildNotFoundException mnfe)
+            {
+                Console.Error.WriteLine(mnfe.Message);
+                return 0xbad;
             }
             catch (Exception e)
             {

--- a/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
@@ -72,7 +72,7 @@ namespace OmniSharp.MSBuild.Discovery
             }
             else
             {
-                logger.LogError("Could not locate MSBuild instance to register with OmniSharp");
+                throw new MSBuildNotFoundException("Could not locate MSBuild instance to register with OmniSharp.");
             }
         }
 

--- a/src/OmniSharp.Host/MSBuild/Discovery/MSBuildNotFoundException.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/MSBuildNotFoundException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace OmniSharp.MSBuild.Discovery
+{
+    internal class MSBuildNotFoundException : Exception
+    {
+        public MSBuildNotFoundException()
+        {
+        }
+
+        public MSBuildNotFoundException(string message) : base(message)
+        {
+        }
+
+        public MSBuildNotFoundException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/MicrosoftBuildLocatorInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/MicrosoftBuildLocatorInstanceProvider.cs
@@ -22,9 +22,17 @@ namespace OmniSharp.MSBuild.Discovery.Providers
         {
 
 #if NETCOREAPP
+            const string DotNetSdkVersion = "6.0.100";
+
             // Restrict instances to NET 6 SDK
             var instances = MicrosoftBuildLocator.QueryVisualStudioInstances()
-                .Where(instance => instance.Version.Major == 6);
+                .Where(instance => instance.Version.ToString() == DotNetSdkVersion)
+                .ToImmutableArray();
+
+            if (instances.Length == 0)
+            {
+                Logger.LogError($"OmniSharp requires .NET SDK version '{DotNetSdkVersion}' be installed. Please visit https://dotnet.microsoft.com/download/dotnet/6.0 to download the .NET SDK.");
+            }
 #else
             if (!PlatformHelper.IsWindows)
             {


### PR DESCRIPTION
Since we fail when loading SDKs with mismatched NuGet.Framework, we can limit our SDK discovery to a known good SDK version.