### PR TITLE
fix(scripts): support single-quoted values in platform parser

### DIFF
--- a/scripts/platform.cake
+++ b/scripts/platform.cake
@@ -129,7 +129,7 @@ public sealed class Platform
             {
                 var key = line.Substring(0, equalsIndex).Trim();
                 var value = line.Substring(equalsIndex + 1).Trim();
-                value = value.Trim('"');
+                value = value.Trim('"').Trim('\'');
 
                 if (key == "ID")
                 {
@@ -144,7 +144,7 @@ public sealed class Platform
                     }
                     version = new Version(value);
                 }
-                
+
                 if (distroName != null && version != null)
                 {
                     break;


### PR DESCRIPTION
I ran into a small snag while getting things set up on my machine and wanted to submit a quick fix.

The `scripts/platform.cake` script previously assumed that values in `/etc/os-release` were always wrapped in double quotes. However, I guess some Linux distributions use single quotes (in my case Gentoo Linux). Because of this, the existing `.Trim('"')` logic was leaving the single quotes intact, which broke downstream OS evaluation and failed the build.

``` bash
$ cat /etc/os-release 

NAME='Gentoo'
ID='gentoo'
PRETTY_NAME='Gentoo Linux'
VERSION='2.18'
VERSION_ID='2.18'
HOME_URL='https://www.gentoo.org/'
SUPPORT_URL='https://www.gentoo.org/support/'
BUG_REPORT_URL='https://bugs.gentoo.org/'
ANSI_COLOR='1;32'
```

I just chained another `.Trim('\'')` at the end as a fallback, works as expected.

As I said small qol fix.