### PR TITLE
added support for linux-musl-x64 and linux-musl-arm64

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -42,7 +42,7 @@ Note: The arguments below should prefixed with a single hyphen on Windows (Power
   `-install-path Path`: Path used for the **Install** target.
     Defaults to `(%USERPROFILE%|$HOME)/.omnisharp`
 
-  `-publish-all`: Publishes all platforms for the current OS. On Windows, specifying this argument would produce win7-x86, win7-x64, and win10-arm64 builds. On OSX/Linux, this argument causes osx, linux-x86, linux-x64, linux-musl-x64, and linux-arm64 builds to be published.
+  `-publish-all`: Publishes all platforms for the current OS. On Windows, specifying this argument would produce win7-x86, win7-x64, and win10-arm64 builds. On OSX/Linux, this argument causes osx, linux-x86, linux-x64, linux-musl-x64, linux-musl-arm64 and linux-arm64 builds to be published.
 
   `-archive`: Enable the generation of publishable archives after a build.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Every merge to `master` is automatically published to this feed and individual r
     -   `linux-x86`
     -   `linux-musl-x64`
     -   `linux-arm64`
+    -   `linux-musl-arm64`
     -   `osx`
     -   `mono` (Requires global mono installed)
 -   Extensions are archive specific, windows will be `zip` and all others will be `tar.gz`.

--- a/build.cake
+++ b/build.cake
@@ -512,6 +512,7 @@ Task("PublishNet6Builds")
                 PublishBuild(project, env, buildPlan, configuration, "linux-x64", "net6.0");
                 PublishBuild(project, env, buildPlan, configuration, "linux-arm64", "net6.0");
                 PublishBuild(project, env, buildPlan, configuration, "linux-musl-x64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "linux-musl-arm64", "net6.0");
                 PublishBuild(project, env, buildPlan, configuration, "osx-x64", "net6.0");
                 PublishBuild(project, env, buildPlan, configuration, "osx-arm64", "net6.0");
             }
@@ -549,6 +550,7 @@ Task("PublishNet6Builds")
                 PublishBuild(project, env, buildPlan, configuration, "linux-x64", "net6.0");
                 PublishBuild(project, env, buildPlan, configuration, "linux-arm64", "net6.0");
                 PublishBuild(project, env, buildPlan, configuration, "linux-musl-x64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "linux-musl-arm64", "net6.0");
             }
         }
 


### PR DESCRIPTION
For lightweight distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) like Alpine Linux.
Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/2366