### PR TITLE
Fixing #2372 (Using sumary instead of xmldoc on signature requests)

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -168,10 +168,14 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
         private static SignatureHelpItem BuildSignature(IMethodSymbol symbol)
         {
             var signature = new SignatureHelpItem();
-            signature.Documentation = symbol.GetDocumentationCommentXml();
             signature.Name = symbol.MethodKind == MethodKind.Constructor ? symbol.ContainingType.Name : symbol.Name;
             signature.Label = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
             signature.StructuredDocumentation = DocumentationConverter.GetStructuredDocumentation(symbol);
+            signature.Documentation = signature.StructuredDocumentation.SummaryText;
+            if (string.IsNullOrEmpty(signature.Documentation))
+            {
+                signature.Documentation = symbol.GetDocumentationCommentXml();
+            }
 
             signature.Parameters = symbol.Parameters.Select(parameter =>
             {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/SignatureHelpFacts.cs
@@ -1142,5 +1142,34 @@ public class ProgramClass
             var requestHandler = GetRequestHandler(SharedOmniSharpTestHost);
             return await requestHandler.Handle(request);
         }
+
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task GetXmlDocTest(string filename)
+        {
+            const string source =
+@"class Program
+{
+    public static void Main()
+    {
+        var flag = Compare($$);
+    }
+    ///<summary>Checks if object is tagged with the tag.</summary>
+    /// <param name=""gameObject"">The game object.</param>
+    /// <param name=""tagName"">Name of the tag.</param>
+    /// <returns>Returns <c>true</c> if object is tagged with tag.</returns>
+    public static bool Compare(GameObject gameObject, string tagName)
+    {
+        return true;
+    }
+}";
+            var actual = await GetSignatureHelp(filename, source);
+            Assert.Single(actual.Signatures);
+            Assert.Equal(0, actual.ActiveParameter);
+            Assert.Equal(0, actual.ActiveSignature);
+            Assert.Equal("Compare", actual.Signatures.ElementAt(0).Name);
+            Assert.Equal("Checks if object is tagged with the tag.", actual.Signatures.ElementAt(0).Documentation);
+        }
     }
 }


### PR DESCRIPTION
This pr fixes #2372.

It uses the xml summary instead of the whole xmldoc if a summary exists, if it does not, it falls back to the whole documentation.

![image](https://user-images.githubusercontent.com/32224410/161448725-75ddaabb-90b5-4d48-bd36-9f251b80de64.png)
