### PR TITLE
Infrastructure improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ defaults:
     shell: pwsh
 on:
   pull_request:
+    paths-ignore:
+      - 'CHANGELOG.md'
     branches:
       - master
       - feature/*

--- a/.github/workflows/tests-net6.yml
+++ b/.github/workflows/tests-net6.yml
@@ -13,6 +13,8 @@ defaults:
     shell: pwsh
 on:
   pull_request:
+    paths-ignore:
+      - 'CHANGELOG.md'
     branches:
       - master
       - demo/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ defaults:
     shell: pwsh
 on:
   pull_request:
+    paths-ignore:
+      - 'CHANGELOG.md'
     branches:
       - master
       - feature/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,9 @@ pr:
     include:
       - master
       - feature/*
+  paths:
+    exclude:
+      - 'CHANGELOG.md'
 
 resources:
   repositories:

--- a/build.cake
+++ b/build.cake
@@ -507,20 +507,23 @@ Task("PublishNet6Builds")
     {
         if (publishAll)
         {
-            if (!Platform.Current.IsWindows)
+            if (Platform.Current.IsWindows)
             {
-                PublishBuild(project, env, buildPlan, configuration, "linux-x64", "net6.0");
-                PublishBuild(project, env, buildPlan, configuration, "linux-arm64", "net6.0");
-                PublishBuild(project, env, buildPlan, configuration, "linux-musl-x64", "net6.0");
-                PublishBuild(project, env, buildPlan, configuration, "linux-musl-arm64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "win7-x86", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "win7-x64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "win10-arm64", "net6.0");
+            }
+            else if (Platform.Current.IsMacOS)
+            {
                 PublishBuild(project, env, buildPlan, configuration, "osx-x64", "net6.0");
                 PublishBuild(project, env, buildPlan, configuration, "osx-arm64", "net6.0");
             }
             else
             {
-                PublishBuild(project, env, buildPlan, configuration, "win7-x86", "net6.0");
-                PublishBuild(project, env, buildPlan, configuration, "win7-x64", "net6.0");
-                PublishBuild(project, env, buildPlan, configuration, "win10-arm64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "linux-x64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "linux-arm64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "linux-musl-x64", "net6.0");
+                PublishBuild(project, env, buildPlan, configuration, "linux-musl-arm64", "net6.0");
             }
         }
         else if (Platform.Current.IsWindows)


### PR DESCRIPTION
The macos and linux build CI legs take longer than necessary because they are building for both platforms. Also this disables CI job for changes to changelog.md.