### PR TITLE
Don't remap line mappings in Razor files

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
@@ -16,9 +16,7 @@ namespace OmniSharp.Helpers
             if (!location.IsInSource)
                 throw new Exception("Location is not in the source tree");
 
-            var lineSpan = Path.GetExtension(location.SourceTree.FilePath).Equals(".cake", StringComparison.OrdinalIgnoreCase)
-                ? location.GetLineSpan()
-                : location.GetMappedLineSpan();
+            var lineSpan = location.GetLineSpan();
 
             var documents = workspace.GetDocuments(lineSpan.Path);
             var sourceText = GetSourceText(location, documents, lineSpan.HasMappedPath);
@@ -39,9 +37,9 @@ namespace OmniSharp.Helpers
                 Text = text.Trim(),
                 FileName = fileName,
                 Line = lineSpan.StartLinePosition.Line,
-                Column = lineSpan.HasMappedPath ? 0 : lineSpan.StartLinePosition.Character, // when a #line directive maps into a separate file, assume columns (0,0)
+                Column = lineSpan.StartLinePosition.Character,
                 EndLine = lineSpan.EndLinePosition.Line,
-                EndColumn = lineSpan.HasMappedPath ? 0 : lineSpan.EndLinePosition.Character,
+                EndColumn = lineSpan.EndLinePosition.Character,
                 Projects = documents.Select(document => document.Project.Name).ToArray(),
                 GeneratedFileInfo = generatedInfo
             };

--- a/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Helpers/LocationExtensions.cs
@@ -16,10 +16,9 @@ namespace OmniSharp.Helpers
             if (!location.IsInSource)
                 throw new Exception("Location is not in the source tree");
 
-            string filePath = location.SourceTree.FilePath;
-            var lineSpan = Path.GetExtension(filePath).Equals(".cake", StringComparison.OrdinalIgnoreCase) ||
-                filePath.EndsWith("razor__virtual.cs") ||
-                filePath.EndsWith("cshtml__virtual.cs")
+            var lineSpan = Path.GetExtension(location.SourceTree.FilePath).Equals(".cake", StringComparison.OrdinalIgnoreCase) ||
+                location.SourceTree.FilePath.EndsWith("razor__virtual.cs") ||
+                location.SourceTree.FilePath.EndsWith("cshtml__virtual.cs")
                 ? location.GetLineSpan()
                 : location.GetMappedLineSpan();
 
@@ -34,7 +33,7 @@ namespace OmniSharp.Helpers
                 // exist on disk
                 ? lineSpan.Path
                 // when a #line directive maps into a separate file using a relative path, get the full path relative to the folder containing the source tree
-                : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(filePath), lineSpan.Path));
+                : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(location.SourceTree.FilePath), lineSpan.Path));
 
 
             return new SymbolLocation

--- a/tests/OmniSharp.Lsp.Tests/ReferencesHandlerFacts.cs
+++ b/tests/OmniSharp.Lsp.Tests/ReferencesHandlerFacts.cs
@@ -134,7 +134,7 @@ namespace OmniSharp.Lsp.Tests
         [Theory]
         [InlineData(9)]
         [InlineData(100)]
-        public async Task CanFindReferencesWithLineMapping(int mappingLine)
+        public async Task FindReferencesWithLineMappingReturnsRegularPosition(int mappingLine)
         {
             var code = @"
                 public class Foo
@@ -162,17 +162,13 @@ namespace OmniSharp.Lsp.Tests
             Assert.Equal("dummy.cs", regularResult.Uri);
             Assert.Equal("dummy.cs", mappedResult.Uri);
 
-            // Assert.Equal("public void bar() { }", regularResult.Text);
-            // Assert.Equal(expectedMappingText, mappedResult.Text);
-
             Assert.Equal(3, regularResult.Range.Start.Line);
-            Assert.Equal(mappingLine - 1, mappedResult.Range.Start.Line);
+            Assert.Equal(11, mappedResult.Range.Start.Line);
 
-            // regular result has regular postition
+            // regular + mapped results have regular postition
             Assert.Equal(32, regularResult.Range.Start.Character);
             Assert.Equal(35, regularResult.Range.End.Character);
 
-            // mapped result has column 0,0
             Assert.Equal(34, mappedResult.Range.Start.Character);
             Assert.Equal(37, mappedResult.Range.End.Character);
         }
@@ -181,7 +177,7 @@ namespace OmniSharp.Lsp.Tests
         [InlineData(1, true)] // everything correct
         [InlineData(100, true)] // file exists in workspace but mapping incorrect
         [InlineData(1, false)] // file doesn't exist in workspace but mapping correct
-        public async Task CanFindReferencesWithLineMappingAcrossFiles(int mappingLine,
+        public async Task FindReferencesWithLineMappingAcrossFilesReturnsRegularPosition(int mappingLine,
             bool mappedFileExistsInWorkspace)
         {
             var testFiles = new List<TestFile>()
@@ -216,21 +212,17 @@ namespace OmniSharp.Lsp.Tests
             var mappedResult = usages.ElementAt(1);
 
             Assert.EndsWith("a.cs", regularResult.Uri.Path);
-            Assert.EndsWith("b.cs", mappedResult.Uri.Path);
+            Assert.EndsWith("a.cs", mappedResult.Uri.Path);
 
             Assert.Equal(3, regularResult.Range.Start.Line);
-            Assert.Equal(mappingLine - 1, mappedResult.Range.Start.Line);
+            Assert.Equal(11, mappedResult.Range.Start.Line);
 
-            // Assert.Equal("public void bar() { }", regularResult.Text);
-            // Assert.Equal(expectedMappingText, mappedResult.Text);
-
-            // regular result has regular postition
+            // regular + mapped results have regular postition
             Assert.Equal(32, regularResult.Range.Start.Character);
             Assert.Equal(35, regularResult.Range.End.Character);
 
-            // mapped result has column 0,0
-            Assert.Equal(0, mappedResult.Range.Start.Character);
-            Assert.Equal(0, mappedResult.Range.End.Character);
+            Assert.Equal(34, mappedResult.Range.Start.Character);
+            Assert.Equal(37, mappedResult.Range.End.Character);
         }
 
         [Fact]

--- a/tests/OmniSharp.Lsp.Tests/ReferencesHandlerFacts.cs
+++ b/tests/OmniSharp.Lsp.Tests/ReferencesHandlerFacts.cs
@@ -2,16 +2,13 @@
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Models;
 using OmniSharp.Models.FindUsages;
 using OmniSharp.Roslyn.CSharp.Services.Navigation;
-
 using TestUtility;
-
 using Xunit;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
**Problem:** O# sets the start/end characters of a location to 0 if the location is within a line mapping directive. This is problematic in Razor, where we're attempting to implement document highlighting for the first time and need exact start/end characters.

**Solution**: Use the original line and character locations (edit: only in Razor files). This also means we need to return the non-mapped file path.

I confirmed features that go through this call path (document highlighting, find all references, go-to-impl, etc.) still work correctly with this change in both C# and Razor files. Most features still work since many [do their own re-mapping](https://github.com/OmniSharp/omnisharp-vscode/blob/1f2d7de27a9e89d8a7303104a710a918eb699827/src/features/referenceProvider.ts#L32) behind the scenes. As a result of this change, document highlighting in Razor now works too. 🙂