### PR TITLE
Remove NuGet.Packaging.Core, as it's an assembly that only contains forwarders

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,7 +8,6 @@
       <PackageReference Include="NuGet.DependencyResolver.Core" ExcludeAssets="all" PrivateAssets="all" />
       <PackageReference Include="NuGet.Frameworks" ExcludeAssets="all" PrivateAssets="all" />
       <PackageReference Include="NuGet.LibraryModel" ExcludeAssets="all" PrivateAssets="all" />
-      <PackageReference Include="NuGet.Packaging.Core" ExcludeAssets="all" PrivateAssets="all" />
       <PackageReference Include="NuGet.Packaging" ExcludeAssets="all" PrivateAssets="all" />
       <PackageReference Include="NuGet.ProjectModel" ExcludeAssets="all" PrivateAssets="all" />
       <PackageReference Include="NuGet.Protocol" ExcludeAssets="all" PrivateAssets="all" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -71,7 +71,6 @@
         <PackageVersion Include="NuGet.DependencyResolver.Core" Version="$(NuGetPackageVersion)" />
         <PackageVersion Include="NuGet.Frameworks" Version="$(NuGetPackageVersion)" />
         <PackageVersion Include="NuGet.LibraryModel" Version="$(NuGetPackageVersion)" />
-        <PackageVersion Include="NuGet.Packaging.Core" Version="$(NuGetPackageVersion)" />
         <PackageVersion Include="NuGet.Packaging" Version="$(NuGetPackageVersion)" />
         <PackageVersion Include="NuGet.ProjectModel" Version="$(NuGetPackageVersion)" />
         <PackageVersion Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />

--- a/src/OmniSharp.MSBuild/OmniSharp.MSBuild.csproj
+++ b/src/OmniSharp.MSBuild/OmniSharp.MSBuild.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="Runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="NuGet.Packaging.Core" />
     <PackageReference Include="NuGet.ProjectModel" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />


### PR DESCRIPTION
Remove NuGet.Packaging.Core since it only contains type forwarders. 

![image](https://github.com/dotnet/Open-XML-SDK/assets/2878341/a09b3425-9026-4f2c-83a7-1b7d54d049ab)
