### PR TITLE
Updated dotnet-script dependencies to 1.4.0

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -63,6 +63,42 @@
             },
             // Use the standard MS compiler pattern to detect errors, warnings and infos
             "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj"
+            ],
+            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -13,8 +13,8 @@
     <ItemGroup>
         <PackageReference Update="Cake.Scripting.Transport" Version="0.9.0" />
 
-        <PackageReference Update="Dotnet.Script.DependencyModel" Version="1.3.1" />
-        <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="1.3.1" />
+        <PackageReference Update="Dotnet.Script.DependencyModel" Version="1.4.0" />
+        <PackageReference Update="Dotnet.Script.DependencyModel.NuGet" Version="1.4.0" />
         <PackageReference Update="ICSharpCode.Decompiler" Version="7.2.1.6856" />
 
         <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />


### PR DESCRIPTION
This is needed to support intellisense in dotnet-script 1.4.0 (which was released with support for .net 7)