### PR TITLE
Update VMs used in build CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2022, macos-11]
     name: 'Build'
     steps:
       - name: Checkout


### PR DESCRIPTION
Fixes build issue brought up in https://github.com/OmniSharp/omnisharp-roslyn/pull/2424#issuecomment-1196947613

The test CI were already using these OS versions.