### PR TITLE
Add .slnx solution format support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,6 +64,8 @@
 
         <PackageVersion Include="Microsoft.IO.Redist" Version="6.1.3" />
 
+        <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
+
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestPackageVersion)" />
         <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftTestPackageVersion)" />
         <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftTestPackageVersion)" />

--- a/src/OmniSharp.Host/Services/OmniSharpEnvironment.cs
+++ b/src/OmniSharp.Host/Services/OmniSharpEnvironment.cs
@@ -27,7 +27,7 @@ namespace OmniSharp.Services
             {
                 TargetDirectory = path;
             }
-            else if (File.Exists(path) && (Path.GetExtension(path).Equals(".sln", StringComparison.OrdinalIgnoreCase) || Path.GetExtension(path).Equals(".slnf", StringComparison.OrdinalIgnoreCase)))
+            else if (File.Exists(path) && (Path.GetExtension(path).Equals(".sln", StringComparison.OrdinalIgnoreCase) || Path.GetExtension(path).Equals(".slnf", StringComparison.OrdinalIgnoreCase) || Path.GetExtension(path).Equals(".slnx", StringComparison.OrdinalIgnoreCase)))
             {
                 SolutionFilePath = path;
                 TargetDirectory = Path.GetDirectoryName(path);
@@ -35,7 +35,7 @@ namespace OmniSharp.Services
 
             if (TargetDirectory == null)
             {
-                throw new ArgumentException("OmniSharp only supports being launched with a directory path or a path to a solution (.sln, .slnf) file.", nameof(path));
+                throw new ArgumentException("OmniSharp only supports being launched with a directory path or a path to a solution (.sln, .slnf, .slnx) file.", nameof(path));
             }
 
             if (TargetDirectory[TargetDirectory.Length - 1] != Path.DirectorySeparatorChar)

--- a/src/OmniSharp.MSBuild/OmniSharp.MSBuild.csproj
+++ b/src/OmniSharp.MSBuild/OmniSharp.MSBuild.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="Runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.ProjectModel" />
     <PackageReference Include="NuGet.Versioning" />

--- a/src/OmniSharp.MSBuild/ProjectSystem.cs
+++ b/src/OmniSharp.MSBuild/ProjectSystem.cs
@@ -3,10 +3,13 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.SolutionPersistence.Model;
+using Microsoft.VisualStudio.SolutionPersistence.Serializer;
 using OmniSharp.Eventing;
 using OmniSharp.FileSystem;
 using OmniSharp.FileWatching;
@@ -171,43 +174,27 @@ namespace OmniSharp.MSBuild
                 throw new InvalidSolutionFileException($"Solution filter file was invalid.");
             }
 
-            var solutionFolder = Path.GetDirectoryName(solutionFilePath);
-            var solutionFile = SolutionFile.ParseFile(solutionFilePath);
+            var serializer = SolutionSerializers.GetSerializerByMoniker(solutionFilePath);
+            if (serializer == null)
+            {
+                throw new InvalidSolutionFileException($"Solution file '{solutionFilePath}' is not a supported format.");
+            }
+
+            var solutionFolder = Path.GetDirectoryName(solutionFilePath) ?? "";
+            var solutionModel = serializer.OpenAsync(solutionFilePath, CancellationToken.None).Result;
+
             var processedProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var result = new List<(string, ProjectIdInfo)>();
 
-            var solutionConfigurations = new Dictionary<ProjectId, Dictionary<string, string>>();
-            foreach (var globalSection in solutionFile.GlobalSections)
+            foreach (var projectModel in solutionModel.SolutionProjects)
             {
-                // Try parse project configurations if they are remapped in solution file
-                if (globalSection.Name == "ProjectConfigurationPlatforms")
-                {
-                    _logger.LogDebug($"Parsing ProjectConfigurationPlatforms of '{solutionFilePath}'.");
-                    foreach (var entry in globalSection.Properties)
-                    {
-                        var guid = Guid.Parse(entry.Name.Substring(0, 38));
-                        var projId = ProjectId.CreateFromSerialized(guid);
-                        var solutionConfig = entry.Name.Substring(39);
-
-                        if (!solutionConfigurations.TryGetValue(projId, out var dict))
-                        {
-                            dict = new Dictionary<string, string>();
-                            solutionConfigurations.Add(projId, dict);
-                        }
-                        dict.Add(solutionConfig, entry.Value);
-                    }
-                }
-            }
-
-            foreach (var project in solutionFile.Projects)
-            {
-                if (project.IsNotSupported)
+                var relativeProjectfilePath = projectModel.FilePath;
+                if (string.IsNullOrEmpty(relativeProjectfilePath))
                 {
                     continue;
                 }
-
                 // Solution files contain relative paths to project files with Windows-style slashes.
-                var relativeProjectfilePath = project.RelativePath.Replace('\\', Path.DirectorySeparatorChar);
+                relativeProjectfilePath = relativeProjectfilePath.Replace('\\', Path.DirectorySeparatorChar);
                 var projectFilePath = Path.GetFullPath(Path.Combine(solutionFolder, relativeProjectfilePath));
                 if (!projectFilter.IsEmpty &&
                     !projectFilter.Contains(projectFilePath))
@@ -223,11 +210,14 @@ namespace OmniSharp.MSBuild
 
                 if (string.Equals(Path.GetExtension(projectFilePath), ".csproj", StringComparison.OrdinalIgnoreCase))
                 {
-                    var projectIdInfo = new ProjectIdInfo(ProjectId.CreateFromSerialized(new Guid(project.ProjectGuid)), true);
-                    if (solutionConfigurations.TryGetValue(projectIdInfo.Id, out var configurations))
+                    var projectIdInfo = new ProjectIdInfo(ProjectId.CreateFromSerialized(projectModel.Id), true);
+
+                    var configurations = BuildSolutionConfigurationMap(solutionModel, projectModel);
+                    if (configurations.Count > 0)
                     {
                         projectIdInfo.SolutionConfiguration = configurations;
                     }
+
                     result.Add((projectFilePath, projectIdInfo));
                 }
 
@@ -237,14 +227,41 @@ namespace OmniSharp.MSBuild
             return result;
         }
 
+        private static Dictionary<string, string> BuildSolutionConfigurationMap(SolutionModel solutionModel, SolutionProjectModel projectModel)
+        {
+            var configurations = new Dictionary<string, string>();
+
+            foreach (var buildType in solutionModel.BuildTypes)
+            {
+                foreach (var platform in solutionModel.Platforms)
+                {
+                    var (projBuildType, projPlatform, build, deploy) = projectModel.GetProjectConfiguration(buildType, platform);
+                    var solKey = $"{buildType}|{platform}";
+                    configurations[$"{solKey}.ActiveCfg"] = $"{projBuildType ?? buildType}|{projPlatform ?? platform}";
+                    if (build)
+                    {
+                        configurations[$"{solKey}.Build.0"] = $"{projBuildType ?? buildType}|{projPlatform ?? platform}";
+                    }
+                }
+            }
+
+            return configurations;
+        }
+
         private static string FindSolutionFilePath(string rootPath, ILogger logger)
         {
             // currently, Directory.GetFiles on Windows collects files that the file extension has 'sln' prefix, while
             // GetFiles on Mono looks for an exact match. Use an approach that works for both.
             // see https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=netframework-4.7.2 ('Note' description)
             var solutionsFilePaths = Directory.GetFiles(rootPath, "*.sln").Where(x => Path.GetExtension(x).Equals(".sln", StringComparison.OrdinalIgnoreCase)).ToArray();
+            var solutionSlnxFilePaths = Directory.GetFiles(rootPath, "*.slnx").Where(x => Path.GetExtension(x).Equals(".slnx", StringComparison.OrdinalIgnoreCase)).ToArray();
+
+            // .slnx takes priority over .sln when both exist with the same stem (migration scenario).
+            // Filter out any .sln that has a matching .slnx sibling.
+            var slnxStems = new HashSet<string>(solutionSlnxFilePaths.Select(x => Path.GetFileNameWithoutExtension(x)), StringComparer.OrdinalIgnoreCase);
+            solutionsFilePaths = solutionsFilePaths.Where(x => !slnxStems.Contains(Path.GetFileNameWithoutExtension(x))).ToArray();
             var solutionFiltersFilePaths = Directory.GetFiles(rootPath, "*.slnf").Where(x => Path.GetExtension(x).Equals(".slnf", StringComparison.OrdinalIgnoreCase)).ToArray();
-            var result = SolutionSelector.Pick(solutionsFilePaths.Concat(solutionFiltersFilePaths).ToArray(), rootPath);
+            var result = SolutionSelector.Pick(solutionsFilePaths.Concat(solutionSlnxFilePaths).Concat(solutionFiltersFilePaths).ToArray(), rootPath);
 
             if (result.Message != null)
             {

--- a/test-assets/test-projects/ProjectAndSolutionFilterWithSlnx/Project1/Class1.cs
+++ b/test-assets/test-projects/ProjectAndSolutionFilterWithSlnx/Project1/Class1.cs
@@ -1,0 +1,6 @@
+namespace Project1
+{
+    public class Class1
+    {
+    }
+}

--- a/test-assets/test-projects/ProjectAndSolutionFilterWithSlnx/Project1/Project1.csproj
+++ b/test-assets/test-projects/ProjectAndSolutionFilterWithSlnx/Project1/Project1.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/test-assets/test-projects/ProjectAndSolutionFilterWithSlnx/Project2/Class1.cs
+++ b/test-assets/test-projects/ProjectAndSolutionFilterWithSlnx/Project2/Class1.cs
@@ -1,0 +1,6 @@
+namespace Project2
+{
+    public class Class1
+    {
+    }
+}

--- a/test-assets/test-projects/ProjectAndSolutionFilterWithSlnx/Project2/Project2.csproj
+++ b/test-assets/test-projects/ProjectAndSolutionFilterWithSlnx/Project2/Project2.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/test-assets/test-projects/ProjectAndSolutionFilterWithSlnx/ProjectAndSolutionFilterWithSlnx.slnf
+++ b/test-assets/test-projects/ProjectAndSolutionFilterWithSlnx/ProjectAndSolutionFilterWithSlnx.slnf
@@ -1,0 +1,8 @@
+{
+  "solution": {
+    "path": "Solution\\ProjectAndSolutionFilterWithSlnx.slnx",
+    "projects": [
+      "..\\Project1\\Project1.csproj"
+    ]
+  }
+}

--- a/test-assets/test-projects/ProjectAndSolutionFilterWithSlnx/Solution/ProjectAndSolutionFilterWithSlnx.slnx
+++ b/test-assets/test-projects/ProjectAndSolutionFilterWithSlnx/Solution/ProjectAndSolutionFilterWithSlnx.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="..\Project1\Project1.csproj" />
+  <Project Path="..\Project2\Project2.csproj" />
+</Solution>

--- a/test-assets/test-projects/ProjectAndSolutionSlnx/Project/Class1.cs
+++ b/test-assets/test-projects/ProjectAndSolutionSlnx/Project/Class1.cs
@@ -1,0 +1,6 @@
+namespace Project
+{
+    public class Class1
+    {
+    }
+}

--- a/test-assets/test-projects/ProjectAndSolutionSlnx/Project/Project.csproj
+++ b/test-assets/test-projects/ProjectAndSolutionSlnx/Project/Project.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/test-assets/test-projects/ProjectAndSolutionSlnx/ProjectAndSolutionSlnx.slnx
+++ b/test-assets/test-projects/ProjectAndSolutionSlnx/ProjectAndSolutionSlnx.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="Project\Project.csproj" />
+</Solution>

--- a/test-assets/test-projects/ProjectAndSolutionSlnxPriority/Project/Class1.cs
+++ b/test-assets/test-projects/ProjectAndSolutionSlnxPriority/Project/Class1.cs
@@ -1,0 +1,6 @@
+namespace Project
+{
+    public class Class1
+    {
+    }
+}

--- a/test-assets/test-projects/ProjectAndSolutionSlnxPriority/Project/Project.csproj
+++ b/test-assets/test-projects/ProjectAndSolutionSlnxPriority/Project/Project.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/test-assets/test-projects/ProjectAndSolutionSlnxPriority/ProjectAndSolutionSlnxPriority.sln
+++ b/test-assets/test-projects/ProjectAndSolutionSlnxPriority/ProjectAndSolutionSlnxPriority.sln
@@ -1,0 +1,16 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project", "Project\Project.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/test-assets/test-projects/ProjectAndSolutionSlnxPriority/ProjectAndSolutionSlnxPriority.slnx
+++ b/test-assets/test-projects/ProjectAndSolutionSlnxPriority/ProjectAndSolutionSlnxPriority.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="Project\Project.csproj" />
+</Solution>

--- a/test-assets/test-projects/ProjectAndSolutionSlnxWithFolders/Libs/Lib/Class1.cs
+++ b/test-assets/test-projects/ProjectAndSolutionSlnxWithFolders/Libs/Lib/Class1.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Lib
+{
+    public class Class1
+    {
+    }
+}

--- a/test-assets/test-projects/ProjectAndSolutionSlnxWithFolders/Libs/Lib/Lib.csproj
+++ b/test-assets/test-projects/ProjectAndSolutionSlnxWithFolders/Libs/Lib/Lib.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test-assets/test-projects/ProjectAndSolutionSlnxWithFolders/ProjectAndSolutionSlnxWithFolders.slnx
+++ b/test-assets/test-projects/ProjectAndSolutionSlnxWithFolders/ProjectAndSolutionSlnxWithFolders.slnx
@@ -1,0 +1,8 @@
+<Solution>
+  <Folder Name="/Src/">
+    <Project Path="Src\App\App.csproj" />
+  </Folder>
+  <Folder Name="/Libs/">
+    <Project Path="Libs\Lib\Lib.csproj" />
+  </Folder>
+</Solution>

--- a/test-assets/test-projects/ProjectAndSolutionSlnxWithFolders/Src/App/App.csproj
+++ b/test-assets/test-projects/ProjectAndSolutionSlnxWithFolders/Src/App/App.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Libs\Lib\Lib.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test-assets/test-projects/ProjectAndSolutionSlnxWithFolders/Src/App/Program.cs
+++ b/test-assets/test-projects/ProjectAndSolutionSlnxWithFolders/Src/App/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace App
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/test-assets/test-projects/TwoProjectsWithSolutionSlnx/App/App.csproj
+++ b/test-assets/test-projects/TwoProjectsWithSolutionSlnx/App/App.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lib\Lib.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test-assets/test-projects/TwoProjectsWithSolutionSlnx/App/Program.cs
+++ b/test-assets/test-projects/TwoProjectsWithSolutionSlnx/App/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace App
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/test-assets/test-projects/TwoProjectsWithSolutionSlnx/Lib/Class1.cs
+++ b/test-assets/test-projects/TwoProjectsWithSolutionSlnx/Lib/Class1.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Lib
+{
+    public class Class1
+    {
+    }
+}

--- a/test-assets/test-projects/TwoProjectsWithSolutionSlnx/Lib/Lib.csproj
+++ b/test-assets/test-projects/TwoProjectsWithSolutionSlnx/Lib/Lib.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test-assets/test-projects/TwoProjectsWithSolutionSlnx/TwoProjectsWithSolutionSlnx.slnx
+++ b/test-assets/test-projects/TwoProjectsWithSolutionSlnx/TwoProjectsWithSolutionSlnx.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="App\App.csproj" />
+  <Project Path="Lib\Lib.csproj" />
+</Solution>

--- a/tests/OmniSharp.MSBuild.Tests/AbstractMSBuildTestFixture.cs
+++ b/tests/OmniSharp.MSBuild.Tests/AbstractMSBuildTestFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Composition.Hosting.Core;
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -24,10 +25,21 @@ namespace OmniSharp.MSBuild.Tests
 
             // Since we can only load MSBuild once into our process we need to include
             // prerelease version so that our .NET 7 tests will pass.
-            var configuration = new Dictionary<string, string>
+            var configEntries = new Dictionary<string, string>
             {
                 ["sdk:IncludePrereleases"] = bool.TrueString
-            }.ToConfiguration();
+            };
+
+            // When running locally, the MSBuild locator may discover incompatible SDK
+            // versions from the system. Set OMNISHARP_TEST_SDK_PATH to force selection
+            // of a specific SDK (via SdkOverrideInstanceProvider → DiscoveryType.UserOverride).
+            var sdkPathOverride = Environment.GetEnvironmentVariable("OMNISHARP_TEST_SDK_PATH");
+            if (!string.IsNullOrEmpty(sdkPathOverride) && Directory.Exists(sdkPathOverride))
+            {
+                configEntries["sdk:Path"] = sdkPathOverride;
+            }
+
+            var configuration = configEntries.ToConfiguration();
 
             _msbuildLocator = MSBuildLocator.CreateDefault(this.LoggerFactory, _assemblyLoader, configuration);
 

--- a/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
+++ b/tests/OmniSharp.MSBuild.Tests/WorkspaceInformationTests.cs
@@ -73,6 +73,127 @@ namespace OmniSharp.MSBuild.Tests
         }
 
         [Fact]
+        public async Task TestProjectAndSolutionSlnx()
+        {
+            using var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectAndSolutionSlnx");
+            using var host = CreateMSBuildTestHost(testProject.Directory);
+            var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
+
+            Assert.Equal("ProjectAndSolutionSlnx.slnx", Path.GetFileName(workspaceInfo.SolutionPath));
+            Assert.NotNull(workspaceInfo.Projects);
+            var project = Assert.Single(workspaceInfo.Projects);
+
+            Assert.Equal("Project", project.AssemblyName);
+            Assert.Equal("bin/Debug/net6.0/", project.OutputPath.EnsureForwardSlashes());
+            Assert.Equal("obj/Debug/net6.0/", project.IntermediateOutputPath.EnsureForwardSlashes());
+            var expectedTargetPath = $"{testProject.Directory}/Project/{project.OutputPath}Project.dll".EnsureForwardSlashes();
+            Assert.Equal(expectedTargetPath, project.TargetPath.EnsureForwardSlashes());
+            Assert.Equal("Debug", project.Configuration);
+            Assert.Equal("AnyCPU", project.Platform);
+            Assert.False(project.IsExe);
+            Assert.False(project.IsUnityProject);
+
+            Assert.Equal(".NETCoreApp,Version=v6.0", project.TargetFramework);
+            var targetFramework = Assert.Single(project.TargetFrameworks);
+            Assert.Equal("net6.0", targetFramework.ShortName);
+        }
+
+        [Fact]
+        public async Task TestProjectAndSolutionFilterWithSlnx()
+        {
+            using var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectAndSolutionFilterWithSlnx");
+            using var host = CreateMSBuildTestHost(testProject.Directory);
+            var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
+
+            Assert.Equal("ProjectAndSolutionFilterWithSlnx.slnf", Path.GetFileName(workspaceInfo.SolutionPath));
+            Assert.NotNull(workspaceInfo.Projects);
+            var project = Assert.Single(workspaceInfo.Projects);
+
+            Assert.Equal("Project1", project.AssemblyName);
+            Assert.Equal("bin/Debug/net6.0/", project.OutputPath.EnsureForwardSlashes());
+            Assert.Equal("obj/Debug/net6.0/", project.IntermediateOutputPath.EnsureForwardSlashes());
+            var expectedTargetPath = $"{testProject.Directory}/Project1/{project.OutputPath}Project1.dll".EnsureForwardSlashes();
+            Assert.Equal(expectedTargetPath, project.TargetPath.EnsureForwardSlashes());
+            Assert.Equal("Debug", project.Configuration);
+            Assert.Equal("AnyCPU", project.Platform);
+            Assert.False(project.IsExe);
+            Assert.False(project.IsUnityProject);
+
+            Assert.Equal(".NETCoreApp,Version=v6.0", project.TargetFramework);
+            var targetFramework = Assert.Single(project.TargetFrameworks);
+            Assert.Equal("net6.0", targetFramework.ShortName);
+        }
+
+        [Fact]
+        public async Task TestTwoProjectsWithSolutionSlnx()
+        {
+            using var testProject = await TestAssets.Instance.GetTestProjectAsync("TwoProjectsWithSolutionSlnx");
+            using var host = CreateMSBuildTestHost(testProject.Directory);
+            var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
+
+            Assert.Equal("TwoProjectsWithSolutionSlnx.slnx", Path.GetFileName(workspaceInfo.SolutionPath));
+            Assert.NotNull(workspaceInfo.Projects);
+            Assert.Equal(2, workspaceInfo.Projects.Count);
+
+            var firstProject = workspaceInfo.Projects[0];
+            Assert.Equal("App.csproj", Path.GetFileName(firstProject.Path));
+            Assert.Equal(".NETCoreApp,Version=v6.0", firstProject.TargetFramework);
+            Assert.Equal("net6.0", firstProject.TargetFrameworks[0].ShortName);
+
+            var secondProject = workspaceInfo.Projects[1];
+            Assert.Equal("Lib.csproj", Path.GetFileName(secondProject.Path));
+            Assert.Equal(".NETStandard,Version=v2.0", secondProject.TargetFramework);
+            Assert.Equal("netstandard2.0", secondProject.TargetFrameworks[0].ShortName);
+        }
+
+        [Fact]
+        public async Task TestProjectAndSolutionSlnxWithFolders()
+        {
+            using var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectAndSolutionSlnxWithFolders");
+            using var host = CreateMSBuildTestHost(testProject.Directory);
+            var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
+
+            Assert.Equal("ProjectAndSolutionSlnxWithFolders.slnx", Path.GetFileName(workspaceInfo.SolutionPath));
+            Assert.NotNull(workspaceInfo.Projects);
+            Assert.Equal(2, workspaceInfo.Projects.Count);
+
+            var firstProject = workspaceInfo.Projects[0];
+            Assert.Equal("App.csproj", Path.GetFileName(firstProject.Path));
+            Assert.Equal(".NETCoreApp,Version=v6.0", firstProject.TargetFramework);
+            Assert.Equal("net6.0", firstProject.TargetFrameworks[0].ShortName);
+
+            var secondProject = workspaceInfo.Projects[1];
+            Assert.Equal("Lib.csproj", Path.GetFileName(secondProject.Path));
+            Assert.Equal(".NETStandard,Version=v2.0", secondProject.TargetFramework);
+            Assert.Equal("netstandard2.0", secondProject.TargetFrameworks[0].ShortName);
+        }
+
+        [Fact]
+        public async Task TestProjectAndSolutionSlnxPriority()
+        {
+            using var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectAndSolutionSlnxPriority");
+            using var host = CreateMSBuildTestHost(testProject.Directory);
+            var workspaceInfo = await host.RequestMSBuildWorkspaceInfoAsync();
+
+            // .slnx takes priority over .sln when both exist with the same stem
+            Assert.Equal("ProjectAndSolutionSlnxPriority.slnx", Path.GetFileName(workspaceInfo.SolutionPath));
+            Assert.NotNull(workspaceInfo.Projects);
+            var project = Assert.Single(workspaceInfo.Projects);
+
+            Assert.Equal("Project", project.AssemblyName);
+            Assert.Equal("bin/Debug/net6.0/", project.OutputPath.EnsureForwardSlashes());
+            Assert.Equal("obj/Debug/net6.0/", project.IntermediateOutputPath.EnsureForwardSlashes());
+            Assert.Equal("Debug", project.Configuration);
+            Assert.Equal("AnyCPU", project.Platform);
+            Assert.False(project.IsExe);
+            Assert.False(project.IsUnityProject);
+
+            Assert.Equal(".NETCoreApp,Version=v6.0", project.TargetFramework);
+            var targetFramework = Assert.Single(project.TargetFrameworks);
+            Assert.Equal("net6.0", targetFramework.ShortName);
+        }
+
+        [Fact]
         public async Task ProjectAndSolutionWithProjectSection()
         {
             using var testProject = await TestAssets.Instance.GetTestProjectAsync("ProjectAndSolutionWithProjectSection");


### PR DESCRIPTION
Adds `.slnx` support to OmniSharp. Closes #2699.

`.slnx` is the default solution format in .NET 10+. Tools embedding OmniSharp (e.g. sonarlint-language-server) still use an embedded build that only understands `.sln` — they work fine with `.sln` in .NET 10 but fail on `.slnx`. This unblocks them.

Uses `Microsoft.VisualStudio.SolutionPersistence` to parse both `.sln` and `.slnx` through `SolutionSerializers.GetSerializerByMoniker()`, replacing the hand-rolled global section parsing with a single unified code path.

### Testing locally with installed net10.0 sdk

`AbstractMSBuildTestFixture` reads `OMNISHARP_TEST_SDK_PATH` env var to override MSBuild SDK discovery. Pass it to `dotnet test`:

```
dotnet test tests/OmniSharp.MSBuild.Tests/OmniSharp.MSBuild.Tests.csproj -f net10.0 \
  --filter "FullyQualifiedName~WorkspaceInformationTests" \
  --environment OMNISHARP_TEST_SDK_PATH=/path/to/sdk/6.0.428
```