### PR TITLE
Allow net6 build of O# to load newer .NET SDKs

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -919,51 +919,51 @@ Task("PublishNet6Builds")
         {
             if (!Platform.Current.IsWindows)
             {
-                PublishBuild(project, env, buildPlan, configuration, "linux-x64", "net6.0", includeMSBuild: false);
-                PublishBuild(project, env, buildPlan, configuration, "linux-arm64", "net6.0", includeMSBuild: false);
-                PublishBuild(project, env, buildPlan, configuration, "osx-x64", "net6.0", includeMSBuild: false);
-                PublishBuild(project, env, buildPlan, configuration, "osx-arm64", "net6.0", includeMSBuild: false);
+                PublishBuild(project, env, buildPlan, configuration, "linux-x64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "linux-arm64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "osx-x64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "osx-arm64", "net6.0");
             }
             else
             {
-                PublishBuild(project, env, buildPlan, configuration, "win7-x86", "net6.0", includeMSBuild: false);
-                PublishBuild(project, env, buildPlan, configuration, "win7-x64", "net6.0", includeMSBuild: false);
-                PublishBuild(project, env, buildPlan, configuration, "win10-arm64", "net6.0", includeMSBuild: false);
+                PublishBuild(project, env, buildPlan, configuration, "win7-x86", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "win7-x64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "win10-arm64", "net6.0");
             }
         }
         else if (Platform.Current.IsWindows)
         {
             if (Platform.Current.IsX86)
             {
-                PublishBuild(project, env, buildPlan, configuration, "win7-x86", "net6.0", includeMSBuild: false);
+                PublishBuild(project, env, buildPlan, configuration, "win7-x86", "net6.0");
             }
             else if (Platform.Current.IsX64)
             {
-                PublishBuild(project, env, buildPlan, configuration, "win7-x64", "net6.0", includeMSBuild: false);
+                PublishBuild(project, env, buildPlan, configuration, "win7-x64", "net6.0");
             }
             else
             {
-                PublishBuild(project, env, buildPlan, configuration, "win10-arm64", "net6.0", includeMSBuild: false);
+                PublishBuild(project, env, buildPlan, configuration, "win10-arm64", "net6.0");
             }
         }
         else
         {
             if (Platform.Current.IsMacOS)
             {
-                PublishBuild(project, env, buildPlan, configuration, "osx-x64", "net6.0", includeMSBuild: false);
-                PublishBuild(project, env, buildPlan, configuration, "osx-arm64", "net6.0", includeMSBuild: false);
+                PublishBuild(project, env, buildPlan, configuration, "osx-x64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "osx-arm64", "net6.0");
             }
             else
             {
-                PublishBuild(project, env, buildPlan, configuration, "linux-x64", "net6.0", includeMSBuild: false);
-                PublishBuild(project, env, buildPlan, configuration, "linux-arm64", "net6.0", includeMSBuild: false);
+                PublishBuild(project, env, buildPlan, configuration, "linux-x64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "linux-arm64", "net6.0");
             }
         }
 
     }
 });
 
-string PublishBuild(string project, BuildEnvironment env, BuildPlan plan, string configuration, string rid, string framework, bool includeMSBuild)
+string PublishBuild(string project, BuildEnvironment env, BuildPlan plan, string configuration, string rid, string framework)
 {
     var projectName = project + ".csproj";
     var projectFileName = CombinePaths(env.Folders.Source, project, projectName);
@@ -998,7 +998,15 @@ string PublishBuild(string project, BuildEnvironment env, BuildPlan plan, string
         throw;
     }
 
-    if (includeMSBuild)
+    if (framework is "net6.0")
+    {
+        // Delete NuGet libraries so they can be loaded from SDK folder.
+        foreach (var filePath in DirectoryHelper.GetFiles(outputFolder, "NuGet.*.dll"))
+        {
+            FileHelper.Delete(filePath);
+        }
+    }
+    else
     {
         // Copy MSBuild to output
         DirectoryHelper.Copy($"{env.Folders.MSBuild}", CombinePaths(outputFolder, ".msbuild"));
@@ -1024,9 +1032,9 @@ Task("PublishWindowsBuilds")
 
         if (publishAll)
         {
-            var outputFolderX86 = PublishBuild(project, env, buildPlan, configuration, "win7-x86", "net472", includeMSBuild: true);
-            var outputFolderX64 = PublishBuild(project, env, buildPlan, configuration, "win7-x64", "net472", includeMSBuild: true);
-            var outputFolderArm64 = PublishBuild(project, env, buildPlan, configuration, "win10-arm64", "net472", includeMSBuild: true);
+            var outputFolderX86 = PublishBuild(project, env, buildPlan, configuration, "win7-x86", "net472");
+            var outputFolderX64 = PublishBuild(project, env, buildPlan, configuration, "win7-x64", "net472");
+            var outputFolderArm64 = PublishBuild(project, env, buildPlan, configuration, "win10-arm64", "net472");
 
             outputFolder = Platform.Current.IsX86
                 ? outputFolderX86
@@ -1036,15 +1044,15 @@ Task("PublishWindowsBuilds")
         }
         else if (Platform.Current.IsX86)
         {
-            outputFolder = PublishBuild(project, env, buildPlan, configuration, "win7-x86", "net472", includeMSBuild: true);
+            outputFolder = PublishBuild(project, env, buildPlan, configuration, "win7-x86", "net472");
         }
         else if (Platform.Current.IsX64)
         {
-            outputFolder = PublishBuild(project, env, buildPlan, configuration, "win7-x64", "net472", includeMSBuild: true);
+            outputFolder = PublishBuild(project, env, buildPlan, configuration, "win7-x64", "net472");
         }
         else
         {
-            outputFolder = PublishBuild(project, env, buildPlan, configuration, "win10-arm64", "net472", includeMSBuild: true);
+            outputFolder = PublishBuild(project, env, buildPlan, configuration, "win10-arm64", "net472");
         }
 
         CreateRunScript(project, outputFolder, env.Folders.ArtifactsScripts);

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -41,9 +41,14 @@ public static class FileHelper
 
 public static class DirectoryHelper
 {
+    public static string[] GetFiles(string path, string searchPattern = "*.*")
+    {
+        return System.IO.Directory.GetFiles(path, searchPattern);
+    }
+
     public static void Copy(string source, string destination, bool copySubDirectories = true)
     {
-        var files = System.IO.Directory.GetFiles(source);
+        var files = GetFiles(source);
         var subDirectories = System.IO.Directory.GetDirectories(source);
 
         if (!Exists(destination))

--- a/src/OmniSharp.Abstractions/SemanticVersion.cs
+++ b/src/OmniSharp.Abstractions/SemanticVersion.cs
@@ -1,0 +1,591 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Original source from https://github.com/PowerShell/PowerShell/blob/f8d6b2f9fefe8467061f04986644aa47c2d10038/src/System.Management.Automation/engine/PSVersionInfo.cs
+// Modified to remove PSObj and PSTraceSource use. Includes parsing fix from https://github.com/PowerShell/PowerShell/pull/16608
+
+using System;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace OmniSharp
+{
+    /// <summary>
+    /// An implementation of semantic versioning (https://semver.org)
+    /// </summary>
+    public sealed class SemanticVersion : IComparable, IComparable<SemanticVersion>, IEquatable<SemanticVersion>
+    {
+        private const string VersionSansRegEx = @"^(?<major>(0|[1-9]\d*))\.(?<minor>(0|[1-9]\d*))\.(?<patch>(0|[1-9]\d*))$";
+        private const string LabelRegEx = @"^((?<preLabel>[0-9A-Za-z][0-9A-Za-z\-\.]*))?(\+(?<buildLabel>[0-9A-Za-z][0-9A-Za-z\-\.]*))?$";
+        private const string LabelUnitRegEx = @"^[0-9A-Za-z][0-9A-Za-z\-\.]*$";
+
+        private string versionString;
+
+        /// <summary>
+        /// Construct a SemanticVersion from a string.
+        /// </summary>
+        /// <param name="version">The version to parse.</param>
+        /// <exception cref="FormatException"></exception>
+        /// <exception cref="OverflowException"></exception>
+        public SemanticVersion(string version)
+        {
+            var v = SemanticVersion.Parse(version);
+
+            Major = v.Major;
+            Minor = v.Minor;
+            Patch = v.Patch < 0 ? 0 : v.Patch;
+            PreReleaseLabel = v.PreReleaseLabel;
+            BuildLabel = v.BuildLabel;
+        }
+
+        /// <summary>
+        /// Construct a SemanticVersion.
+        /// </summary>
+        /// <param name="major">The major version.</param>
+        /// <param name="minor">The minor version.</param>
+        /// <param name="patch">The patch version.</param>
+        /// <param name="preReleaseLabel">The pre-release label for the version.</param>
+        /// <param name="buildLabel">The build metadata for the version.</param>
+        /// <exception cref="FormatException">
+        /// If <paramref name="preReleaseLabel"/> don't match 'LabelUnitRegEx'.
+        /// If <paramref name="buildLabel"/> don't match 'LabelUnitRegEx'.
+        /// </exception>
+        public SemanticVersion(int major, int minor, int patch, string preReleaseLabel, string buildLabel)
+            : this(major, minor, patch)
+        {
+            if (!string.IsNullOrEmpty(preReleaseLabel))
+            {
+                if (!Regex.IsMatch(preReleaseLabel, LabelUnitRegEx)) throw new FormatException(nameof(preReleaseLabel));
+
+                PreReleaseLabel = preReleaseLabel;
+            }
+
+            if (!string.IsNullOrEmpty(buildLabel))
+            {
+                if (!Regex.IsMatch(buildLabel, LabelUnitRegEx)) throw new FormatException(nameof(buildLabel));
+
+                BuildLabel = buildLabel;
+            }
+        }
+
+        /// <summary>
+        /// Construct a SemanticVersion.
+        /// </summary>
+        /// <param name="major">The major version.</param>
+        /// <param name="minor">The minor version.</param>
+        /// <param name="patch">The minor version.</param>
+        /// <param name="label">The label for the version.</param>
+        /// <exception cref="PSArgumentException">
+        /// <exception cref="FormatException">
+        /// If <paramref name="label"/> don't match 'LabelRegEx'.
+        /// </exception>
+        public SemanticVersion(int major, int minor, int patch, string label)
+            : this(major, minor, patch)
+        {
+            // We presume the SymVer :
+            // 1) major.minor.patch-label
+            // 2) 'label' starts with letter or digit.
+            if (!string.IsNullOrEmpty(label))
+            {
+                var match = Regex.Match(label, LabelRegEx);
+                if (!match.Success) throw new FormatException(nameof(label));
+
+                PreReleaseLabel = match.Groups["preLabel"].Value;
+                BuildLabel = match.Groups["buildLabel"].Value;
+            }
+        }
+
+        /// <summary>
+        /// Construct a SemanticVersion.
+        /// </summary>
+        /// <param name="major">The major version.</param>
+        /// <param name="minor">The minor version.</param>
+        /// <param name="patch">The minor version.</param>
+        /// <exception cref="PSArgumentException">
+        /// If <paramref name="major"/>, <paramref name="minor"/>, or <paramref name="patch"/> is less than 0.
+        /// </exception>
+        public SemanticVersion(int major, int minor, int patch)
+        {
+            if (major < 0) throw new ArgumentException("Major version cannot be less than 0", nameof(major));
+            if (minor < 0) throw new ArgumentException("Minor version cannot be less than 0", nameof(minor));
+            if (patch < 0) throw new ArgumentException("Patch version cannot be less than 0", nameof(patch));
+
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+            // We presume:
+            // PreReleaseLabel = null;
+            // BuildLabel = null;
+        }
+
+        /// <summary>
+        /// Construct a SemanticVersion.
+        /// </summary>
+        /// <param name="major">The major version.</param>
+        /// <param name="minor">The minor version.</param>
+        /// <exception cref="PSArgumentException">
+        /// If <paramref name="major"/> or <paramref name="minor"/> is less than 0.
+        /// </exception>
+        public SemanticVersion(int major, int minor) : this(major, minor, 0) { }
+
+        /// <summary>
+        /// Construct a SemanticVersion.
+        /// </summary>
+        /// <param name="major">The major version.</param>
+        /// <exception cref="PSArgumentException">
+        /// If <paramref name="major"/> is less than 0.
+        /// </exception>
+        public SemanticVersion(int major) : this(major, 0, 0) { }
+
+        /// <summary>
+        /// The major version number, never negative.
+        /// </summary>
+        public int Major { get; }
+
+        /// <summary>
+        /// The minor version number, never negative.
+        /// </summary>
+        public int Minor { get; }
+
+        /// <summary>
+        /// The patch version, -1 if not specified.
+        /// </summary>
+        public int Patch { get; }
+
+        /// <summary>
+        /// PreReleaseLabel position in the SymVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
+        /// </summary>
+        public string PreReleaseLabel { get; }
+
+        /// <summary>
+        /// BuildLabel position in the SymVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
+        /// </summary>
+        public string BuildLabel { get; }
+
+        /// <summary>
+        /// Parse <paramref name="version"/> and return the result if it is a valid <see cref="SemanticVersion"/>, otherwise throws an exception.
+        /// </summary>
+        /// <param name="version">The string to parse.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="FormatException"></exception>
+        /// <exception cref="OverflowException"></exception>
+        public static SemanticVersion Parse(string version)
+        {
+            if (version == null) throw new ArgumentNullException(nameof(version));
+            if (version == string.Empty) throw new FormatException(nameof(version));
+
+            var r = new VersionResult();
+            r.Init(true);
+            TryParseVersion(version, ref r);
+
+            return r._parsedVersion;
+        }
+
+        /// <summary>
+        /// Parse <paramref name="version"/> and return true if it is a valid <see cref="SemanticVersion"/>, otherwise return false.
+        /// No exceptions are raised.
+        /// </summary>
+        /// <param name="version">The string to parse.</param>
+        /// <param name="result">The return value when the string is a valid <see cref="SemanticVersion"/></param>
+        public static bool TryParse(string version, out SemanticVersion result)
+        {
+            if (version != null)
+            {
+                var r = new VersionResult();
+                r.Init(false);
+
+                if (TryParseVersion(version, ref r))
+                {
+                    result = r._parsedVersion;
+                    return true;
+                }
+            }
+
+            result = null;
+            return false;
+        }
+
+        private static bool TryParseVersion(string version, ref VersionResult result)
+        {
+            if (version.EndsWith("-") || version.EndsWith("+") || version.EndsWith("."))
+            {
+                result.SetFailure(ParseFailureKind.FormatException);
+                return false;
+            }
+
+            string versionSansLabel = null;
+            var major = 0;
+            var minor = 0;
+            var patch = 0;
+            string preLabel = null;
+            string buildLabel = null;
+
+            // We parse the SymVer 'version' string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
+            var dashIndex = version.IndexOf('-');
+            var plusIndex = version.IndexOf('+');
+
+            if (dashIndex > plusIndex)
+            {
+                // 'PreReleaseLabel' can contains dashes.
+                if (plusIndex == -1)
+                {
+                    // No buildLabel: buildLabel == null
+                    // Format is 'major.minor.patch-PreReleaseLabel'
+                    preLabel = version.Substring(dashIndex + 1);
+                    versionSansLabel = version.Substring(0, dashIndex);
+                }
+                else
+                {
+                    // No PreReleaseLabel: preLabel == null
+                    // Format is 'major.minor.patch+BuildLabel'
+                    buildLabel = version.Substring(plusIndex + 1);
+                    versionSansLabel = version.Substring(0, plusIndex);
+                    dashIndex = -1;
+                }
+            }
+            else
+            {
+                if (plusIndex == -1)
+                {
+                    // Here dashIndex == plusIndex == -1
+                    // No preLabel - preLabel == null;
+                    // No buildLabel - buildLabel == null;
+                    // Format is 'major.minor.patch'
+                    versionSansLabel = version;
+                }
+                else if (dashIndex == -1)
+                {
+                    // No PreReleaseLabel: preLabel == null
+                    // Format is 'major.minor.patch+BuildLabel'
+                    buildLabel = version.Substring(plusIndex + 1);
+                    versionSansLabel = version.Substring(0, plusIndex);
+                }
+                else
+                {
+                    // Format is 'major.minor.patch-PreReleaseLabel+BuildLabel'
+                    preLabel = version.Substring(dashIndex + 1, plusIndex - dashIndex - 1);
+                    buildLabel = version.Substring(plusIndex + 1);
+                    versionSansLabel = version.Substring(0, dashIndex);
+                }
+            }
+
+            if ((dashIndex != -1 && string.IsNullOrEmpty(preLabel)) ||
+                (plusIndex != -1 && string.IsNullOrEmpty(buildLabel)) ||
+                string.IsNullOrEmpty(versionSansLabel))
+            {
+                // We have dash and no preReleaseLabel  or
+                // we have plus and no buildLabel or
+                // we have no main version part (versionSansLabel==null)
+                result.SetFailure(ParseFailureKind.FormatException);
+                return false;
+            }
+
+            var match = Regex.Match(versionSansLabel, VersionSansRegEx);
+            if (!match.Success)
+            {
+                result.SetFailure(ParseFailureKind.FormatException);
+                return false;
+            }
+
+            if (!int.TryParse(match.Groups["major"].Value, out major))
+            {
+                result.SetFailure(ParseFailureKind.FormatException);
+                return false;
+            }
+
+            if (match.Groups["minor"].Success && !int.TryParse(match.Groups["minor"].Value, out minor))
+            {
+                result.SetFailure(ParseFailureKind.FormatException);
+                return false;
+            }
+
+            if (match.Groups["patch"].Success && !int.TryParse(match.Groups["patch"].Value, out patch))
+            {
+                result.SetFailure(ParseFailureKind.FormatException);
+                return false;
+            }
+
+            if (preLabel != null && !Regex.IsMatch(preLabel, LabelUnitRegEx) ||
+               (buildLabel != null && !Regex.IsMatch(buildLabel, LabelUnitRegEx)))
+            {
+                result.SetFailure(ParseFailureKind.FormatException);
+                return false;
+            }
+
+            result._parsedVersion = new SemanticVersion(major, minor, patch, preLabel, buildLabel);
+            return true;
+        }
+
+        /// <summary>
+        /// Implement ToString()
+        /// </summary>
+        public override string ToString()
+        {
+            if (versionString == null)
+            {
+                var result = new StringBuilder();
+
+                result.Append(Major).Append('.').Append(Minor).Append('.').Append(Patch);
+
+                if (!string.IsNullOrEmpty(PreReleaseLabel))
+                {
+                    result.Append('-').Append(PreReleaseLabel);
+                }
+
+                if (!string.IsNullOrEmpty(BuildLabel))
+                {
+                    result.Append('+').Append(BuildLabel);
+                }
+
+                versionString = result.ToString();
+            }
+
+            return versionString;
+        }
+
+        /// <summary>
+        /// Implement Compare.
+        /// </summary>
+        public static int Compare(SemanticVersion versionA, SemanticVersion versionB)
+        {
+            if (versionA != null)
+            {
+                return versionA.CompareTo(versionB);
+            }
+
+            if (versionB != null)
+            {
+                return -1;
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Implement <see cref="IComparable.CompareTo"/>
+        /// </summary>
+        public int CompareTo(object version)
+        {
+            if (version == null)
+            {
+                return 1;
+            }
+
+            return CompareTo(version as SemanticVersion);
+        }
+
+        /// <summary>
+        /// Implement <see cref="IComparable{T}.CompareTo"/>.
+        /// Meets SymVer 2.0 p.11 https://semver.org/
+        /// </summary>
+        public int CompareTo(SemanticVersion value)
+        {
+            if (value is null)
+                return 1;
+
+            if (Major != value.Major)
+                return Major > value.Major ? 1 : -1;
+
+            if (Minor != value.Minor)
+                return Minor > value.Minor ? 1 : -1;
+
+            if (Patch != value.Patch)
+                return Patch > value.Patch ? 1 : -1;
+
+            // SymVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
+            return ComparePreLabel(this.PreReleaseLabel, value.PreReleaseLabel);
+        }
+
+        /// <summary>
+        /// Override <see cref="object.Equals(object)"/>
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as SemanticVersion);
+        }
+
+        /// <summary>
+        /// Implement <see cref="IEquatable{T}.Equals(T)"/>
+        /// </summary>
+        public bool Equals(SemanticVersion other)
+        {
+            // SymVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
+            return other != null &&
+                   (Major == other.Major) && (Minor == other.Minor) && (Patch == other.Patch) &&
+                   string.Equals(PreReleaseLabel, other.PreReleaseLabel, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Override <see cref="object.GetHashCode()"/>
+        /// </summary>
+        public override int GetHashCode()
+        {
+            return this.ToString().GetHashCode();
+        }
+
+        /// <summary>
+        /// Overloaded == operator.
+        /// </summary>
+        public static bool operator ==(SemanticVersion v1, SemanticVersion v2)
+        {
+            if (v1 is null)
+            {
+                return v2 is null;
+            }
+
+            return v1.Equals(v2);
+        }
+
+        /// <summary>
+        /// Overloaded != operator.
+        /// </summary>
+        public static bool operator !=(SemanticVersion v1, SemanticVersion v2)
+        {
+            return !(v1 == v2);
+        }
+
+        /// <summary>
+        /// Overloaded &lt; operator.
+        /// </summary>
+        public static bool operator <(SemanticVersion v1, SemanticVersion v2)
+        {
+            return (Compare(v1, v2) < 0);
+        }
+
+        /// <summary>
+        /// Overloaded &lt;= operator.
+        /// </summary>
+        public static bool operator <=(SemanticVersion v1, SemanticVersion v2)
+        {
+            return (Compare(v1, v2) <= 0);
+        }
+
+        /// <summary>
+        /// Overloaded &gt; operator.
+        /// </summary>
+        public static bool operator >(SemanticVersion v1, SemanticVersion v2)
+        {
+            return (Compare(v1, v2) > 0);
+        }
+
+        /// <summary>
+        /// Overloaded &gt;= operator.
+        /// </summary>
+        public static bool operator >=(SemanticVersion v1, SemanticVersion v2)
+        {
+            return (Compare(v1, v2) >= 0);
+        }
+
+        private static int ComparePreLabel(string preLabel1, string preLabel2)
+        {
+            // Symver 2.0 standard p.9
+            // Pre-release versions have a lower precedence than the associated normal version.
+            // Comparing each dot separated identifier from left to right
+            // until a difference is found as follows:
+            //     identifiers consisting of only digits are compared numerically
+            //     and identifiers with letters or hyphens are compared lexically in ASCII sort order.
+            // Numeric identifiers always have lower precedence than non-numeric identifiers.
+            // A larger set of pre-release fields has a higher precedence than a smaller set,
+            // if all of the preceding identifiers are equal.
+            if (string.IsNullOrEmpty(preLabel1)) { return string.IsNullOrEmpty(preLabel2) ? 0 : 1; }
+
+            if (string.IsNullOrEmpty(preLabel2)) { return -1; }
+
+            var units1 = preLabel1.Split('.');
+            var units2 = preLabel2.Split('.');
+
+            var minLength = units1.Length < units2.Length ? units1.Length : units2.Length;
+
+            for (int i = 0; i < minLength; i++)
+            {
+                var ac = units1[i];
+                var bc = units2[i];
+                int number1, number2;
+                var isNumber1 = Int32.TryParse(ac, out number1);
+                var isNumber2 = Int32.TryParse(bc, out number2);
+
+                if (isNumber1 && isNumber2)
+                {
+                    if (number1 != number2) { return number1 < number2 ? -1 : 1; }
+                }
+                else
+                {
+                    if (isNumber1) { return -1; }
+
+                    if (isNumber2) { return 1; }
+
+                    int result = string.CompareOrdinal(ac, bc);
+                    if (result != 0) { return result; }
+                }
+            }
+
+            return units1.Length.CompareTo(units2.Length);
+        }
+
+        internal enum ParseFailureKind
+        {
+            ArgumentException,
+            ArgumentOutOfRangeException,
+            FormatException
+        }
+
+        internal struct VersionResult
+        {
+            internal SemanticVersion _parsedVersion;
+            internal ParseFailureKind _failure;
+            internal string _exceptionArgument;
+            internal bool _canThrow;
+
+            internal void Init(bool canThrow)
+            {
+                _canThrow = canThrow;
+            }
+
+            internal void SetFailure(ParseFailureKind failure)
+            {
+                SetFailure(failure, string.Empty);
+            }
+
+            internal void SetFailure(ParseFailureKind failure, string argument)
+            {
+                _failure = failure;
+                _exceptionArgument = argument;
+                if (_canThrow)
+                {
+                    throw GetVersionParseException();
+                }
+            }
+
+            internal Exception GetVersionParseException()
+            {
+                switch (_failure)
+                {
+                    case ParseFailureKind.ArgumentException:
+                        return new ArgumentException("version");
+                    case ParseFailureKind.ArgumentOutOfRangeException:
+                        throw new ArgumentOutOfRangeException("version");
+                    case ParseFailureKind.FormatException:
+                        // Regenerate the FormatException as would be thrown by Int32.Parse()
+                        try
+                        {
+                            int.Parse(_exceptionArgument, CultureInfo.InvariantCulture);
+                        }
+                        catch (FormatException e)
+                        {
+                            return e;
+                        }
+                        catch (OverflowException e)
+                        {
+                            return e;
+                        }
+
+                        break;
+                }
+
+                return new ArgumentException("version");
+            }
+        }
+    }
+}

--- a/src/OmniSharp.Abstractions/Services/DotNetInfo.cs
+++ b/src/OmniSharp.Abstractions/Services/DotNetInfo.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using NuGet.Versioning;
 
 namespace OmniSharp.Services
 {

--- a/src/OmniSharp.Abstractions/Services/IDotNetCliService.cs
+++ b/src/OmniSharp.Abstractions/Services/IDotNetCliService.cs
@@ -1,5 +1,4 @@
-﻿using NuGet.Versioning;
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 

--- a/src/OmniSharp.DotNetTest/TestManager.cs
+++ b/src/OmniSharp.DotNetTest/TestManager.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using NuGet.Versioning;
 using OmniSharp.DotNetTest.Models;
 using OmniSharp.DotNetTest.Models.Events;
 using OmniSharp.Eventing;
@@ -83,7 +82,7 @@ namespace OmniSharp.DotNetTest
         public abstract Task<RunTestResponse> RunTestAsync(string[] methodNames, string runSettings, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken);
 
         public abstract Task<DiscoverTestsResponse> DiscoverTestsAsync(string runSettings, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken);
-        
+
         public abstract Task<GetTestStartInfoResponse> GetTestStartInfoAsync(string methodName, string runSettings, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken);
 
         public abstract Task<DebugTestGetStartInfoResponse> DebugGetStartInfoAsync(string methodName, string runSettings, string testFrameworkName, string targetFrameworkVersion, CancellationToken cancellationToken);

--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -15,7 +15,6 @@ using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using NuGet.Versioning;
 using OmniSharp.DotNetTest.Models;
 using OmniSharp.DotNetTest.TestFrameworks;
 using OmniSharp.Eventing;

--- a/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Extensions.cs
@@ -163,7 +163,7 @@ namespace OmniSharp.MSBuild.Discovery
 
             var version = dotNetInfo.SdkVersion;
             var sdksPath = dotNetInfo.SdksPath;
-            var minimumVersionPath = Path.Combine(sdksPath, version.ToNormalizedString(), "minimumMSBuildVersion");
+            var minimumVersionPath = Path.Combine(sdksPath, version.ToString(), "minimumMSBuildVersion");
 
             if (!File.Exists(minimumVersionPath))
             {

--- a/src/OmniSharp.Host/MSBuild/Discovery/MSBuildInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/MSBuildInstanceProvider.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
-using NuGet.Versioning;
 
 namespace OmniSharp.MSBuild.Discovery
 {

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/MicrosoftBuildLocatorInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/MicrosoftBuildLocatorInstanceProvider.cs
@@ -22,16 +22,15 @@ namespace OmniSharp.MSBuild.Discovery.Providers
         {
 
 #if NETCOREAPP
-            const string DotNetSdkVersion = "6.0.100";
-
             // Restrict instances to NET 6 SDK
             var instances = MicrosoftBuildLocator.QueryVisualStudioInstances()
-                .Where(instance => instance.Version.ToString() == DotNetSdkVersion)
+                .Where(instance => instance.Version.Major == 6)
+                .OrderByDescending(instance => instance.Version)
                 .ToImmutableArray();
 
             if (instances.Length == 0)
             {
-                Logger.LogError($"OmniSharp requires .NET SDK version '{DotNetSdkVersion}' be installed. Please visit https://dotnet.microsoft.com/download/dotnet/6.0 to download the .NET SDK.");
+                Logger.LogError($"OmniSharp requires the .NET 6 SDK be installed. Please visit https://dotnet.microsoft.com/download/dotnet/6.0 to download the .NET SDK.");
             }
 #else
             if (!PlatformHelper.IsWindows)

--- a/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
+++ b/src/OmniSharp.Host/MSBuild/Discovery/Providers/StandAloneInstanceProvider.cs
@@ -3,7 +3,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using Microsoft.Extensions.Logging;
-using NuGet.Versioning;
 using OmniSharp.Utilities;
 
 namespace OmniSharp.MSBuild.Discovery.Providers

--- a/src/OmniSharp.Host/Services/DotNetCliService.cs
+++ b/src/OmniSharp.Host/Services/DotNetCliService.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using NuGet.Versioning;
 using OmniSharp.Eventing;
 using OmniSharp.Options;
 using OmniSharp.Utilities;
@@ -209,8 +208,8 @@ namespace OmniSharp.Services
                 version.Minor == 0 &&
                 version.Patch == 0)
             {
-                if (version.Release.StartsWith("preview1") ||
-                    version.Release.StartsWith("preview2"))
+                if (version.PreReleaseLabel.StartsWith("preview1") ||
+                    version.PreReleaseLabel.StartsWith("preview2"))
                 {
                     return true;
                 }

--- a/src/OmniSharp.MSBuild/Notification/ProjectLoadedEventArgs.cs
+++ b/src/OmniSharp.MSBuild/Notification/ProjectLoadedEventArgs.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
-using NuGet.Versioning;
 using OmniSharp.MSBuild.Logging;
 using MSB = Microsoft.Build;
 

--- a/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
+++ b/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
@@ -1,5 +1,4 @@
-﻿using NuGet.Versioning;
-using OmniSharp.Services;
+﻿using OmniSharp.Services;
 using TestUtility;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,7 +20,7 @@ namespace OmniSharp.Tests
             Major = version.Major;
             Minor = version.Minor;
             Patch = version.Patch;
-            Release = version.Release;
+            Release = version.PreReleaseLabel;
         }
 
         [Fact]
@@ -36,7 +35,7 @@ namespace OmniSharp.Tests
                 Assert.Equal(Major, version.Major);
                 Assert.Equal(Minor, version.Minor);
                 Assert.Equal(Patch, version.Patch);
-                Assert.Equal(Release, version.Release);
+                Assert.Equal(Release, version.PreReleaseLabel);
             }
         }
 
@@ -52,7 +51,7 @@ namespace OmniSharp.Tests
                 Assert.Equal(Major, info.Version.Major);
                 Assert.Equal(Minor, info.Version.Minor);
                 Assert.Equal(Patch, info.Version.Patch);
-                Assert.Equal(Release, info.Version.Release);
+                Assert.Equal(Release, info.Version.PreReleaseLabel);
             }
         }
     }

--- a/tests/OmniSharp.Tests/SemanticVersionFacts.cs
+++ b/tests/OmniSharp.Tests/SemanticVersionFacts.cs
@@ -1,0 +1,84 @@
+using Xunit;
+
+namespace OmniSharp.Tests
+{
+    public class SemanticVersionFacts
+    {
+        [Theory]
+        [InlineData("1.0.0")]
+        [InlineData("0.1.0")]
+        [InlineData("0.0.1")]
+        [InlineData("1.0.3-alpha")]
+        [InlineData("1.0.0-alpha.023")]
+        [InlineData("0.2.0+META")]
+        [InlineData("1.1.0-alpha+META")]
+        [InlineData("1.2.3-alpha.023+META.024")]
+        public void ValidSemanticVersionsParse(string version)
+        {
+            var parsed = SemanticVersion.TryParse(version, out var result);
+
+            Assert.True(parsed, $"{version} did not successfully parse.");
+            Assert.Equal(version, result.ToString());
+        }
+
+        [Theory]
+        [InlineData("2.7")]
+        [InlineData("1.3.4.5")]
+        [InlineData("1.3-alpha")]
+        [InlineData("1.3 .4")]
+        [InlineData("2.3.18.2-a")]
+        [InlineData("01.2.3")]
+        [InlineData("1.02.3")]
+        [InlineData("1.2.03")]
+        [InlineData(".2.03")]
+        [InlineData("1.2.")]
+        [InlineData("1.2.3-a$b")]
+        [InlineData("a.b.c")]
+        public void InvalidSemanticVersionsDoNotParse(string version)
+        {
+            var result = SemanticVersion.TryParse(version, out var semanticVersion);
+
+            Assert.False(result, $"{version} successfully parsed.");
+            Assert.Null(semanticVersion);
+        }
+
+        [Theory]
+        [InlineData("1.2.3", "1.2.3+0")]
+        [InlineData("1.2.3+0", "1.2.3+321")]
+        [InlineData("1.2.3+321", "1.2.3+XYZ")]
+        [InlineData("1.2.3+XYZ", "1.2.3")]
+        [InlineData("1.2.3-alpha", "1.2.3-alpha+0")]
+        [InlineData("1.2.3-alpha+0", "1.2.3-alpha+321")]
+        [InlineData("1.2.3-alpha+321", "1.2.3-alpha+XYZ")]
+        [InlineData("1.2.3-alpha+XYZ", "1.2.3-alpha")]
+        public void SemanticVersionsAreEqual(string version1, string version2)
+        {
+            Assert.True(SemanticVersion.TryParse(version1, out var result1));
+            Assert.True(SemanticVersion.TryParse(version2, out var result2));
+
+            Assert.True(result1.Equals(result2));
+            Assert.True(result2.Equals(result1));
+
+            Assert.Equal(0, result1.CompareTo(result2));
+            Assert.Equal(0, result2.CompareTo(result1));
+        }
+
+        [Theory]
+        [InlineData("1.2.3-alpha", "1.2.3-beta")]
+        [InlineData("1.2.3-alpha", "1.2.3")]
+        [InlineData("1.2.3", "1.2.4")]
+        [InlineData("1.2.3", "1.2.4-alpha")]
+        [InlineData("1.2.3", "1.3.0")]
+        [InlineData("1.2.3", "1.3.0-alpha")]
+        [InlineData("1.2.3", "2.0.0")]
+        [InlineData("1.2.3", "2.0.0-alpha")]
+        public void SemanticVersionsCanBeCompared(string lowerVersion, string higherVersion)
+        {
+            Assert.True(SemanticVersion.TryParse(lowerVersion, out var lowerResult));
+            Assert.True(SemanticVersion.TryParse(higherVersion, out var higherResult));
+
+            Assert.Equal(-1, lowerResult.CompareTo(higherResult));
+            Assert.Equal(1, higherResult.CompareTo(lowerResult));
+        }
+    }
+}


### PR DESCRIPTION
By not shipping NuGet libraries ourselves in our net6 packages, we will load the NuGet libraries shipped with the SDK registered by the MSBuildLocator. I did need to add a SemanticVersion implementation in order to remove our use of NuGet.Versioning.

To test you can install 6.0.2xx version of the .NET SDK from [dotnet/installers](https://github.com/dotnet/installer).