### PR TITLE
fixed run script for Mono

### DIFF
--- a/mono-packaging/run
+++ b/mono-packaging/run
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 
 base_dir="$(cd "$(dirname "$0")" && pwd -P)"
-bin_dir=${base_dir}/bin
-etc_dir=${base_dir}/etc
 omnisharp_dir=${base_dir}/omnisharp
 
 mono_cmd=mono
 omnisharp_cmd=${omnisharp_dir}/OmniSharp.exe
-config_file=${etc_dir}/config
 
 no_omnisharp=false
 
@@ -15,9 +12,6 @@ if [ "$1" = "--no-omnisharp" ]; then
     shift
     no_omnisharp=true
 fi
-
-export MONO_CFG_DIR=${etc_dir}
-export MONO_ENV_OPTIONS="--assembly-loader=strict --config \"${config_file}\""
 
 if [ "$no_omnisharp" = true ]; then
     "${mono_cmd}" "$@"


### PR DESCRIPTION
fixes https://github.com/OmniSharp/omnisharp-vscode/issues/5181 

After the removal of local Mono, the global Mono was still launched using the leftover local etc config dir which caused it to crash.