### PR TITLE
NoWarn NU1903

### DIFF
--- a/build/Settings.props
+++ b/build/Settings.props
@@ -8,7 +8,7 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-    <NoWarn>NU1701;NU5104</NoWarn>
+    <NoWarn>NU1701;NU5104;NU1903</NoWarn>
     <IsPackable>false</IsPackable>
     <Authors>OmniSharp Contributors</Authors>
     <PackageTags>omnisharp;lsp;csharp;roslyn;language</PackageTags>


### PR DESCRIPTION
We use an old MSBuild version only as a reference package. Actual MSBuild libraries are loaded by MSBuildLocator and come from the installed MSBuild tooling.