### PR TITLE
removed nuget versioning reference from OmniSharp.Abstractions

### DIFF
--- a/src/OmniSharp.Abstractions/OmniSharp.Abstractions.csproj
+++ b/src/OmniSharp.Abstractions/OmniSharp.Abstractions.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Composition" />
     <PackageReference Include="System.ValueTuple" />


### PR DESCRIPTION
This is a leftover from https://github.com/OmniSharp/omnisharp-roslyn/pull/2308

Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/2410