### PR TITLE
Include Cake bits in .NET 6 builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to the project will be documented in this file.
 
 ## [1.39.2] - not yet released
 * Updated ILSpy to 7.2.1.6856 (PR: [#2447](https://github.com/OmniSharp/omnisharp-roslyn/pull/2447))
+* Include OmniSharp.Cake in .NET 6 builds (PR: [#2455](https://github.com/OmniSharp/omnisharp-roslyn/pull/2455))
 
 ## [1.39.1] - 2022-07-25
 * Update Roslyn to 4.4.0 1.22369.1 (PR: [#2420](https://github.com/OmniSharp/omnisharp-roslyn/pull/2420))

--- a/src/OmniSharp.Http/OmniSharp.Http.csproj
+++ b/src/OmniSharp.Http/OmniSharp.Http.csproj
@@ -15,7 +15,7 @@
         <ProjectReference Include="..\OmniSharp.MSBuild\OmniSharp.MSBuild.csproj" />
         <ProjectReference Include="..\OmniSharp.Script\OmniSharp.Script.csproj" />
         <ProjectReference Include="..\OmniSharp.Roslyn.CSharp\OmniSharp.Roslyn.CSharp.csproj" />
-        <ProjectReference Condition="'$(TargetFramework)' == 'net472'" Include="..\OmniSharp.Cake\OmniSharp.Cake.csproj" />
+        <ProjectReference Include="..\OmniSharp.Cake\OmniSharp.Cake.csproj" />
     </ItemGroup>
 
 

--- a/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj
+++ b/src/OmniSharp.Stdio/OmniSharp.Stdio.csproj
@@ -12,7 +12,7 @@
         <ProjectReference Include="..\OmniSharp.DotNetTest\OmniSharp.DotNetTest.csproj" />
         <ProjectReference Include="..\OmniSharp.MSBuild\OmniSharp.MSBuild.csproj" />
         <ProjectReference Include="..\OmniSharp.Script\OmniSharp.Script.csproj" />
-        <ProjectReference Condition="'$(TargetFramework)' == 'net472'" Include="..\OmniSharp.Cake\OmniSharp.Cake.csproj" />
+        <ProjectReference Include="..\OmniSharp.Cake\OmniSharp.Cake.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test-assets/test-projects/CakeProject/tools/packages.config
+++ b/test-assets/test-projects/CakeProject/tools/packages.config
@@ -1,3 +1,3 @@
 <packages>
-    <package id="Cake.Bakery" version="0.9.0" />
+    <package id="Cake.Bakery" version="0.11.0" />
 </packages>


### PR DESCRIPTION
Seems we forgot to remove the TFM check on project reference for Cake after .NET 6 support was added.