### PR TITLE
Use double quote when quoting un script path

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -77,7 +77,7 @@ void InstallDotNetSdk(BuildEnvironment env, BuildPlan plan, string version, stri
 
     if (!Platform.Current.IsWindows)
     {
-        Run("chmod", $"+x '{scriptFilePath}'");
+        Run("chmod", $"+x \"{scriptFilePath}\"");
     }
 
     var argList = new List<string>();
@@ -467,7 +467,7 @@ string PublishMonoBuildForPlatform(string project, MonoRuntime monoRuntime, Buil
 
     var runScriptFile = CombinePaths(env.Folders.MonoPackaging, "run");
     FileHelper.Copy(runScriptFile, CombinePaths(outputFolder, "run"), overwrite: true);
-    Run("chmod", $"+x '{CombinePaths(outputFolder, "run")}'");
+    Run("chmod", $"+x \"{CombinePaths(outputFolder, "run")}\"");
 
     CopyExtraDependencies(env, outputFolder);
     AddOmniSharpBindingRedirects(omnisharpFolder);


### PR DESCRIPTION
Was seeing errors like `chmod: cannot access "'/home/vsts/work/1/s/artifacts/publish/OmniSharp.Stdio.Driver/linux-x64/run'": No such file or directory` in the CI build log as well as locally.

Resolves https://github.com/OmniSharp/omnisharp-roslyn/issues/2547