### PR TITLE
Delete System.Configuration.ConfigurationManager from deployed packages

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1009,6 +1009,11 @@ string PublishBuild(string project, BuildEnvironment env, BuildPlan plan, string
         {
             FileHelper.Delete(filePath);
         }
+
+        foreach (var filePath in DirectoryHelper.GetFiles(outputFolder, "System.Configuration.ConfigurationManager.dll"))
+        {
+            FileHelper.Delete(filePath);
+        }
     }
     else
     {


### PR DESCRIPTION
The SDK ships a newer version of System.Configuration.ConfigurationManager than we do, and it's causing load issues. This is a quick patch to fix https://github.com/OmniSharp/omnisharp-vscode/issues/5113 for now, but we'll want to remove all dlls that the SDK ships to avoid this long-term.
