### PR TITLE
Respond to vscode breaking change in 1.79.2 that triggers completion inside words

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionListBuilder_Sync.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionListBuilder_Sync.cs
@@ -220,6 +220,15 @@ namespace OmniSharp.Roslyn.CSharp.Services.Completion
                     }
 
                     changeSpan = updatedChange.Span;
+                    // When inserting at the beginning or middle of a word, we want to only replace characters
+                    // up until the caret position, but not after.  For example when typing at the beginning of a word
+                    // we only want to insert the completion before the rest of the word.
+                    // However, Roslyn returns the entire word as the span to replace, so we have to adjust it.
+                    if (position < changeSpan.End)
+                    {
+                        changeSpan = new(changeSpan.Start, length: position - changeSpan.Start);
+                    }
+
                     (insertText, insertTextFormat) = getPossiblySnippetizedInsertText(updatedChange, adjustedNewPosition);
 
                     // If we're expecting there to be unimported types, put in an explicit sort text to put things already in scope first.

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
@@ -2255,16 +2255,16 @@ namespace N
         [InlineData("dummy.csx")]
         public async Task ReplacesUpUntilCursorInMiddleOfWord(string filename)
         {
-            const string input =
-                @"pub$$class}";
+            const string input = @"public class C1 {}
+pub$$class";
 
             var completions = await FindCompletionsAsync(filename, input, SharedOmniSharpTestHost);
             Assert.All(completions.Items, (completion) =>
             {
                 Assert.Equal(0, completion.TextEdit.StartColumn);
-                Assert.Equal(0, completion.TextEdit.StartLine);
+                Assert.Equal(1, completion.TextEdit.StartLine);
                 Assert.Equal(3, completion.TextEdit.EndColumn);
-                Assert.Equal(0, completion.TextEdit.EndLine);
+                Assert.Equal(1, completion.TextEdit.EndLine);
             });
         }
 

--- a/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
+++ b/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs
@@ -2250,6 +2250,24 @@ namespace N
             }
         }
 
+        [Theory]
+        [InlineData("dummy.cs")]
+        [InlineData("dummy.csx")]
+        public async Task ReplacesUpUntilCursorInMiddleOfWord(string filename)
+        {
+            const string input =
+                @"pub$$class}";
+
+            var completions = await FindCompletionsAsync(filename, input, SharedOmniSharpTestHost);
+            Assert.All(completions.Items, (completion) =>
+            {
+                Assert.Equal(0, completion.TextEdit.StartColumn);
+                Assert.Equal(0, completion.TextEdit.StartLine);
+                Assert.Equal(3, completion.TextEdit.EndColumn);
+                Assert.Equal(0, completion.TextEdit.EndLine);
+            });
+        }
+
         private CompletionService GetCompletionService(OmniSharpTestHost host)
             => host.GetRequestHandler<CompletionService>(EndpointName);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/vscode-csharp/issues/5801

VSCode made a change in completion somewhere between 1.78.2 and 1.79.2 where they now trigger completion automatically inside words.  This was confirmed as an intentional change here - https://github.com/microsoft/vscode/issues/185286

However, this has caused lots of bug reports on us because O# will replace the entire word (including after the cursor) if a completion is accepted, instead of just inserting the selected completion item before the cursor. 

This does the same change as we did to fix this in Roslyn LSP - we limit the range to the cursor position.  See https://github.com/dotnet/roslyn/pull/68624

Now looks like 
![completion_1_79_2](https://github.com/OmniSharp/omnisharp-roslyn/assets/5749229/a6001cc6-05b0-40d7-a0aa-6551ab139769)
