### PR TITLE
Add `--locale` commandline option

### DIFF
--- a/src/OmniSharp.Host/CommandLineApplication.cs
+++ b/src/OmniSharp.Host/CommandLineApplication.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -21,6 +22,7 @@ namespace OmniSharp
         private readonly CommandOption _logLevel;
         private readonly CommandOption _applicationRoot;
         private readonly CommandOption _debug;
+        private readonly CommandOption _locale;
 
         public CommandLineApplication()
         {
@@ -37,6 +39,7 @@ namespace OmniSharp
             _zeroBasedIndices = Application.Option("-z | --zero-based-indices", "Use zero based indices in request/responses (defaults to 'false').", CommandOptionType.NoValue);
             _plugin = Application.Option("-pl | --plugin", "Plugin name(s).", CommandOptionType.MultipleValue);
             _debug = Application.Option("-d | --debug", "Wait for debugger to attach", CommandOptionType.NoValue);
+            _locale = Application.Option("--locale", "Locale to use for localization (defaults to system locale).", CommandOptionType.SingleValue);
         }
 
         public int Execute(string[] args)
@@ -70,6 +73,7 @@ namespace OmniSharp
         {
             Application.OnExecuteAsync((_) =>
             {
+                SetLocale();
                 DebugAttach();
                 return func();
             });
@@ -79,6 +83,7 @@ namespace OmniSharp
         {
             Application.OnExecuteAsync((token) =>
             {
+                SetLocale();
                 DebugAttach();
                 return func(token);
             });
@@ -88,6 +93,7 @@ namespace OmniSharp
         {
             Application.OnExecute(() =>
             {
+                SetLocale();
                 DebugAttach();
                 return func();
             });
@@ -115,6 +121,20 @@ namespace OmniSharp
                 {
                     Thread.Sleep(100);
                 }
+            }
+        }
+
+        public string Locale => _locale.GetValueOrDefault(string.Empty);
+
+        private void SetLocale()
+        {
+            if (!string.IsNullOrEmpty(Locale))
+            {
+                try
+                {
+                    CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(Locale);
+                }
+                catch (CultureNotFoundException) { }
             }
         }
     }

--- a/src/OmniSharp.Host/CommandLineApplication.cs
+++ b/src/OmniSharp.Host/CommandLineApplication.cs
@@ -134,7 +134,11 @@ namespace OmniSharp
                 {
                     CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(Locale);
                 }
-                catch (CultureNotFoundException) { }
+                catch (CultureNotFoundException)
+                {
+                    // We couldn't find the culture, log a warning and fallback to the OS configured value.
+                    Console.Error.WriteLine($"Culture {Locale} was not found, falling back to OS culture.");
+                }
             }
         }
     }

--- a/tests/OmniSharp.Tests/CommandLineApplicationFacts.cs
+++ b/tests/OmniSharp.Tests/CommandLineApplicationFacts.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.Globalization;
+using System.Linq;
+using TestUtility;
 using Xunit;
 
 namespace OmniSharp.Tests
@@ -23,6 +25,34 @@ namespace OmniSharp.Tests
 
             Assert.Single(app.OtherArgs);
             Assert.Equal("a=b", app.OtherArgs.First());
+        }
+
+        [Fact]
+        [UseCulture("de-DE", "de-DE")]
+        public void PassingLocaleSetsRuntimeLocale()
+        {
+            const string locale = "es-ES";
+            var runtimeLocale = string.Empty;
+
+            var app = new CommandLineApplication();
+            app.OnExecute(() => { runtimeLocale = CultureInfo.CurrentUICulture.Name; return 0; });
+            app.Execute(["--locale", locale]);
+
+            Assert.Equal(locale, runtimeLocale);
+        }
+
+        [Fact]
+        [UseCulture("de-DE", "de-DE")]
+        public void NotPassingLocaleUsesSystemLocale()
+        {
+            const string locale = "de-DE";
+            var runtimeLocale = string.Empty;
+
+            var app = new CommandLineApplication();
+            app.OnExecute(() => { runtimeLocale = CultureInfo.CurrentUICulture.Name; return 0; });
+            app.Execute([]);
+
+            Assert.Equal(locale, runtimeLocale);
         }
     }
 }

--- a/tests/OmniSharp.Tests/CommandLineApplicationFacts.cs
+++ b/tests/OmniSharp.Tests/CommandLineApplicationFacts.cs
@@ -31,28 +31,43 @@ namespace OmniSharp.Tests
         [UseCulture("de-DE", "de-DE")]
         public void PassingLocaleSetsRuntimeLocale()
         {
-            const string locale = "es-ES";
-            var runtimeLocale = string.Empty;
+            const string expectedLocale = "es-ES";
 
             var app = new CommandLineApplication();
+            var runtimeLocale = string.Empty;
             app.OnExecute(() => { runtimeLocale = CultureInfo.CurrentUICulture.Name; return 0; });
-            app.Execute(["--locale", locale]);
+            app.Execute(["--locale", expectedLocale]);
 
-            Assert.Equal(locale, runtimeLocale);
+            Assert.Equal(expectedLocale, runtimeLocale);
+        }
+
+        [Fact]
+        [UseCulture("de-DE", "de-DE")]
+        public void PassingInvalidLocaleUsesSystemLocale()
+        {
+            const string expectedLocale = "de-DE";
+            const string invalidLocale = "zz~ZZ";
+
+            var app = new CommandLineApplication();
+            var runtimeLocale = string.Empty;
+            app.OnExecute(() => { runtimeLocale = CultureInfo.CurrentUICulture.Name; return 0; });
+            app.Execute(["--locale", invalidLocale]);
+
+            Assert.Equal(expectedLocale, runtimeLocale);
         }
 
         [Fact]
         [UseCulture("de-DE", "de-DE")]
         public void NotPassingLocaleUsesSystemLocale()
         {
-            const string locale = "de-DE";
-            var runtimeLocale = string.Empty;
+            const string expectedLocale = "de-DE";
 
             var app = new CommandLineApplication();
+            var runtimeLocale = string.Empty;
             app.OnExecute(() => { runtimeLocale = CultureInfo.CurrentUICulture.Name; return 0; });
             app.Execute([]);
 
-            Assert.Equal(locale, runtimeLocale);
+            Assert.Equal(expectedLocale, runtimeLocale);
         }
     }
 }

--- a/tests/TestUtility/UseCultureAttribute.cs
+++ b/tests/TestUtility/UseCultureAttribute.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Threading;
+using Xunit.Sdk;
+
+namespace TestUtility
+{
+    /// <summary>
+    /// Apply this attribute to your test method to replace the
+    /// <see cref="Thread.CurrentThread" /> <see cref="CultureInfo.CurrentCulture" /> and
+    /// <see cref="CultureInfo.CurrentUICulture" /> with another culture.
+    /// </summary>
+    /// <remarks>
+    /// This code was adapted from
+    /// https://github.com/xunit/samples.xunit/blob/5de2967/UseCulture/UseCultureAttribute.cs.
+    /// The original code is (c) 2014 Outercurve Foundation and licensed under the Apache License,
+    /// Version 2.0.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class UseCultureAttribute : BeforeAfterTestAttribute
+    {
+        private readonly Lazy<CultureInfo> _culture;
+        private readonly Lazy<CultureInfo> _uiCulture;
+        private CultureInfo _originalCulture;
+        private CultureInfo _originalUICulture;
+
+        /// <summary>
+        /// Replaces the culture and UI culture of the current thread with
+        /// <paramref name="culture" />
+        /// </summary>
+        /// <param name="culture">The name of the culture.</param>
+        /// <remarks>
+        /// <para>
+        /// This constructor overload uses <paramref name="culture" /> for both
+        /// <see cref="Culture" /> and <see cref="UICulture" />.
+        /// </para>
+        /// </remarks>
+        public UseCultureAttribute(string culture)
+            : this(culture, culture)
+        {
+        }
+
+        /// <summary>
+        /// Replaces the culture and UI culture of the current thread with
+        /// <paramref name="culture" /> and <paramref name="uiCulture" />
+        /// </summary>
+        /// <param name="culture">The name of the culture.</param>
+        /// <param name="uiCulture">The name of the UI culture.</param>
+        public UseCultureAttribute(string culture, string uiCulture)
+        {
+            _culture = new Lazy<CultureInfo>(() => new CultureInfo(culture, useUserOverride: false));
+            _uiCulture = new Lazy<CultureInfo>(() => new CultureInfo(uiCulture, useUserOverride: false));
+        }
+
+        /// <summary>
+        /// Gets the culture.
+        /// </summary>
+        public CultureInfo Culture => _culture.Value;
+
+        /// <summary>
+        /// Gets the UI culture.
+        /// </summary>
+        public CultureInfo UICulture => _uiCulture.Value;
+
+        /// <summary>
+        /// Stores the current <see cref="CultureInfo.CurrentCulture" /> and <see cref="CultureInfo.CurrentUICulture" />
+        /// and replaces them with the new cultures defined in the constructor.
+        /// </summary>
+        /// <param name="methodUnderTest">The method under test</param>
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            _originalCulture = CultureInfo.CurrentCulture;
+            _originalUICulture = CultureInfo.CurrentUICulture;
+
+            CultureInfo.CurrentCulture = Culture;
+            CultureInfo.CurrentUICulture = UICulture;
+            CultureInfo.CurrentCulture.ClearCachedData();
+            CultureInfo.CurrentUICulture.ClearCachedData();
+        }
+
+        /// <summary>
+        /// Restores the original <see cref="CultureInfo.CurrentCulture" /> and
+        /// <see cref="CultureInfo.CurrentUICulture" />.
+        /// </summary>
+        /// <param name="methodUnderTest">The method under test</param>
+        public override void After(MethodInfo methodUnderTest)
+        {
+            CultureInfo.CurrentCulture = _originalCulture;
+            CultureInfo.CurrentUICulture = _originalUICulture;
+            CultureInfo.CurrentCulture.ClearCachedData();
+            CultureInfo.CurrentUICulture.ClearCachedData();
+        }
+    }
+}


### PR DESCRIPTION
The option is optional and defaults to the system locale. Extensions will need to be updated to pass this along when starting O#.

resolves #2661