### PR TITLE
Return meaningful error when pinned SDK version is not found.

### DIFF
--- a/src/OmniSharp.Abstractions/Services/DotNetVersion.cs
+++ b/src/OmniSharp.Abstractions/Services/DotNetVersion.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+
+namespace OmniSharp.Services
+{
+    public class DotNetVersion
+    {
+        public static DotNetVersion FailedToStartError { get; } = new DotNetVersion("`dotnet --version` failed to start.");
+
+        public bool HasError { get; }
+        public string ErrorMessage { get; }
+
+        public SemanticVersion Version { get; }
+
+        private DotNetVersion(SemanticVersion version)
+        {
+            Version = version;
+        }
+
+        private DotNetVersion(string errorMessage)
+        {
+            HasError = true;
+            ErrorMessage = errorMessage;
+        }
+
+        public static DotNetVersion Parse(List<string> lines)
+        {
+            if (lines == null || lines.Count == 0)
+            {
+                return new DotNetVersion("`dotnet --version` produced no output.");
+            }
+
+            if (SemanticVersion.TryParse(lines[0], out var version))
+            {
+                return new DotNetVersion(version);
+            }
+
+            var requestedSdkVersion = string.Empty;
+            var globalJsonFile = string.Empty;
+
+            foreach (var line in lines)
+            {
+                var colonIndex = line.IndexOf(':');
+                if (colonIndex >= 0)
+                {
+                    var name = line.Substring(0, colonIndex).Trim();
+                    var value = line.Substring(colonIndex + 1).Trim();
+
+                    if (string.IsNullOrEmpty(requestedSdkVersion) && name.Equals("Requested SDK version", StringComparison.OrdinalIgnoreCase))
+                    {
+                        requestedSdkVersion = value;
+                    }
+                    else if (string.IsNullOrEmpty(globalJsonFile) && name.Equals("global.json file", StringComparison.OrdinalIgnoreCase))
+                    {
+                        globalJsonFile = value;
+                    }
+                }
+            }
+
+            return requestedSdkVersion.Length > 0 && globalJsonFile.Length > 0
+                ? new DotNetVersion($"Install the [{requestedSdkVersion}] .NET SDK or update [{globalJsonFile}] to match an installed SDK.")
+                : new DotNetVersion($"Unexpected output from `dotnet --version`: {string.Join(Environment.NewLine, lines)}");
+        }
+    }
+}

--- a/src/OmniSharp.Abstractions/Services/IDotNetCliService.cs
+++ b/src/OmniSharp.Abstractions/Services/IDotNetCliService.cs
@@ -19,9 +19,9 @@ namespace OmniSharp.Services
 
         /// <summary>
         /// Launches "dotnet --version" in the given working directory and returns a
-        /// <see cref="SemanticVersion"/> representing the returned version text.
+        /// <see cref="DotNetVersion"/> representing the returned version text.
         /// </summary>
-        SemanticVersion GetVersion(string workingDirectory = null);
+        DotNetVersion GetVersion(string workingDirectory = null);
 
         /// <summary>
         /// Launches "dotnet --version" in the given working directory and determines
@@ -36,7 +36,7 @@ namespace OmniSharp.Services
         /// .NET CLI. If true, this .NET CLI supports project.json development;
         /// otherwise, it supports .csproj development.
         /// </summary>
-        bool IsLegacy(SemanticVersion version);
+        bool IsLegacy(DotNetVersion version);
 
         /// <summary>
         /// Launches "dotnet restore" in the given working directory.

--- a/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
+++ b/tests/OmniSharp.Tests/DotNetCliServiceFacts.cs
@@ -30,7 +30,11 @@ namespace OmniSharp.Tests
             {
                 var dotNetCli = host.GetExport<IDotNetCliService>();
 
-                var version = dotNetCli.GetVersion();
+                var cliVersion = dotNetCli.GetVersion();
+
+                Assert.False(cliVersion.HasError);
+
+                var version = cliVersion.Version;
 
                 Assert.Equal(Major, version.Major);
                 Assert.Equal(Minor, version.Minor);

--- a/tests/OmniSharp.Tests/DotNetVersionFacts.cs
+++ b/tests/OmniSharp.Tests/DotNetVersionFacts.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using OmniSharp.Services;
+using TestUtility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OmniSharp.Tests
+{
+    public class DotNetVersionFacts : AbstractTestFixture
+    {
+        public DotNetVersionFacts(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Theory]
+        [InlineData("6.0.201")]
+        [InlineData("7.0.100-preview.2.22153.17")]
+        public void ParseVersion(string versionString)
+        {
+            var cliVersion = DotNetVersion.Parse(new() { versionString });
+
+            Assert.False(cliVersion.HasError, $"{versionString} did not successfully parse.");
+
+            Assert.Equal(versionString, cliVersion.Version.ToString());
+        }
+
+        [Fact]
+        public void ParseErrorMessage()
+        {
+            const string RequestedSdkVersion = "6.0.301-rtm.22263.15";
+            const string GlobalJsonFile = "/Users/username/Source/format/global.json";
+            const string ExpectedErrorMessage = $"Install the [{RequestedSdkVersion}] .NET SDK or update [{GlobalJsonFile}] to match an installed SDK.";
+
+            var lines = new List<string>() {
+                "The command could not be loaded, possibly because:",
+                "  * You intended to execute a .NET application:",
+                "      The application '--version' does not exist.",
+                "  * You intended to execute a .NET SDK command:",
+                "      A compatible .NET SDK was not found.",
+                "",
+                $"Requested SDK version: {RequestedSdkVersion}",
+                $"global.json file: {GlobalJsonFile}",
+                "",
+                "Installed SDKs:",
+                "6.0.105 [/usr/local/share/dotnet/sdk]",
+                "6.0.202 [/usr/local/share/dotnet/sdk]",
+                "6.0.300 [/usr/local/share/dotnet/sdk]",
+                "7.0.100-preview.4.22252.9 [/usr/local/share/dotnet/sdk]",
+                "",
+                $"Install the [{RequestedSdkVersion}] .NET SDK or update [{GlobalJsonFile}] to match an installed SDK.",
+                "",
+                "Learn about SDK resolution:",
+                "https://aka.ms/dotnet/sdk-not-found"
+            };
+
+            var cliVersion = DotNetVersion.Parse(lines);
+
+            Assert.True(cliVersion.HasError);
+
+            Assert.Equal(ExpectedErrorMessage, cliVersion.ErrorMessage);
+        }
+    }
+}


### PR DESCRIPTION
Reported in https://github.com/OmniSharp/omnisharp-vscode/issues/5128

As part of creating the TestManager OmniSharp attempts to parse the .NET CLI version. When a global.json is being used by a project and the SDK version pinned in the SDK is not installed a detailed error message is output to a combination of stderr and stdout. OmniSharp would then fail to parse a valid SemanticVersion from this output and the user would be given a generic FormatException. This change adds additional parsing of the output when it is not a valid SemanticVersion to provide the user with a more meaningful error.


Prior to this change users would see the following error in their OmniSharp log:
```
[fail]: OmniSharp.Stdio.Host
        ************  Response (35.0185ms) ************ 
{
  "Request_seq": 1013,
  "Command": "/v2/debugtest/getstartinfo",
  "Running": true,
  "Success": false,
  "Message": "\"System.FormatException: version\\n  at OmniSharp.SemanticVersion.Parse (System.String version) [0x0001b] in <04928efb700c47abb8cc2114b31a9ccb>:0 \\n  at OmniSharp.Services.DotNetCliService.GetVersion (System.String workingDirectory) [0x00011] in <3d93fabea6954f4ba147450b0cf4332a>:0 \\n  at OmniSharp.DotNetTest.TestManager.Create (Microsoft.CodeAnalysis.Project project, OmniSharp.Services.IDotNetCliService dotNetCli, OmniSharp.Eventing.IEventEmitter eventEmitter, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) [0x0000c] in <9d87b466e5a04dffb95becc0b4dfd560>:0 \\n  at OmniSharp.DotNetTest.TestManager.Start (Microsoft.CodeAnalysis.Project project, OmniSharp.Services.IDotNetCliService dotNetCli, OmniSharp.Eventing.IEventEmitter eventEmitter, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, System.Boolean noBuild) [0x00000] in <9d87b466e5a04dffb95becc0b4dfd560>:0 \\n  at OmniSharp.DotNetTest.Services.BaseTestService.CreateTestManager (System.String fileName, System.Boolean noBuild) [0x00011] in <9d87b466e5a04dffb95becc0b4dfd560>:0 \\n  at OmniSharp.DotNetTest.Services.DebugTestService.Handle (OmniSharp.DotNetTest.Models.DebugTestGetStartInfoRequest request) [0x0000d] in <9d87b466e5a04dffb95becc0b4dfd560>:0 \\n  at OmniSharp.Endpoint.Exports.RequestHandlerExportHandler`2[TRequest,TResponse].Handle (TRequest request) [0x00000] in <3d93fabea6954f4ba147450b0cf4332a>:0 \\n  at OmniSharp.Endpoint.EndpointHandler`2[TRequest,TResponse].GetFirstNotEmptyResponseFromHandlers (OmniSharp.Endpoint.Exports.ExportHandler`2[TRequest,TResponse][] handlers, TRequest request) [0x00022] in <3d93fabea6954f4ba147450b0cf4332a>:0 \\n  at OmniSharp.Endpoint.EndpointHandler`2[TRequest,TResponse].HandleRequestForLanguage (System.String language, TRequest request, OmniSharp.Protocol.RequestPacket packet) [0x00163] in <3d93fabea6954f4ba147450b0cf4332a>:0 \\n  at OmniSharp.Endpoint.EndpointHandler`2[TRequest,TResponse].Process (OmniSharp.Protocol.RequestPacket packet, OmniSharp.Endpoint.LanguageModel model, Newtonsoft.Json.Linq.JToken requestObject) [0x0024b] in <3d93fabea6954f4ba147450b0cf4332a>:0 \\n  at OmniSharp.Stdio.Host.HandleRequest (System.String json, Microsoft.Extensions.Logging.ILogger logger) [0x000f3] in <2584067dfcea42a69c19a025cfbc4799>:0 \"",
  "Body": null,
  "Seq": 3637,
  "Type": "response"
}
```

With this change they will see a more actionable message.
```
Install the [6.0.301-rtm.22263.15] .NET SDK or update [/Users/joeyrobichaud/Source/format/global.json] to match an installed SDK.
```

Example from VS Code:
<img width="1098" alt="image" src="https://user-images.githubusercontent.com/611219/169939795-0661749e-42de-4be7-b09e-c65fc08e5e69.png">
