### PR TITLE
Pass --overwrite when pushing build artifacts to azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,7 +165,7 @@ jobs:
           curl -L https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
           sudo apt-get install apt-transport-https
           sudo apt-get update && sudo apt-get install azure-cli
-          az storage blob upload-batch --destination "releases" --source "$(System.ArtifactsDirectory)/deployment/" --account-name roslynomnisharp --account-key $BLOB_KEY
+          az storage blob upload-batch --destination "releases" --source "$(System.ArtifactsDirectory)/deployment/" --overwrite --account-name roslynomnisharp --account-key $BLOB_KEY
         displayName: Upload to Azure Storage
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
         env:


### PR DESCRIPTION
Due to this breaking change we have not been publishing nightly builds - https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli#storage