### PR TITLE
Update Roslyn to 4.4.0 1.22369.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,18 @@
 All changes to the project will be documented in this file.
 
 ## [1.39.1]
+* Update Roslyn to 4.3.0-3.22329.4 (PR: [#2416](https://github.com/OmniSharp/omnisharp-roslyn/pull/2416))
+* Return meaningful error when pinned SDK version is not found. ([[omnisharp-vscode#5128](https://github.com/OmniSharp/omnisharp-vscode/issues/5128), PR: [#2403](https://github.com/OmniSharp/omnisharp-roslyn/pull/2403))
 * Added support for `<WarningsAsErrors>nullable</WarningsAsErrors>` ([#2292](https://github.com/OmniSharp/omnisharp-roslyn/issues/2292), PR: [#2406](https://github.com/OmniSharp/omnisharp-roslyn/pull/2406))
+* Removed nuget versioning reference from OmniSharp.Abstractions ([#2410](https://github.com/OmniSharp/omnisharp-roslyn/issues/2410), PR: [#2414](https://github.com/OmniSharp/omnisharp-roslyn/pull/2414))
+* Bump Newtonsoft.Json to 13.0.1 (PR: [#2415](https://github.com/OmniSharp/omnisharp-roslyn/pull/2415))
 
 ## [1.39.0] - 2022-05-19
 * Update Roslyn to 4.3.0-2.22267.5 (PR: [#2401](https://github.com/OmniSharp/omnisharp-roslyn/pull/2401))
-* Fixed run script for Mono ([OmniSharp/omnisharp-vscode#5181](https://github.com/OmniSharp/omnisharp-vscode/issues/5181), [OmniSharp/omnisharp-vscode#5179](https://github.com/OmniSharp/omnisharp-vscode/issues/5179), PR: [#2398](https://github.com/OmniSharp/omnisharp-roslyn/pull/2398))
+* Fixed run script for Mono ([omnisharp-vscode#5181](https://github.com/OmniSharp/omnisharp-vscode/issues/5181), [omnisharp-vscode#5179](https://github.com/OmniSharp/omnisharp-vscode/issues/5179), PR: [#2398](https://github.com/OmniSharp/omnisharp-roslyn/pull/2398))
 * Fall back to /usr/lib/os-release if /etc/os-release doesn't exist (PR: [#2380](https://github.com/OmniSharp/omnisharp-roslyn/pull/2380))
 * Added support for linux-musl-x64 and linux-musl-arm64 ([#2366](https://github.com/OmniSharp/omnisharp-roslyn/issues/2366), PR: [#2395](https://github.com/OmniSharp/omnisharp-roslyn/pull/2395))
-* Enable GoToDefinition for symbols in metadata documents ([OmniSharp/omnisharp-vscode#4818](https://github.com/OmniSharp/omnisharp-vscode/issues/4818), PR: [#2390](https://github.com/OmniSharp/omnisharp-roslyn/pull/2390))
+* Enable GoToDefinition for symbols in metadata documents ([omnisharp-vscode#4818](https://github.com/OmniSharp/omnisharp-vscode/issues/4818), PR: [#2390](https://github.com/OmniSharp/omnisharp-roslyn/pull/2390))
 * Use human readable doc in lsp's signature help ([#2372](https://github.com/OmniSharp/omnisharp-roslyn/issues/2372), PR: [#2392](https://github.com/OmniSharp/omnisharp-roslyn/pull/2392))
 * Add TextEdits support to InlayHints (PR: [#2385](https://github.com/OmniSharp/omnisharp-roslyn/pull/2385))
 * Fix Equals of AutoCompleteResponse and simplify some code (PR: [#2362](https://github.com/OmniSharp/omnisharp-roslyn/pull/2362))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 All changes to the project will be documented in this file.
 
 ## [1.39.1]
-* Update Roslyn to 4.3.0-3.22329.4 (PR: [#2416](https://github.com/OmniSharp/omnisharp-roslyn/pull/2416))
+* Update Roslyn to 4.4.0 1.22369.1 (PR: [#2420](https://github.com/OmniSharp/omnisharp-roslyn/pull/2420))
+* Simplify some code (PR: [#2370](https://github.com/OmniSharp/omnisharp-roslyn/pull/2370))
 * Return meaningful error when pinned SDK version is not found. ([[omnisharp-vscode#5128](https://github.com/OmniSharp/omnisharp-vscode/issues/5128), PR: [#2403](https://github.com/OmniSharp/omnisharp-roslyn/pull/2403))
 * Added support for `<WarningsAsErrors>nullable</WarningsAsErrors>` ([#2292](https://github.com/OmniSharp/omnisharp-roslyn/issues/2292), PR: [#2406](https://github.com/OmniSharp/omnisharp-roslyn/pull/2406))
 * Removed nuget versioning reference from OmniSharp.Abstractions ([#2410](https://github.com/OmniSharp/omnisharp-roslyn/issues/2410), PR: [#2414](https://github.com/OmniSharp/omnisharp-roslyn/pull/2414))

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -7,7 +7,7 @@
         <MicrosoftTestPackageVersion>17.2.0</MicrosoftTestPackageVersion>
         <MSBuildPackageVersion>17.0.0</MSBuildPackageVersion>
         <NuGetPackageVersion>6.3.0-preview.1.32</NuGetPackageVersion>
-        <RoslynPackageVersion>4.3.0-2.22267.5</RoslynPackageVersion>
+        <RoslynPackageVersion>4.4.0-1.22369.1</RoslynPackageVersion>
         <XunitPackageVersion>2.4.1</XunitPackageVersion>
     </PropertyGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
     "sdk": {
-        "version": "7.0.100-preview.4.22252.9"
+        "version": "7.0.100-preview.4.22252.9",
+        "rollForward": "patch"
     }
 }

--- a/src/OmniSharp.Abstractions/Configuration.cs
+++ b/src/OmniSharp.Abstractions/Configuration.cs
@@ -4,7 +4,7 @@ namespace OmniSharp
     {
         public static bool ZeroBasedIndices = false;
 
-        public const string RoslynVersion = "4.3.0.0";
+        public const string RoslynVersion = "4.4.0.0";
         public const string RoslynPublicKeyToken = "31bf3856ad364e35";
 
         public readonly static string RoslynFeatures = GetRoslynAssemblyFullName("Microsoft.CodeAnalysis.Features");

--- a/src/OmniSharp.Http.Driver/app.config
+++ b/src/OmniSharp.Http.Driver/app.config
@@ -7,23 +7,23 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/OmniSharp.LanguageServerProtocol/app.config
+++ b/src/OmniSharp.LanguageServerProtocol/app.config
@@ -7,23 +7,23 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionListBuilder_Async.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionListBuilder_Async.cs
@@ -28,14 +28,14 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             TextSpan typedSpan,
             bool expectingImportedItems, bool isSuggestionMode)
         {
-            var completionsBuilder = new List<CompletionItem>(completions.Items.Length);
+            var completionsBuilder = new List<CompletionItem>(completions.ItemsList.Count);
             var seenUnimportedCompletions = false;
             var commitCharacterRuleCache = new Dictionary<ImmutableArray<CharacterSetModificationRule>, IReadOnlyList<char>>();
             var commitCharacterRuleBuilder = new HashSet<char>();
 
-            for (int i = 0; i < completions.Items.Length; i++)
+            for (int i = 0; i < completions.ItemsList.Count; i++)
             {
-                var completion = completions.Items[i];
+                var completion = completions.ItemsList[i];
                 string labelText = completion.DisplayTextPrefix + completion.DisplayText + completion.DisplayTextSuffix;
                 string? insertText;
                 string? filterText = null;

--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionListBuilder_Sync.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionListBuilder_Sync.cs
@@ -55,7 +55,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
                     completionTasksAndProviderNamesBuilder.Add(((Task<CompletionChange>?)completionService.GetChangeAsync(document, completion), providerName));
                 }
             }
-            var completionTasksAndProviderNames = completionTasksAndProviderNamesBuilder.MoveToImmutable();
+            var completionTasksAndProviderNames = completionTasksAndProviderNamesBuilder.ToImmutable();
 
             for (int i = 0; i < completions.ItemsList.Count; i++)
             {

--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionListBuilder_Sync.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionListBuilder_Sync.cs
@@ -55,7 +55,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
                     completionTasksAndProviderNamesBuilder.Add(((Task<CompletionChange>?)completionService.GetChangeAsync(document, completion), providerName));
                 }
             }
-            var completionTasksAndProviderNames = completionTasksAndProviderNamesBuilder.ToImmutable();
+            var completionTasksAndProviderNames = completionTasksAndProviderNamesBuilder.MoveToImmutable();
 
             for (int i = 0; i < completions.ItemsList.Count; i++)
             {

--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs
@@ -94,17 +94,17 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
 
             var completions = await OmniSharpCompletionService.GetCompletionsAsync(completionService, document, position, trigger, roles: null, options, CancellationToken.None);
             _logger.LogTrace("Found {0} completions for {1}:{2},{3}",
-                             completions?.Items.IsDefaultOrEmpty != false ? 0 : completions.Items.Length,
+                             completions.ItemsList.Count,
                              request.FileName,
                              request.Line,
                              request.Column);
 
-            if (completions is null || completions.Items.Length == 0)
+            if (completions is null || completions.ItemsList.Count == 0)
             {
                 return new CompletionResponse { Items = ImmutableArray<CompletionItem>.Empty };
             }
 
-            if (request.TriggerCharacter == ' ' && !completions.Items.Any(c =>
+            if (request.TriggerCharacter == ' ' && !completions.ItemsList.Any(c =>
             {
                 var providerName = c.GetProviderName();
                 return providerName is CompletionListBuilder.OverrideCompletionProvider or
@@ -166,14 +166,14 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             var index = request.Item.Data.Index;
 
             if (request.Item is null
-                || index >= completions.Items.Length
+                || index >= completions.ItemsList.Count
                 || index < 0)
             {
                 _logger.LogError("Received invalid completion resolve!");
                 return new CompletionResolveResponse { Item = request.Item };
             }
 
-            var lastCompletionItem = completions.Items[index];
+            var lastCompletionItem = completions.ItemsList[index];
             if (lastCompletionItem.DisplayTextPrefix + lastCompletionItem.DisplayText + lastCompletionItem.DisplayTextSuffix != request.Item.Label)
             {
                 _logger.LogError("Inconsistent completion data. Requested data on {0}, but found completion item {1}", request.Item.Label, lastCompletionItem.DisplayText);
@@ -234,7 +234,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             var index = request.Item.Data.Index;
 
             if (request.Item is null
-                || index >= completions.Items.Length
+                || index >= completions.ItemsList.Count
                 || index < 0
                 || request.Item.TextEdit is null)
             {
@@ -242,7 +242,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
                 return new CompletionAfterInsertResponse();
             }
 
-            var lastCompletionItem = completions.Items[index];
+            var lastCompletionItem = completions.ItemsList[index];
             if (lastCompletionItem.DisplayTextPrefix + lastCompletionItem.DisplayText + lastCompletionItem.DisplayTextSuffix != request.Item.Label)
             {
                 _logger.LogError("Inconsistent completion data. Requested data on {0}, but found completion item {1}", request.Item.Label, lastCompletionItem.DisplayText);

--- a/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/BaseCodeActionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Refactoring/V2/BaseCodeActionService.cs
@@ -184,13 +184,20 @@ namespace OmniSharp.Roslyn.CSharp.Services.Refactoring.V2
 
         private async Task CollectRefactoringActions(Document document, TextSpan span, List<CodeAction> codeActions)
         {
+            var codeActionOptions = CodeActionOptionsFactory.Create(Options);
             var availableRefactorings = OrderedCodeRefactoringProviders.Value;
 
             foreach (var codeRefactoringProvider in availableRefactorings)
             {
                 try
                 {
-                    var context = new CodeRefactoringContext(document, span, a => codeActions.Add(a), CancellationToken.None);
+                    var context = OmniSharpCodeFixContextFactory.CreateCodeRefactoringContext(
+                        document,
+                        span,
+                        (a, _) => codeActions.Add(a),
+                        codeActionOptions,
+                        CancellationToken.None);
+
                     await codeRefactoringProvider.ComputeRefactoringsAsync(context);
                 }
                 catch (Exception ex)

--- a/src/OmniSharp.Roslyn/HostServicesAggregator.cs
+++ b/src/OmniSharp.Roslyn/HostServicesAggregator.cs
@@ -68,6 +68,8 @@ namespace OmniSharp
         public HostServices CreateHostServices()
         {
             var config = new ContainerConfiguration()
+                // We smuggle the OmniSharpOptions from the Host container into the workspace services
+                // container so that we can provide global option fallbacks for LineFormattingOptions.
                 .WithProvider(new MefValueProvider<IOptionsMonitor<OmniSharpOptions>>(_options))
                 .WithAssemblies(_assemblies.Distinct());
             return new MefHostServices(config.CreateContainer());

--- a/src/OmniSharp.Roslyn/HostServicesAggregator.cs
+++ b/src/OmniSharp.Roslyn/HostServicesAggregator.cs
@@ -2,10 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Composition.Hosting;
+using System.Composition.Hosting.Core;
+using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OmniSharp.Options;
 using OmniSharp.Services;
 
 namespace OmniSharp
@@ -13,11 +18,14 @@ namespace OmniSharp
     [Export]
     public class HostServicesAggregator
     {
-        private ImmutableArray<Assembly> _assemblies;
+        private readonly ImmutableArray<Assembly> _assemblies;
+        private readonly IOptionsMonitor<OmniSharpOptions> _options;
 
         [ImportingConstructor]
         public HostServicesAggregator(
-            [ImportMany] IEnumerable<IHostServicesProvider> hostServicesProviders, ILoggerFactory loggerFactory)
+            [ImportMany] IEnumerable<IHostServicesProvider> hostServicesProviders,
+            ILoggerFactory loggerFactory,
+            IOptionsMonitor<OmniSharpOptions> options = null)
         {
             var logger = loggerFactory.CreateLogger<HostServicesAggregator>();
             var builder = ImmutableHashSet.CreateBuilder<Assembly>();
@@ -54,11 +62,40 @@ namespace OmniSharp
 
             builder.Add(typeof(OmniSharpSymbolRenamedCodeActionOperationFactoryWorkspaceService).Assembly);
             _assemblies = builder.ToImmutableArray();
+            _options = options;
         }
 
         public HostServices CreateHostServices()
         {
-            return MefHostServices.Create(_assemblies);
+            var config = new ContainerConfiguration()
+                .WithProvider(new MefValueProvider<IOptionsMonitor<OmniSharpOptions>>(_options))
+                .WithAssemblies(_assemblies.Distinct());
+            return new MefHostServices(config.CreateContainer());
+        }
+
+        internal class MefValueProvider<T> : ExportDescriptorProvider
+        {
+            private readonly T _item;
+            private readonly IDictionary<string, object> _metadata;
+
+            public MefValueProvider(T item, IDictionary<string, object> metadata = null)
+            {
+                _item = item;
+                _metadata = metadata;
+            }
+
+            public override IEnumerable<ExportDescriptorPromise> GetExportDescriptors(CompositionContract contract, DependencyAccessor descriptorAccessor)
+            {
+                if (contract.ContractType == typeof(T))
+                {
+                    yield return new ExportDescriptorPromise(
+                        contract,
+                        origin: string.Empty,
+                        isShared: true,
+                        () => Enumerable.Empty<CompositionDependency>(),
+                        deps => ExportDescriptor.Create((context, operation) => _item, _metadata ?? new Dictionary<string, object>()));
+                }
+            }
         }
     }
 }

--- a/src/OmniSharp.Roslyn/Utilities/CodeActionOptionsFactory.cs
+++ b/src/OmniSharp.Roslyn/Utilities/CodeActionOptionsFactory.cs
@@ -7,8 +7,10 @@ namespace OmniSharp.Roslyn.CodeActions
     internal static class CodeActionOptionsFactory
     {
         public static OmniSharpCodeActionOptions Create(OmniSharpOptions options)
-            => new(new OmniSharpImplementTypeOptions(
-                (OmniSharpImplementTypeInsertionBehavior)options.ImplementTypeOptions.InsertionBehavior,
-                (OmniSharpImplementTypePropertyGenerationBehavior)options.ImplementTypeOptions.PropertyGenerationBehavior));
+            => new OmniSharpCodeActionOptions(
+                new OmniSharpImplementTypeOptions(
+                    (OmniSharpImplementTypeInsertionBehavior)options.ImplementTypeOptions.InsertionBehavior,
+                    (OmniSharpImplementTypePropertyGenerationBehavior)options.ImplementTypeOptions.PropertyGenerationBehavior),
+                OmniSharpLineFormattingOptionsProvider.CreateFromOptions(options));
     }
 }

--- a/src/OmniSharp.Roslyn/WorkspaceServices/ExtractClassWorkspaceService.cs
+++ b/src/OmniSharp.Roslyn/WorkspaceServices/ExtractClassWorkspaceService.cs
@@ -16,14 +16,16 @@ namespace OmniSharp
         {
         }
 
-        public Task<OmniSharpExtractClassOptions> GetExtractClassOptionsAsync(Document document, INamedTypeSymbol originalType, ISymbol selectedMember)
+        public Task<OmniSharpExtractClassOptions> GetExtractClassOptionsAsync(Document document, INamedTypeSymbol originalType, ImmutableArray<ISymbol> selectedMembers)
         {
-            var symbolsToUse = selectedMember == null ? originalType.GetMembers().Where(member => member switch
-            {
-                IMethodSymbol methodSymbol => methodSymbol.MethodKind == MethodKind.Ordinary,
-                IFieldSymbol fieldSymbol => !fieldSymbol.IsImplicitlyDeclared,
-                _ => member.Kind == SymbolKind.Property || member.Kind == SymbolKind.Event
-            }) : new ISymbol[] { selectedMember };
+            var symbolsToUse = selectedMembers.IsEmpty
+                ? originalType.GetMembers().Where(member => member switch
+                    {
+                        IMethodSymbol methodSymbol => methodSymbol.MethodKind == MethodKind.Ordinary,
+                        IFieldSymbol fieldSymbol => !fieldSymbol.IsImplicitlyDeclared,
+                        _ => member.Kind == SymbolKind.Property || member.Kind == SymbolKind.Event
+                    })
+                : selectedMembers;
 
             var memberAnalysisResults = symbolsToUse.Select(m => new OmniSharpExtractClassMemberAnalysisResult(m, makeAbstract: false)).ToImmutableArray();
             const string name = "NewBaseType";

--- a/src/OmniSharp.Roslyn/WorkspaceServices/OmniSharpLineFormattingOptionsProvider.cs
+++ b/src/OmniSharp.Roslyn/WorkspaceServices/OmniSharpLineFormattingOptionsProvider.cs
@@ -1,0 +1,33 @@
+using System.Composition;
+using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Options;
+using Microsoft.Extensions.Options;
+using OmniSharp.Options;
+
+namespace OmniSharp
+{
+    [Export(typeof(IOmniSharpLineFormattingOptionsProvider)), Shared]
+    public class OmniSharpLineFormattingOptionsProvider : IOmniSharpLineFormattingOptionsProvider
+    {
+        private readonly IOptionsMonitor<OmniSharpOptions> _options;
+
+        [ImportingConstructor]
+        public OmniSharpLineFormattingOptionsProvider(IOptionsMonitor<OmniSharpOptions> options)
+        {
+            _options = options;
+        }
+
+        OmniSharpLineFormattingOptions IOmniSharpLineFormattingOptionsProvider.GetLineFormattingOptions()
+            => _options is null
+                ? new OmniSharpLineFormattingOptions()
+                : CreateFromOptions(_options.CurrentValue);
+
+        internal static OmniSharpLineFormattingOptions CreateFromOptions(OmniSharpOptions options)
+            => new()
+            {
+                IndentationSize = options.FormattingOptions.IndentationSize,
+                TabSize = options.FormattingOptions.TabSize,
+                UseTabs = options.FormattingOptions.UseTabs,
+                NewLine = options.FormattingOptions.NewLine,
+            };
+    }
+}

--- a/src/OmniSharp.Stdio.Driver/app.config
+++ b/src/OmniSharp.Stdio.Driver/app.config
@@ -7,23 +7,23 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
@@ -15,17 +15,21 @@ using Xunit.Abstractions;
 
 namespace OmniSharp.Roslyn.CSharp.Tests
 {
-    public class CompletionFacts : AbstractTestFixture
+    public class CompletionFacts : AbstractTestFixture, IClassFixture<CompletionFixture>
     {
         private const int ImportCompletionTimeout = 2000;
         private readonly ILogger _logger;
+        private readonly CompletionFixture _completionFixture;
 
         private string EndpointName => OmniSharpEndpoints.Completion;
 
-        public CompletionFacts(ITestOutputHelper output, SharedOmniSharpHostFixture sharedOmniSharpHostFixture)
+        public CompletionFacts(ITestOutputHelper output, SharedOmniSharpHostFixture sharedOmniSharpHostFixture, CompletionFixture completionFixture)
             : base(output, sharedOmniSharpHostFixture)
         {
             this._logger = this.LoggerFactory.CreateLogger<CompletionFacts>();
+            completionFixture.ImportCompletionTestHost?.ClearWorkspace();
+            completionFixture.ImportAndAsyncCompletionTestHost?.ClearWorkspace();
+            this._completionFixture = completionFixture;
         }
 
         [Theory]
@@ -145,7 +149,7 @@ namespace OmniSharp.Roslyn.CSharp.Tests
             Assert.DoesNotContain("Guid", completions.Items.Select(c => c.TextEdit.NewText));
         }
 
-        [Theory]
+        [Theory(Skip = "Test needs a fresh completion host, but there's a bug with host disposal causing resources not to be correctly freed and OOMs the test runners")]
         [InlineData("dummy.cs", true)]
         [InlineData("dummy.cs", false)]
         [InlineData("dummy.csx", true)]
@@ -2289,19 +2293,35 @@ namespace N
 
         private OmniSharpTestHost GetImportCompletionHost()
         {
-            var testHost = CreateOmniSharpHost(configurationData: new[] { new KeyValuePair<string, string>("RoslynExtensionsOptions:EnableImportCompletion", "true") });
-            testHost.AddFilesToWorkspace();
-            return testHost;
+            if (_completionFixture.ImportCompletionTestHost != null)
+            {
+                return _completionFixture.ImportCompletionTestHost;
+            }
+            else
+            {
+                var testHost = CreateOmniSharpHost(configurationData: new[] { new KeyValuePair<string, string>("RoslynExtensionsOptions:EnableImportCompletion", "true") });
+                testHost.AddFilesToWorkspace();
+                _completionFixture.ImportCompletionTestHost = testHost;
+                return testHost;
+            }
         }
 
         private OmniSharpTestHost GetAsyncCompletionAndImportCompletionHost()
         {
-            var testHost = CreateOmniSharpHost(configurationData: new[] {
-                new KeyValuePair<string, string>("RoslynExtensionsOptions:EnableImportCompletion", "true"),
-                new KeyValuePair<string, string>("RoslynExtensionsOptions:EnableAsyncCompletion", "true"),
-            });
-            testHost.AddFilesToWorkspace();
-            return testHost;
+            if (_completionFixture.ImportAndAsyncCompletionTestHost != null)
+            {
+                return _completionFixture.ImportAndAsyncCompletionTestHost;
+            }
+            else
+            {
+                var testHost = CreateOmniSharpHost(configurationData: new[] {
+                    new KeyValuePair<string, string>("RoslynExtensionsOptions:EnableImportCompletion", "true"),
+                    new KeyValuePair<string, string>("RoslynExtensionsOptions:EnableAsyncCompletion", "true"),
+                });
+                testHost.AddFilesToWorkspace();
+                _completionFixture.ImportAndAsyncCompletionTestHost = testHost;
+                return testHost;
+            }
         }
 
         private Task<CompletionAfterInsertResponse> AfterInsertResponse(CompletionItem completionItem, OmniSharpTestHost testHost)
@@ -2327,5 +2347,18 @@ namespace N
     internal static class CompletionResponseExtensions
     {
         public static bool IsSuggestionMode(this CompletionItem item) => !item.CommitCharacters?.Contains(' ') ?? true;
+    }
+
+#nullable enable
+    public sealed class CompletionFixture : IDisposable
+    {
+        public OmniSharpTestHost? ImportCompletionTestHost { get; set; }
+        public OmniSharpTestHost? ImportAndAsyncCompletionTestHost { get; set; }
+
+        public void Dispose()
+        {
+            ImportCompletionTestHost?.Dispose();
+            ImportAndAsyncCompletionTestHost?.Dispose();
+        }
     }
 }

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
@@ -2301,7 +2301,12 @@ namespace N
             {
                 var testHost = CreateOmniSharpHost(configurationData: new[] { new KeyValuePair<string, string>("RoslynExtensionsOptions:EnableImportCompletion", "true") });
                 testHost.AddFilesToWorkspace();
-                _completionFixture.ImportCompletionTestHost = testHost;
+                var result = Interlocked.CompareExchange(ref _completionFixture.ImportCompletionTestHost, testHost, null);
+                if (result != null)
+                {
+                    testHost.Dispose();
+                    testHost = result;
+                }
                 return testHost;
             }
         }
@@ -2319,7 +2324,12 @@ namespace N
                     new KeyValuePair<string, string>("RoslynExtensionsOptions:EnableAsyncCompletion", "true"),
                 });
                 testHost.AddFilesToWorkspace();
-                _completionFixture.ImportAndAsyncCompletionTestHost = testHost;
+                var result = Interlocked.CompareExchange(ref _completionFixture.ImportCompletionTestHost, testHost, null);
+                if (result != null)
+                {
+                    testHost.Dispose();
+                    testHost = result;
+                }
                 return testHost;
             }
         }
@@ -2352,8 +2362,8 @@ namespace N
 #nullable enable
     public sealed class CompletionFixture : IDisposable
     {
-        public OmniSharpTestHost? ImportCompletionTestHost { get; set; }
-        public OmniSharpTestHost? ImportAndAsyncCompletionTestHost { get; set; }
+        public OmniSharpTestHost? ImportCompletionTestHost;
+        public OmniSharpTestHost? ImportAndAsyncCompletionTestHost;
 
         public void Dispose()
         {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
@@ -2301,12 +2301,7 @@ namespace N
             {
                 var testHost = CreateOmniSharpHost(configurationData: new[] { new KeyValuePair<string, string>("RoslynExtensionsOptions:EnableImportCompletion", "true") });
                 testHost.AddFilesToWorkspace();
-                var result = Interlocked.CompareExchange(ref _completionFixture.ImportCompletionTestHost, testHost, null);
-                if (result != null)
-                {
-                    testHost.Dispose();
-                    testHost = result;
-                }
+                _completionFixture.ImportCompletionTestHost = testHost;
                 return testHost;
             }
         }
@@ -2324,12 +2319,7 @@ namespace N
                     new KeyValuePair<string, string>("RoslynExtensionsOptions:EnableAsyncCompletion", "true"),
                 });
                 testHost.AddFilesToWorkspace();
-                var result = Interlocked.CompareExchange(ref _completionFixture.ImportCompletionTestHost, testHost, null);
-                if (result != null)
-                {
-                    testHost.Dispose();
-                    testHost = result;
-                }
+                _completionFixture.ImportAndAsyncCompletionTestHost = testHost;
                 return testHost;
             }
         }
@@ -2362,8 +2352,8 @@ namespace N
 #nullable enable
     public sealed class CompletionFixture : IDisposable
     {
-        public OmniSharpTestHost? ImportCompletionTestHost;
-        public OmniSharpTestHost? ImportAndAsyncCompletionTestHost;
+        public OmniSharpTestHost? ImportCompletionTestHost { get; set; }
+        public OmniSharpTestHost? ImportAndAsyncCompletionTestHost { get; set; }
 
         public void Dispose()
         {

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/EditorConfigFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/EditorConfigFacts.cs
@@ -18,8 +18,8 @@ namespace OmniSharp.Roslyn.CSharp.Tests
 {
     public class EditorConfigFacts : AbstractTestFixture
     {
-        public EditorConfigFacts(ITestOutputHelper output)
-            : base(output)
+        public EditorConfigFacts(ITestOutputHelper output, SharedOmniSharpHostFixture sharedOmniSharpHostFixture)
+            : base(output, sharedOmniSharpHostFixture)
         {
         }
 

--- a/tests/OmniSharp.Script.Tests/ScriptProjectProviderTests.cs
+++ b/tests/OmniSharp.Script.Tests/ScriptProjectProviderTests.cs
@@ -17,7 +17,7 @@ namespace OmniSharp.Script.Tests
             var scriptProjectProvider = new ScriptProjectProvider(new ScriptOptions(), new OmniSharpEnvironment(), new LoggerFactory(), true, false);
             var scriptProjectInfo = scriptProjectProvider.CreateProject("test.csx", Enumerable.Empty<MetadataReference>(), Path.GetTempPath(), typeof(CommandLineScriptGlobals));
             Assert.Equal(LanguageVersion.Latest, ((CSharpParseOptions)scriptProjectInfo.ParseOptions).SpecifiedLanguageVersion);
-            Assert.Equal(LanguageVersion.CSharp10, ((CSharpParseOptions)scriptProjectInfo.ParseOptions).LanguageVersion);
+            Assert.Equal(LanguageVersion.CSharp11, ((CSharpParseOptions)scriptProjectInfo.ParseOptions).LanguageVersion);
         }
     }
 }

--- a/tests/TestUtility/TestHelpers.cs
+++ b/tests/TestUtility/TestHelpers.cs
@@ -97,8 +97,15 @@ namespace TestUtility
             return projectsIds;
         }
 
+        private static ImmutableArray<PortableExecutableReference> _references;
+
         private static IEnumerable<PortableExecutableReference> GetReferences()
         {
+            if (!_references.IsDefaultOrEmpty)
+            {
+                return _references;
+            }
+
             // This is a bit messy. Essentially, we need to add all assemblies that type forwarders might point to.
             var assemblies = new[]
             {
@@ -114,13 +121,14 @@ namespace TestUtility
 #endif
             };
 
-            var references = assemblies
+            _references = assemblies
                 .Where(a => a != null)
                 .Select(a => a.Location)
                 .Distinct()
-                .Select(l => MetadataReference.CreateFromFile(l));
+                .Select(l => MetadataReference.CreateFromFile(l))
+                .ToImmutableArray();
 
-            return references;
+            return _references;
         }
 
         public static MSBuildInstance AddDotNetCoreToFakeInstance(this MSBuildInstance instance)

--- a/tests/app.config
+++ b/tests/app.config
@@ -7,23 +7,23 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Features" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>


### PR DESCRIPTION
The changes are mostly around how Global Options in Roslyn is changing. We need to provide fallbacks which derive from OmniSharpOptions for LineFormatting options that are normally found in the .editorconfig.