### PR TITLE
fix: get source text exceptions

### DIFF
--- a/src/OmniSharp.Roslyn.CSharp/Services/InlayHints/InlayHintService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/InlayHints/InlayHintService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -56,8 +57,17 @@ internal class InlayHintService :
             return InlayHintResponse.None;
         }
 
-        var sourceText = await document.GetTextAsync();
-        var mappedSpan = sourceText.GetSpanFromRange(request.Location.Range);
+        SourceText sourceText;
+        TextSpan mappedSpan;
+        try
+        {
+            sourceText = await document.GetTextAsync();
+            mappedSpan = sourceText.GetSpanFromRange(request.Location.Range);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return InlayHintResponse.None;
+        }
 
         var inlayHintsOptions = _omniSharpOptions.CurrentValue.RoslynExtensionsOptions.InlayHintsOptions;
         var options = new OmniSharpInlineHintsOptions

--- a/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
+++ b/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
@@ -5,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Extensions;
 using OmniSharp.Mef;
 using OmniSharp.Models;
@@ -103,8 +105,17 @@ namespace OmniSharp.Roslyn.CSharp.Services.Signatures
 
         private async Task<InvocationContext> GetInvocation(Document document, Request request)
         {
-            var sourceText = await document.GetTextAsync();
-            var position = sourceText.GetTextPosition(request);
+            SourceText sourceText;
+            int position;
+            try
+            {
+                sourceText = await document.GetTextAsync();
+                position = sourceText.GetTextPosition(request);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return null;
+            }
             var tree = await document.GetSyntaxTreeAsync();
             var root = await tree.GetRootAsync();
             var node = root.FindToken(position).Parent;


### PR DESCRIPTION
Should fix https://github.com/OmniSharp/omnisharp-roslyn/issues/2655

Logs:

```
[WARN][2025-02-03 20:17:47] ...lsp/handlers.lua:625	"OmniSharp.Roslyn.CSharp.Services.InlayHints.InlayHintService: Inlay hints requested for document /$metadata$/Project/OmniSharp/Tests/Assembly/Microsoft/CodeAnalysis/Symbol/Microsoft/CodeAnalysis/Text/TextLineCollection.cs: [Point { Line = 0, Column = 0 }, Point { Line = 158, Column = 0 }] | "
[ERROR][2025-02-03 20:17:48] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/inlayHint 347 - System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'index')\n   at Microsoft.CodeAnalysis.Text.SourceText.LineInfo.get_Item(Int32 index)\n   at OmniSharp.Extensions.TextExtensions.GetPositionFromLineAndOffset(SourceText text, Int32 lineNumber, Int32 offset) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn/Extensions/TextExtensions.cs:line 28\n   at OmniSharp.Extensions.TextExtensions.GetSpanFromRange(SourceText text, Range range) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn/Extensions/TextExtensions.cs:line 55\n   at OmniSharp.Roslyn.CSharp.Services.InlayHints.InlayHintService.Handle(InlayHintRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/InlayHints/InlayHintService.cs:line 61\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpInlayHintHandler.Handle(InlayHintParams request, CancellationToken cancellationToken) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpInlayHintHandler.cs:line 56\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/inlayHint' RequestId='347'"
[ERROR][2025-02-03 20:17:48] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/signatureHelp 348 - System.ArgumentOutOfRangeException: The requested line number 125 must be less than the number of lines 1. (Parameter 'Line')\n   at Microsoft.CodeAnalysis.Text.TextLineCollection.GetPosition(LinePosition position)\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.GetInvocation(Document document, Request request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 107\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.Handle(SignatureHelpRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 32\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpSignatureHelpHandler.Handle(SignatureHelpParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs:line 43\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/signatureHelp' RequestId='348'"
[ERROR][2025-02-03 20:18:24] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/signatureHelp 350 - System.ArgumentOutOfRangeException: The requested line number 125 must be less than the number of lines 1. (Parameter 'Line')\n   at Microsoft.CodeAnalysis.Text.TextLineCollection.GetPosition(LinePosition position)\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.GetInvocation(Document document, Request request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 107\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.Handle(SignatureHelpRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 32\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpSignatureHelpHandler.Handle(SignatureHelpParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs:line 43\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/signatureHelp' RequestId='350'"
[ERROR][2025-02-03 20:18:43] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/signatureHelp 351 - System.ArgumentOutOfRangeException: The requested line number 129 must be less than the number of lines 1. (Parameter 'Line')\n   at Microsoft.CodeAnalysis.Text.TextLineCollection.GetPosition(LinePosition position)\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.GetInvocation(Document document, Request request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 107\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.Handle(SignatureHelpRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 32\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpSignatureHelpHandler.Handle(SignatureHelpParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs:line 43\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/signatureHelp' RequestId='351'"
[ERROR][2025-02-03 20:18:43] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/definition 352 - System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'index')\n   at Microsoft.CodeAnalysis.Text.SourceText.LineInfo.get_Item(Int32 index)\n   at OmniSharp.Extensions.TextExtensions.GetPositionFromLineAndOffset(SourceText text, Int32 lineNumber, Int32 offset) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn/Extensions/TextExtensions.cs:line 28\n   at OmniSharp.Roslyn.CSharp.Services.Navigation.GoToDefinitionHelpers.GetDefinitionSymbol(Document document, Int32 line, Int32 column, CancellationToken cancellationToken) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GoToDefinitionHelpers.cs:line 15\n   at OmniSharp.Roslyn.CSharp.Services.Navigation.GotoDefinitionServiceV2.Handle(GotoDefinitionRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionServiceV2.cs:line 43\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpDefinitionHandler.Handle(DefinitionParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpDefinitionHandler.cs:line 42\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/definition' RequestId='352'"
[ERROR][2025-02-03 20:18:44] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/signatureHelp 354 - System.ArgumentOutOfRangeException: The requested line number 129 must be less than the number of lines 1. (Parameter 'Line')\n   at Microsoft.CodeAnalysis.Text.TextLineCollection.GetPosition(LinePosition position)\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.GetInvocation(Document document, Request request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 107\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.Handle(SignatureHelpRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 32\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpSignatureHelpHandler.Handle(SignatureHelpParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs:line 43\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/signatureHelp' RequestId='354'"
[ERROR][2025-02-03 20:18:49] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/definition 355 - System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'index')\n   at OmniSharp.Roslyn.CSharp.Services.Navigation.GoToDefinitionHelpers.GetDefinitionSymbol(Document document, Int32 line, Int32 column, CancellationToken cancellationToken) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GoToDefinitionHelpers.cs:line 15\n   at OmniSharp.Roslyn.CSharp.Services.Navigation.GotoDefinitionServiceV2.Handle(GotoDefinitionRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Navigation/GotoDefinitionServiceV2.cs:line 43\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpDefinitionHandler.Handle(DefinitionParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpDefinitionHandler.cs:line 42\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/definition' RequestId='355'"
[ERROR][2025-02-03 20:18:50] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/signatureHelp 357 - System.ArgumentOutOfRangeException: The requested line number 80 must be less than the number of lines 1. (Parameter 'Line')\n   at Microsoft.CodeAnalysis.Text.TextLineCollection.GetPosition(LinePosition position)\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.GetInvocation(Document document, Request request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 107\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.Handle(SignatureHelpRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 32\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpSignatureHelpHandler.Handle(SignatureHelpParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs:line 43\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/signatureHelp' RequestId='357'"
[ERROR][2025-02-03 20:18:51] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/signatureHelp 358 - System.ArgumentOutOfRangeException: The requested line number 77 must be less than the number of lines 1. (Parameter 'Line')\n   at Microsoft.CodeAnalysis.Text.TextLineCollection.GetPosition(LinePosition position)\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.GetInvocation(Document document, Request request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 107\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.Handle(SignatureHelpRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 32\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpSignatureHelpHandler.Handle(SignatureHelpParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs:line 43\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/signatureHelp' RequestId='358'"
[ERROR][2025-02-03 20:18:53] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/signatureHelp 359 - System.ArgumentOutOfRangeException: The requested line number 117 must be less than the number of lines 1. (Parameter 'Line')\n   at Microsoft.CodeAnalysis.Text.TextLineCollection.GetPosition(LinePosition position)\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.GetInvocation(Document document, Request request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 107\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.Handle(SignatureHelpRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 32\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpSignatureHelpHandler.Handle(SignatureHelpParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs:line 43\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/signatureHelp' RequestId='359'"
[WARN][2025-02-03 20:19:13] ...lsp/handlers.lua:625	"OmniSharp.Roslyn.CSharp.Services.InlayHints.InlayHintService: Inlay hints requested for document /$metadata$/Project/OmniSharp/Tests/Assembly/Microsoft/CodeAnalysis/Workspaces/Symbol/Microsoft/CodeAnalysis/TextDocument.cs: [Point { Line = 0, Column = 0 }, Point { Line = 149, Column = 0 }] | "
[ERROR][2025-02-03 20:19:14] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/signatureHelp 373 - System.ArgumentOutOfRangeException: The requested line number 80 must be less than the number of lines 1. (Parameter 'Line')\n   at Microsoft.CodeAnalysis.Text.TextLineCollection.GetPosition(LinePosition position)\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.GetInvocation(Document document, Request request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 107\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.Handle(SignatureHelpRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 32\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpSignatureHelpHandler.Handle(SignatureHelpParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs:line 43\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/signatureHelp' RequestId='373'"
[ERROR][2025-02-03 20:19:14] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/inlayHint 372 - System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'index')\n   at Microsoft.CodeAnalysis.Text.SourceText.LineInfo.get_Item(Int32 index)\n   at OmniSharp.Extensions.TextExtensions.GetPositionFromLineAndOffset(SourceText text, Int32 lineNumber, Int32 offset) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn/Extensions/TextExtensions.cs:line 28\n   at OmniSharp.Extensions.TextExtensions.GetSpanFromRange(SourceText text, Range range) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn/Extensions/TextExtensions.cs:line 55\n   at OmniSharp.Roslyn.CSharp.Services.InlayHints.InlayHintService.Handle(InlayHintRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/InlayHints/InlayHintService.cs:line 61\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpInlayHintHandler.Handle(InlayHintParams request, CancellationToken cancellationToken) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpInlayHintHandler.cs:line 56\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/inlayHint' RequestId='372'"
[ERROR][2025-02-03 20:19:42] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/signatureHelp 375 - System.ArgumentOutOfRangeException: The requested line number 80 must be less than the number of lines 1. (Parameter 'Line')\n   at Microsoft.CodeAnalysis.Text.TextLineCollection.GetPosition(LinePosition position)\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.GetInvocation(Document document, Request request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 107\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.Handle(SignatureHelpRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 32\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpSignatureHelpHandler.Handle(SignatureHelpParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs:line 43\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/signatureHelp' RequestId='375'"
[ERROR][2025-02-03 20:19:44] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/signatureHelp 376 - System.ArgumentOutOfRangeException: The requested line number 148 must be less than the number of lines 1. (Parameter 'Line')\n   at Microsoft.CodeAnalysis.Text.TextLineCollection.GetPosition(LinePosition position)\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.GetInvocation(Document document, Request request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 107\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.Handle(SignatureHelpRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 32\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpSignatureHelpHandler.Handle(SignatureHelpParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs:line 43\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/signatureHelp' RequestId='376'"
[ERROR][2025-02-03 20:19:45] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/signatureHelp 377 - System.ArgumentOutOfRangeException: The requested line number 80 must be less than the number of lines 1. (Parameter 'Line')\n   at Microsoft.CodeAnalysis.Text.TextLineCollection.GetPosition(LinePosition position)\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.GetInvocation(Document document, Request request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 107\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.Handle(SignatureHelpRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 32\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpSignatureHelpHandler.Handle(SignatureHelpParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs:line 43\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/signatureHelp' RequestId='377'"
[ERROR][2025-02-03 20:20:16] ...lsp/handlers.lua:623	"OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request textDocument/signatureHelp 378 - System.ArgumentOutOfRangeException: The requested line number 80 must be less than the number of lines 1. (Parameter 'Line')\n   at Microsoft.CodeAnalysis.Text.TextLineCollection.GetPosition(LinePosition position)\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.GetInvocation(Document document, Request request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 107\n   at OmniSharp.Roslyn.CSharp.Services.Signatures.SignatureHelpService.Handle(SignatureHelpRequest request) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Signatures/SignatureHelpService.cs:line 32\n   at OmniSharp.LanguageServerProtocol.Handlers.OmniSharpSignatureHelpHandler.Handle(SignatureHelpParams request, CancellationToken token) in /home/dmitry/Documents/Programming/omnisharp-roslyn/src/OmniSharp.LanguageServerProtocol/Handlers/OmniSharpSignatureHelpHandler.cs:line 43\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)\n   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)\n   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='textDocument/signatureHelp' RequestId='378'"
```

But seems like actual problem is in parsing source text in Roslyn, but as for now can be fixed here.