### PR TITLE
Take the first found dotnet CLI path instead of the last one

### DIFF
--- a/src/OmniSharp.Host/Services/DotNetCliService.cs
+++ b/src/OmniSharp.Host/Services/DotNetCliService.cs
@@ -40,6 +40,7 @@ namespace OmniSharp.Services
                 {
                     // We'll take the first path that has a dotnet executable.
                     DotNetPath = Path.Combine(path, "dotnet");
+                    break;
                 }
                 else
                 {


### PR DESCRIPTION
Take the first found CLI path instead of the last one (as described in _https://github.com/OmniSharp/omnisharp-roslyn/pull/2227#discussion_r728553310_)