### PR TITLE
fix #2550 inlay hints lambdas parameter type null reference exception

### DIFF
--- a/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpInlayHintHandler.cs
+++ b/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpInlayHintHandler.cs
@@ -82,7 +82,7 @@ namespace OmniSharp.LanguageServerProtocol.Handlers
                     ? new MarkupContent() { Kind = MarkupKind.Markdown, Value = hint.Tooltip }
                     : null,
                 Position = ToPosition(hint.Position),
-                TextEdits = new(ToTextEdits(hint.TextEdits)),
+                TextEdits = hint.TextEdits is not null ? new(ToTextEdits(hint.TextEdits)) : null,
                 PaddingLeft = hint.Label.Length > trimmedStartLabel.Length,
                 PaddingRight = trimmedStartLabel.Length > trimmedLabel.Length,
                 Data = JToken.FromObject(hint.Data),


### PR DESCRIPTION
this fixes #2550

the issue happens with lambdas as parameters of a function call (Though it might happen in other cases too) es `function(sp => sp.GetService<CloudAdapter>()`

this should expand to `function(|paramName:| |Type| sp => sp.GetService<CloudAdapter>()`

each hint has a field called TextEdits of type `LinePositionSpanTextChange[]?` (either is an array or is null), which tell the editor that there is an option to promote the virtual text to real text in the document, but for lambdas paramenters type this is not an option so is set to null, when the TextEdits object gets passed to a foreach loop without checking for null the LSP would crash with a null reference

```csharp
public static IEnumerable<TextEdit> ToTextEdits(LinePositionSpanTextChange[] textChanges)
{
    foreach (var change in textChanges) //<--- ops this is null!
    {
        yield return ToTextEdit(change);
    }
}
```

I've also added a test to replicate the exception, I hope it's all that's needed, if I need to change something in the PR let me know!