### PR TITLE
Remove NuGet.Packaging.Core, as it's an assembly that only contains forwarders 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-11]
+        os: [ubuntu-20.04, windows-2022, macos-12]
     name: 'Build'
     steps:
       - name: Checkout

--- a/.github/workflows/tests-net6.yml
+++ b/.github/workflows/tests-net6.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-11]
+        os: [ubuntu-20.04, windows-2022, macos-12]
         testProjects:
           - OmniSharp.MSBuild.Tests,OmniSharp.Roslyn.CSharp.Tests,OmniSharp.Cake.Tests,OmniSharp.Script.Tests,OmniSharp.Stdio.Tests,OmniSharp.Http.Tests,OmniSharp.Tests,OmniSharp.Lsp.Tests
           - OmniSharp.DotNetTest.Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-11]
+        os: [ubuntu-20.04, windows-2022, macos-12]
         testProjects:
           - OmniSharp.MSBuild.Tests,OmniSharp.Roslyn.CSharp.Tests,OmniSharp.Cake.Tests,OmniSharp.Script.Tests,OmniSharp.Stdio.Tests,OmniSharp.Http.Tests,OmniSharp.Tests,OmniSharp.Lsp.Tests
           - OmniSharp.DotNetTest.Tests

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,7 +8,6 @@
       <PackageReference Include="NuGet.DependencyResolver.Core" ExcludeAssets="all" PrivateAssets="all" />
       <PackageReference Include="NuGet.Frameworks" ExcludeAssets="all" PrivateAssets="all" />
       <PackageReference Include="NuGet.LibraryModel" ExcludeAssets="all" PrivateAssets="all" />
-      <PackageReference Include="NuGet.Packaging.Core" ExcludeAssets="all" PrivateAssets="all" />
       <PackageReference Include="NuGet.Packaging" ExcludeAssets="all" PrivateAssets="all" />
       <PackageReference Include="NuGet.ProjectModel" ExcludeAssets="all" PrivateAssets="all" />
       <PackageReference Include="NuGet.Protocol" ExcludeAssets="all" PrivateAssets="all" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
         <MicrosoftExtensionPackageVersion>8.0.0</MicrosoftExtensionPackageVersion>
         <MicrosoftTestPackageVersion>17.8.0</MicrosoftTestPackageVersion>
         <MSBuildPackageVersion>17.3.2</MSBuildPackageVersion>
-        <NuGetPackageVersion>6.10.0-preview.1.18</NuGetPackageVersion>
+        <NuGetPackageVersion>6.11.0-rc.110</NuGetPackageVersion>
         <RoslynPackageVersion>4.10.0-2.24112.8</RoslynPackageVersion>
         <XunitPackageVersion>2.6.1</XunitPackageVersion>
     </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,7 +88,7 @@
         <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
         <PackageVersion Include="System.Memory" Version="4.5.5" />
         <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
-        <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+        <PackageVersion Include="System.Text.Json" Version="8.0.4" />
         <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
         <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -71,7 +71,6 @@
         <PackageVersion Include="NuGet.DependencyResolver.Core" Version="$(NuGetPackageVersion)" />
         <PackageVersion Include="NuGet.Frameworks" Version="$(NuGetPackageVersion)" />
         <PackageVersion Include="NuGet.LibraryModel" Version="$(NuGetPackageVersion)" />
-        <PackageVersion Include="NuGet.Packaging.Core" Version="$(NuGetPackageVersion)" />
         <PackageVersion Include="NuGet.Packaging" Version="$(NuGetPackageVersion)" />
         <PackageVersion Include="NuGet.ProjectModel" Version="$(NuGetPackageVersion)" />
         <PackageVersion Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ jobs:
 
   - job: macOS
     pool:
-      vmImage: "macOS-11"
+      vmImage: "macos-12"
     dependsOn: GitVersion
     steps:
       - template: ./.pipelines/init.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,7 +113,7 @@ jobs:
 
   - job: Release
     pool:
-      vmImage: "Ubuntu-latest"
+      vmImage: "ubuntu-latest"
     dependsOn:
       - macOS
       - Linux

--- a/src/OmniSharp.MSBuild/OmniSharp.MSBuild.csproj
+++ b/src/OmniSharp.MSBuild/OmniSharp.MSBuild.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="Runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="NuGet.Packaging.Core" />
     <PackageReference Include="NuGet.ProjectModel" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />


### PR DESCRIPTION
Same changes as #2610 just getting a new run of CI.