### PR TITLE
Provide SourceGeneratedFileInfo for workspace symbols requests

### DIFF
--- a/src/OmniSharp.Abstractions/Models/v1/SymbolLocation.cs
+++ b/src/OmniSharp.Abstractions/Models/v1/SymbolLocation.cs
@@ -1,7 +1,11 @@
-﻿namespace OmniSharp.Models
+﻿using OmniSharp.Models.v1.SourceGeneratedFile;
+
+namespace OmniSharp.Models
 {
     public class SymbolLocation : QuickFix
     {
         public string Kind { get; set; }
+        public string ContainingSymbolName { get; set; }
+        public SourceGeneratedFileInfo GeneratedFileInfo { get; set; }
     }
 }

--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpWorkspaceSymbolsHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpWorkspaceSymbolsHandler.cs
@@ -60,6 +60,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
                     {
                         Name = x.Text,
                         Kind = Helpers.ToSymbolKind(x.Kind),
+                        ContainerName = x.ContainingSymbolName,
                         Location = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Location
                         {
                             Uri = Helpers.ToUri(x.FileName),

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GoToDefinitionHelpers.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GoToDefinitionHelpers.cs
@@ -3,8 +3,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
 using OmniSharp.Extensions;
-using OmniSharp.Models.v1.SourceGeneratedFile;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -43,22 +41,6 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
             }
 
             return null;
-        }
-
-        internal static SourceGeneratedFileInfo? GetSourceGeneratedFileInfo(OmniSharpWorkspace workspace, Location location)
-        {
-            Debug.Assert(location.IsInSource);
-            var document = workspace.CurrentSolution.GetDocument(location.SourceTree);
-            if (document is not SourceGeneratedDocument)
-            {
-                return null;
-            }
-
-            return new SourceGeneratedFileInfo
-            {
-                ProjectGuid = document.Project.Id.Id,
-                DocumentGuid = document.Id.Id
-            };
         }
     }
 }

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionService.cs
@@ -51,7 +51,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                     FileName = lineSpan.Path,
                     Line = lineSpan.StartLinePosition.Line,
                     Column = lineSpan.StartLinePosition.Character,
-                    SourceGeneratedInfo = GoToDefinitionHelpers.GetSourceGeneratedFileInfo(_workspace, location)
+                    SourceGeneratedInfo = SolutionExtensions.GetSourceGeneratedFileInfo(document.Project.Solution, location)
                 };
             }
             else if (location.IsInMetadata && request.WantMetadata)

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionServiceV2.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionServiceV2.cs
@@ -65,7 +65,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                         }
                         else
                         {
-                            sourceGeneratedFileInfo = GoToDefinitionHelpers.GetSourceGeneratedFileInfo(_workspace, location);
+                            sourceGeneratedFileInfo = SolutionExtensions.GetSourceGeneratedFileInfo(document.Project.Solution, location);
                         }
 
                         return new Definition

--- a/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoTypeDefinitionService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoTypeDefinitionService.cs
@@ -53,7 +53,7 @@ namespace OmniSharp.Roslyn.CSharp.Services.Navigation
                         .Select(location => new TypeDefinition
                         {
                             Location = location.GetMappedLineSpan().GetLocationFromFileLinePositionSpan(),
-                            SourceGeneratedFileInfo = GoToDefinitionHelpers.GetSourceGeneratedFileInfo(_workspace, location)
+                            SourceGeneratedFileInfo = SolutionExtensions.GetSourceGeneratedFileInfo(document.Project.Solution, location)
                         })
                         .ToList()
                 };

--- a/src/OmniSharp.Roslyn/Extensions/SolutionExtensions.cs
+++ b/src/OmniSharp.Roslyn/Extensions/SolutionExtensions.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
 using OmniSharp.Models;
+using OmniSharp.Models.v1.SourceGeneratedFile;
+
+#nullable enable
 
 namespace OmniSharp.Extensions
 {
@@ -67,7 +71,7 @@ namespace OmniSharp.Extensions
             var lineSpan = location.GetLineSpan();
             var path = lineSpan.Path;
             var projects = solution.GetDocumentIdsWithFilePath(path)
-                                    .Select(documentId => solution.GetProject(documentId.ProjectId).Name)
+                                    .Select(documentId => solution.GetProject(documentId.ProjectId)!.Name)
                                     .ToArray();
 
             var format = SymbolDisplayFormat.MinimallyQualifiedFormat;
@@ -86,7 +90,25 @@ namespace OmniSharp.Extensions
                 Column = lineSpan.StartLinePosition.Character,
                 EndLine = lineSpan.EndLinePosition.Line,
                 EndColumn = lineSpan.EndLinePosition.Character,
-                Projects = projects
+                Projects = projects,
+                ContainingSymbolName = symbol.ContainingSymbol?.Name ?? "",
+                GeneratedFileInfo = GetSourceGeneratedFileInfo(solution, location),
+            };
+        }
+
+        internal static SourceGeneratedFileInfo? GetSourceGeneratedFileInfo(Solution solution, Location location)
+        {
+            Debug.Assert(location.IsInSource);
+            var document = solution.GetDocument(location.SourceTree);
+            if (document is not SourceGeneratedDocument)
+            {
+                return null;
+            }
+
+            return new SourceGeneratedFileInfo
+            {
+                ProjectGuid = document.Project.Id.Id,
+                DocumentGuid = document.Id.Id
             };
         }
     }


### PR DESCRIPTION
Updates the workspace symbols requests to provide a SourceGeneratedFileInfo when the symbol is from a source generated file, so aware editors can retrieve information about the file and display it correctly, rather than showing no information.
