### PR TITLE
Include the project file name when invoking `dotnet build`

### DIFF
--- a/src/OmniSharp.DotNetTest/VSTestManager.cs
+++ b/src/OmniSharp.DotNetTest/VSTestManager.cs
@@ -86,8 +86,10 @@ namespace OmniSharp.DotNetTest
                 return true;
             }
 
+            var projectFileName = Path.GetFileName(Project.FilePath);
+
             // The project must be built before we can test.
-            var arguments = "build";
+            var arguments = $"build {projectFileName}";
 
             // If this is .NET CLI version 2.0.0 or greater, we also specify --no-restore to ensure that
             // implicit restore on build doesn't slow the build down.


### PR DESCRIPTION
When multiple .sln or .csproj files are present in the same directory as the project that tests are being run against, dotnet errors that we should specify which we want built.