### PR TITLE
Update Roslyn to 4.2.0-1.22108.11

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -7,7 +7,7 @@
         <MicrosoftTestPackageVersion>17.0.0</MicrosoftTestPackageVersion>
         <MSBuildPackageVersion>17.0.0</MSBuildPackageVersion>
         <NuGetPackageVersion>6.0.0</NuGetPackageVersion>
-        <RoslynPackageVersion>4.2.0-1.final</RoslynPackageVersion>
+        <RoslynPackageVersion>4.2.0-1.22108.11</RoslynPackageVersion>
         <XunitPackageVersion>2.4.1</XunitPackageVersion>
     </PropertyGroup>
 

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -7,7 +7,7 @@
         <MicrosoftTestPackageVersion>17.0.0</MicrosoftTestPackageVersion>
         <MSBuildPackageVersion>17.0.0</MSBuildPackageVersion>
         <NuGetPackageVersion>6.0.0</NuGetPackageVersion>
-        <RoslynPackageVersion>4.2.0-1.22074.8</RoslynPackageVersion>
+        <RoslynPackageVersion>4.2.0-1.final</RoslynPackageVersion>
         <XunitPackageVersion>2.4.1</XunitPackageVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
Move to the 17.2 Preview 1 release of Roslyn. Includes fix for missing IMoveStaticMembersOptionService https://github.com/dotnet/roslyn/commit/72f98f861f86389396518987d02859cf7cb7dbbb

Resolves https://github.com/OmniSharp/omnisharp-roslyn/issues/2353 