### PR TITLE
Use ubuntu 22.04 image for building release packages.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,7 +112,7 @@ stages:
 
       - job: Linux
         pool:
-          vmImage: "ubuntu-latest"
+          vmImage: "ubuntu-22.04"
         dependsOn: GitVersion
         steps:
           - template: ./.pipelines/init.yml


### PR DESCRIPTION
Mono is not preinstalled on 24.04 images.