### PR TITLE
Allow for alternate versions of documents to be semantically highlighted

### DIFF
--- a/src/OmniSharp.Abstractions/Models/v2/SemanticHighlight/SemanticHighlightRequest.cs
+++ b/src/OmniSharp.Abstractions/Models/v2/SemanticHighlight/SemanticHighlightRequest.cs
@@ -7,10 +7,15 @@ namespace OmniSharp.Models.SemanticHighlight
     public class SemanticHighlightRequest : Request
     {
         /// <summary>
-        ///   Specifies the range to highlight.
-        ///   If none is given, highlight the entire
-        ///   file.
+        ///   Specifies the range to highlight. If none is given, highlight the entire file.
         /// </summary>
         public Range Range { get; set; }
+
+        /// <summary>
+        ///   Optionally provide the text for a different version of the document to be highlighted.
+        ///   This property works differently than the Buffer property, since it is only used for
+        ///   highlighting and will not update the document in the CurrentSolution.
+        /// </summary>
+        public string VersionedText { get; set; }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/SemanticHighlight/SemanticHighlightService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/SemanticHighlight/SemanticHighlightService.cs
@@ -33,7 +33,12 @@ namespace OmniSharp.Roslyn.CSharp.Services.SemanticHighlight
             foreach (var document in documents)
             {
                 var project = document.Project.Name;
-                var text = await document.GetTextAsync();
+
+                var highlightDocument = request.VersionedText != null
+                    ? document.WithText(SourceText.From(request.VersionedText))
+                    : document;
+
+                var text = await highlightDocument.GetTextAsync();
 
                 TextSpan textSpan;
                 if (request.Range is object)
@@ -55,7 +60,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.SemanticHighlight
                     textSpan = new TextSpan(0, text.Length);
                 }
 
-                results.AddRange((await Classifier.GetClassifiedSpansAsync(document, textSpan))
+                results.AddRange((await Classifier.GetClassifiedSpansAsync(highlightDocument, textSpan))
                     .Select(span => new ClassifiedResult()
                     {
                         Span = span,

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SemanticHighlightFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SemanticHighlightFacts.cs
@@ -31,7 +31,7 @@ namespace N1
 ");
 
             var line = -1;
-            var highlights = await GetSemanticHighlightsForLineAsync(testFile, line);
+            var highlights = await GetSemanticHighlightsForLineAsync(testFile, line, versionedText: null);
 
             Assert.Empty(highlights);
         }
@@ -47,7 +47,7 @@ namespace N1
 ");
 
             var line = 3;
-            var highlights = await GetSemanticHighlightsForLineAsync(testFile, line);
+            var highlights = await GetSemanticHighlightsForLineAsync(testFile, line, versionedText: null);
 
             AssertSyntax(highlights, testFile.Content.Code, line,
                 Keyword("class"),
@@ -89,6 +89,42 @@ namespace N1
                 Punctuation("}")
             );
         }
+
+        [Fact]
+        public async Task SemanticHighlightEntireFileWithVersionedText()
+        {
+            var testFile = new TestFile("a.cs", @"
+namespace N1
+{
+    class C1 { int n = true; }
+}
+");
+            var versionedText = @"
+namespace N1
+{
+    class C { int n = false; }
+}
+";
+
+            var highlights = await GetSemanticHighlightsForFileAsync(testFile, versionedText);
+
+            AssertSyntax(highlights, versionedText, 0,
+                Keyword("namespace"),
+                NamespaceName("N1"),
+                Punctuation("{"),
+                Keyword("class"),
+                ClassName("C"),
+                Punctuation("{"),
+                Keyword("int"),
+                Field("n"),
+                Operator("="),
+                Keyword("false"),
+                Punctuation(";"),
+                Punctuation("}"),
+                Punctuation("}")
+            );
+        }
+
 
         [Fact]
         public async Task SemanticHighlightStringInterpolation()
@@ -317,10 +353,15 @@ record struct R1(string S, int I);
 
         private Task<SemanticHighlightSpan[]> GetSemanticHighlightsForFileAsync(TestFile testFile)
         {
-            return GetSemanticHighlightsAsync(testFile, range: null);
+            return GetSemanticHighlightsAsync(testFile, range: null, versionedText: null);
         }
 
-        private Task<SemanticHighlightSpan[]> GetSemanticHighlightsForLineAsync(TestFile testFile, int line)
+        private Task<SemanticHighlightSpan[]> GetSemanticHighlightsForFileAsync(TestFile testFile, string versionedText)
+        {
+            return GetSemanticHighlightsAsync(testFile, range: null, versionedText);
+        }
+
+        private Task<SemanticHighlightSpan[]> GetSemanticHighlightsForLineAsync(TestFile testFile, int line, string versionedText)
         {
             var range = new Range()
             {
@@ -328,17 +369,18 @@ record struct R1(string S, int I);
                 End = new Point() { Column = 0, Line = line + 1 }
             };
 
-            return GetSemanticHighlightsAsync(testFile, range);
+            return GetSemanticHighlightsAsync(testFile, range, versionedText);
         }
 
-        private async Task<SemanticHighlightSpan[]> GetSemanticHighlightsAsync(TestFile testFile, Range range)
+        private async Task<SemanticHighlightSpan[]> GetSemanticHighlightsAsync(TestFile testFile, Range range, string versionedText)
         {
             SharedOmniSharpTestHost.AddFilesToWorkspace(testFile);
             var requestHandler = GetRequestHandler(SharedOmniSharpTestHost);
             var request = new SemanticHighlightRequest
             {
                 FileName = testFile.FileName,
-                Range = range
+                Range = range,
+                VersionedText = versionedText,
             };
 
             var response = await requestHandler.Handle(request);


### PR DESCRIPTION
To fix diff highlighting in the VSCode C# extension, we need to pass along alternate versions of the document we are highlighting. Request has a `Buffer` property but populating that will invoke the updateBufferHandler when the request is handled (as alluded to in https://github.com/OmniSharp/omnisharp-vscode/pull/4915#discussion_r760604439).
https://github.com/OmniSharp/omnisharp-roslyn/blob/52f9ed3efbd2aa85afd3feb1433462474ad30fcd/src/OmniSharp.Host/Endpoint/EndpointHandler.cs#L109-L116

This PR adds an optional `VersionedText` property to the highlight request which can carry the alternate version of the document contents. The highlight service will then swap the document text for the duration of the request when it is populated.