### PR TITLE
Upgrade http driver to latest ASP.NET Core version when running in .NET 6

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <PropertyGroup>
-        <AspNetCorePackageVersion>2.2.0</AspNetCorePackageVersion>
         <MicrosoftExtensionPackageVersion>6.0.0</MicrosoftExtensionPackageVersion>
         <MicrosoftTestPackageVersion>17.3.0</MicrosoftTestPackageVersion>
         <MSBuildPackageVersion>17.3.1</MSBuildPackageVersion>
@@ -19,11 +18,6 @@
         <PackageReference Update="ICSharpCode.Decompiler" Version="7.1.0.6543" />
 
         <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-
-        <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="$(AspNetCorePackageVersion)" />
-        <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="$(AspNetCorePackageVersion)" />
-        <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="$(AspNetCorePackageVersion)" />
-        <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCorePackageVersion)" />
 
         <PackageReference Update="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
         <PackageReference Update="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
@@ -93,6 +87,12 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+        <PackageReference Update="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
+        <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
+        <PackageReference Update="Microsoft.AspNetCore.Http.Features" Version="2.2.0" />
+        <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     </ItemGroup>
 </Project>
 

--- a/src/OmniSharp.Http/Host.cs
+++ b/src/OmniSharp.Http/Host.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
+#if NETCOREAPP
+using Microsoft.Extensions.Hosting;
+#endif
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OmniSharp.Eventing;
@@ -38,7 +41,13 @@ namespace OmniSharp.Http
                 .AddCommandLine(new[] { "--server.urls", $"http://{_serverInterface}:{_serverPort}" });
 
             var builder = new WebHostBuilder()
+#if NETCOREAPP
+                .UseKestrel(config => {
+                    config.AllowSynchronousIO = true;
+                })
+#else
                 .UseKestrel()
+#endif
                 .ConfigureServices(serviceCollection =>
                 {
                     serviceCollection.AddSingleton(_environment);
@@ -56,7 +65,11 @@ namespace OmniSharp.Http
             {
                 app.Start();
 
+#if NETCOREAPP
+                var appLifeTime = app.Services.GetRequiredService<IHostApplicationLifetime>();
+#else
                 var appLifeTime = app.Services.GetRequiredService<IApplicationLifetime>();
+#endif
 
                 Console.CancelKeyPress += (sender, e) =>
                 {

--- a/src/OmniSharp.Http/Middleware/StopServerMiddleware.cs
+++ b/src/OmniSharp.Http/Middleware/StopServerMiddleware.cs
@@ -1,15 +1,25 @@
 using System.Threading;
 using System.Threading.Tasks;
+#if NETCOREAPP
+using Microsoft.Extensions.Hosting;
+#else
 using Microsoft.AspNetCore.Hosting;
+#endif
 using Microsoft.AspNetCore.Http;
 
 namespace OmniSharp.Http.Middleware
 {
     class StopServerMiddleware
     {
+#if NETCOREAPP
+        private readonly IHostApplicationLifetime _lifetime;
+
+        public StopServerMiddleware(RequestDelegate next, IHostApplicationLifetime lifetime)
+#else
         private readonly IApplicationLifetime _lifetime;
 
         public StopServerMiddleware(RequestDelegate next, IApplicationLifetime lifetime)
+#endif
         {
             _lifetime = lifetime;
         }

--- a/src/OmniSharp.Http/OmniSharp.Http.csproj
+++ b/src/OmniSharp.Http/OmniSharp.Http.csproj
@@ -5,6 +5,10 @@
         <PlatformTarget>AnyCPU</PlatformTarget>
     </PropertyGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\OmniSharp.DotNetTest\OmniSharp.DotNetTest.csproj" />
         <ProjectReference Include="..\OmniSharp.Host\OmniSharp.Host.csproj" />
@@ -14,8 +18,11 @@
         <ProjectReference Condition="'$(TargetFramework)' == 'net472'" Include="..\OmniSharp.Cake\OmniSharp.Cake.csproj" />
     </ItemGroup>
 
+
     <ItemGroup>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
         <PackageReference Include="Microsoft.AspNetCore.Diagnostics" />
         <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" />
         <PackageReference Include="Microsoft.AspNetCore.Hosting" />


### PR DESCRIPTION
The HTTP driver is currently using ASP.NET Core 2.2.  This reached its end of life in Dec 2019, almost 3 years ago.

This PR updates to the latest ASP.NET core version.

ASP.NET Core 3 and later do not support .NET framework, so this only applies to the build for .NET 6 (and later when supported)

Fixes #2259 