### PR TITLE
Add analyze open documents only

### DIFF
--- a/src/OmniSharp.Shared/Options/RoslynExtensionsOptions.cs
+++ b/src/OmniSharp.Shared/Options/RoslynExtensionsOptions.cs
@@ -13,6 +13,7 @@ namespace OmniSharp.Options
         public bool EnableAsyncCompletion { get; set; }
         public int DocumentAnalysisTimeoutMs { get; set; } = 30 * 1000;
         public int DiagnosticWorkersThreadCount { get; set; } = Math.Max(1, (int)(Environment.ProcessorCount * 0.75)); // Use 75% of available processors by default (but at least one)
+        public bool AnalyzeOpenDocumentsOnly { get; set; }
     }
 
     public class OmniSharpExtensionsOptions

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CustomRoslynAnalyzerFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CustomRoslynAnalyzerFacts.cs
@@ -264,7 +264,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
         [InlineData(false, true)]
         [InlineData(true, false)]
         [InlineData(true, true)]
-        public async Task WhenDocumentIsntOpenAndAnalyzeOpenDocumentsOnlyIsSet_DontAnylizeFiles(bool analyzeOpenDocumentsOnly, bool isDocumentOpen)
+        public async Task WhenDocumentIsntOpenAndAnalyzeOpenDocumentsOnlyIsSet_DontAnalyzeFiles(bool analyzeOpenDocumentsOnly, bool isDocumentOpen)
         {
             using (var host = GetHost(analyzeOpenDocumentsOnly))
             {

--- a/tests/TestUtility/AbstractCodeActionsTestFixture.cs
+++ b/tests/TestUtility/AbstractCodeActionsTestFixture.cs
@@ -64,9 +64,9 @@ namespace TestUtility
             return await RunRefactoringsAsync(code, identifier, wantsChanges);
         }
 
-        protected async Task<IEnumerable<string>> FindRefactoringNamesAsync(string code, bool isAnalyzersEnabled = true)
+        protected async Task<IEnumerable<string>> FindRefactoringNamesAsync(string code, bool isAnalyzersEnabled = true, bool analyzeOpenDocumentsOnly = false)
         {
-            var codeActions = await FindRefactoringsAsync(code, TestHelpers.GetConfigurationDataWithAnalyzerConfig(isAnalyzersEnabled));
+            var codeActions = await FindRefactoringsAsync(code, TestHelpers.GetConfigurationDataWithAnalyzerConfig(isAnalyzersEnabled, analyzeOpenDocumentsOnly: analyzeOpenDocumentsOnly));
 
             return codeActions.Select(a => a.Name);
         }

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -143,13 +143,15 @@ namespace TestUtility
         public static IConfiguration GetConfigurationDataWithAnalyzerConfig(
             bool roslynAnalyzersEnabled = false,
             bool editorConfigEnabled = false,
-            Dictionary<string, string> existingConfiguration = null)
+            Dictionary<string, string> existingConfiguration = null,
+            bool analyzeOpenDocumentsOnly = false)
         {
             if (existingConfiguration == null)
             {
                 return new Dictionary<string, string>()
                 {
                     { "RoslynExtensionsOptions:EnableAnalyzersSupport", roslynAnalyzersEnabled.ToString() },
+                    { "RoslynExtensionsOptions:AnalyzeOpenDocumentsOnly", analyzeOpenDocumentsOnly.ToString() },
                     { "FormattingOptions:EnableEditorConfigSupport", editorConfigEnabled.ToString() }
                 }.ToConfiguration();
             }


### PR DESCRIPTION
Hey, this is a pull requestion to add an `AnalyzeOpenDocumentsOnly` option to `RoslynExtensionsOptions`, which `CSharpDiagnosticWorkerWithAnalyzer` uses to decided if it runs full roslyn anaylizers or just the base diagnostics provided by  `syntaxTree.GetDiagnostics()`.

The main benefit is the speed of the initial analysis of all files in the solution. For large solutions this is pretty handy, for example the roslyn solution takes 18 minutes for that first pass, vs. 1 minute with `AnalyzeOpenDocumentsOnly` set to true.