### PR TITLE
Disable snippets in synchronous completion logic

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionListBuilder_Sync.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionListBuilder_Sync.cs
@@ -61,6 +61,13 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
             {
                 TextSpan changeSpan = typedSpan;
                 var completion = completions.ItemsList[i];
+
+                // To-do: Add support for snippet items: https://github.com/OmniSharp/omnisharp-roslyn/issues/2485
+                if (completion.GetProviderName() == SnippetCompletionProvider)
+                {
+                    continue;
+                }
+
                 var insertTextFormat = InsertTextFormat.PlainText;
                 string labelText = completion.DisplayTextPrefix + completion.DisplayText + completion.DisplayTextSuffix;
                 List<LinePositionSpanTextChange>? additionalTextEdits = null;


### PR DESCRIPTION
Previously, when upgrading Roslyn to a newer version, we [disabled snippets](https://github.com/OmniSharp/omnisharp-roslyn/pull/2486/files#diff-fcd6685e91560d2c357ca740527ebe592b32bd3e59c51765ddee005f385b8d3eR49) due to duplicates in the completion list (see #2485). We did this in our async completion logic, but it turns out we need to do the same in our sync completion logic as well. This fixes issues such as `@inject [||]` not displaying C# completions in Razor files.